### PR TITLE
feat: allow `Secret`s as `BackendTLSPolicy` `CACertificateRefs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,9 @@ Adding a new version? You'll need three changes:
   to those having this label set to "true". This limits the amount of resources that are kept in memory.
   The default value is `konghq.com/configmap`.
   [#6753](https://github.com/Kong/kubernetes-ingress-controller/pull/6753)
+- Added the possibility to set `Secret`s as `CACertificateRefs` in the `BackendTLSPolicy`
+  objects.
+  [#6853](https://github.com/Kong/kubernetes-ingress-controller/pull/6853)
 
 ## [3.3.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,18 +254,17 @@ Adding a new version? You'll need three changes:
 - Added `BackendTLSPolicy` support. The user can now reference any Kubernetes `Service`
   in the `BackendTLSPolicy` spec, and in case the service is used as a backend by
   `HTTPRoute`s that reference a Kong Gateway as parent, such Backend TLS configuration
-  is applied to the service section of the Kong configuration.
+  is applied to the service section of the Kong configuration. The `BackendTLSPolicies`
+  CA Certificates can be set in `Secret`s or `ConfigMap`s.
   [#6712](https://github.com/Kong/kubernetes-ingress-controller/pull/6712)
   [#6753](https://github.com/Kong/kubernetes-ingress-controller/pull/6753)
   [#6837](https://github.com/Kong/kubernetes-ingress-controller/pull/6837)
+  [#6853](https://github.com/Kong/kubernetes-ingress-controller/pull/6853)
 - Added the flag `--configmap-label-selector` to set the label selector for `ConfigMap`s
   to ingest. By setting this flag, the `ConfigMap`s that are ingested will be limited
   to those having this label set to "true". This limits the amount of resources that are kept in memory.
   The default value is `konghq.com/configmap`.
   [#6753](https://github.com/Kong/kubernetes-ingress-controller/pull/6753)
-- Added the possibility to set `Secret`s as `CACertificateRefs` in the `BackendTLSPolicy`
-  objects.
-  [#6853](https://github.com/Kong/kubernetes-ingress-controller/pull/6853)
 
 ## [3.3.1]
 

--- a/config/rbac/gateway/role.yaml
+++ b/config/rbac/gateway/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -455,13 +455,29 @@ func SetTLSVerify(anns map[string]string, value bool) {
 	anns[AnnotationPrefix+TLSVerifyKey] = strconv.FormatBool(value)
 }
 
-// SetCACertificates merge the ca-certificates secret names into the already existing CA certificates set via annotation.
-func SetCACertificates(anns map[string]string, certificates []string) {
+// SetConfigMapCACertificates merge the ca-certificates configmap names into the already existing CA certificates set via annotation.
+func SetConfigMapCACertificates(anns map[string]string, configMapCertificates []string) {
+	if len(configMapCertificates) == 0 {
+		return
+	}
 	existingCACerts := anns[AnnotationPrefix+CACertificatesConfigMapsKey]
 	if existingCACerts == "" {
-		anns[AnnotationPrefix+CACertificatesConfigMapsKey] = strings.Join(certificates, ",")
+		anns[AnnotationPrefix+CACertificatesConfigMapsKey] = strings.Join(configMapCertificates, ",")
 	} else {
-		anns[AnnotationPrefix+CACertificatesConfigMapsKey] = existingCACerts + "," + strings.Join(certificates, ",")
+		anns[AnnotationPrefix+CACertificatesConfigMapsKey] = existingCACerts + "," + strings.Join(configMapCertificates, ",")
+	}
+}
+
+// SetSecretCACertificates merge the ca-certificates secret names into the already existing CA certificates set via annotation.
+func SetSecretCACertificates(anns map[string]string, secretCertificates []string) {
+	if len(secretCertificates) == 0 {
+		return
+	}
+	existingCACerts := anns[AnnotationPrefix+CACertificatesSecretsKey]
+	if existingCACerts == "" {
+		anns[AnnotationPrefix+CACertificatesSecretsKey] = strings.Join(secretCertificates, ",")
+	} else {
+		anns[AnnotationPrefix+CACertificatesSecretsKey] = existingCACerts + "," + strings.Join(secretCertificates, ",")
 	}
 }
 

--- a/internal/controllers/gateway/backendtlspolicy_controller.go
+++ b/internal/controllers/gateway/backendtlspolicy_controller.go
@@ -55,6 +55,7 @@ func (r *BackendTLSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&gatewayapi.BackendTLSPolicy{}).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.listBackendTLSPoliciesForConfigMaps)).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.listBackendTLSPoliciesForSecrets)).
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.listBackendTLSPoliciesForServices)).
 		Watches(&gatewayapi.HTTPRoute{}, handler.EnqueueRequestsFromMapFunc(r.listBackendTLSPoliciesForHTTPRoutes)).
 		Watches(&gatewayapi.Gateway{}, handler.EnqueueRequestsFromMapFunc(r.listBackendTLSPoliciesForGateways)).
@@ -66,9 +67,12 @@ func (r *BackendTLSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // -----------------------------------------------------------------------------
 
 const (
-	// backendTLSPolicyValidationCARefIndexKey is the index key for BackendTLSPolicy objects by their validation CA configmap reference.
+	// backendTLSPolicyValidationCARefConfigMapIndexKey is the index key for BackendTLSPolicy objects by their validation CA configmap reference.
 	// The value is the name of the configmap.
-	backendTLSPolicyValidationCARefIndexKey = "backendtlspolicy-validation-cacertificateref"
+	backendTLSPolicyValidationCARefConfigMapIndexKey = "backendtlspolicy-validation-cacertificateref-configmap"
+	// backendTLSPolicyValidationCARefSecretIndexKey is the index key for BackendTLSPolicy objects by their validation CA secret reference.
+	// The value is the name of the secret.
+	backendTLSPolicyValidationCARefSecretIndexKey = "backendtlspolicy-validation-cacertificateref-secret"
 	// backendTLSPolicyTargetRefIndexKey is the index key for BackendTLSPolicy objects by their target service reference.
 	// The value is the name of the service.
 	backendTLSPolicyTargetRefIndexKey = "backendtlspolicy-targetref"
@@ -96,9 +100,9 @@ func indexBackendTLSPolicyOnTargetRef(obj client.Object) []string {
 	return services
 }
 
-// indexBackendTLSPolicyOnValidationCACertificateRef indexes BackendTLSPolicy objects
+// indexBackendTLSPolicyOnValidationCACertificateConfigMapRef indexes BackendTLSPolicy objects
 // by their validation CA Certificate configmap reference.
-func indexBackendTLSPolicyOnValidationCACertificateRef(obj client.Object) []string {
+func indexBackendTLSPolicyOnValidationCACertificateConfigMapRef(obj client.Object) []string {
 	policy, ok := obj.(*gatewayapi.BackendTLSPolicy)
 	if !ok {
 		return []string{}
@@ -106,11 +110,28 @@ func indexBackendTLSPolicyOnValidationCACertificateRef(obj client.Object) []stri
 
 	configmaps := []string{}
 	for _, cacertref := range policy.Spec.Validation.CACertificateRefs {
-		if (cacertref.Group == "" || cacertref.Group == "core") && cacertref.Kind == "ConfigMap" {
+		if (cacertref.Group == "" || cacertref.Group == "core") && cacertref.Kind == ctrlref.KindConfigMap {
 			configmaps = append(configmaps, string(cacertref.Name))
 		}
 	}
 	return configmaps
+}
+
+// indexBackendTLSPolicyOnValidationCACertificateSecretRef indexes BackendTLSPolicy objects
+// by their validation CA Certificate secret reference.
+func indexBackendTLSPolicyOnValidationCACertificateSecretRef(obj client.Object) []string {
+	policy, ok := obj.(*gatewayapi.BackendTLSPolicy)
+	if !ok {
+		return []string{}
+	}
+
+	secrets := []string{}
+	for _, cacertref := range policy.Spec.Validation.CACertificateRefs {
+		if (cacertref.Group == "" || cacertref.Group == "core") && cacertref.Kind == ctrlref.KindSecret {
+			secrets = append(secrets, string(cacertref.Name))
+		}
+	}
+	return secrets
 }
 
 // indexHTTPRouteOnParentRef indexes HTTPRoute objects by their parent Gateway references.
@@ -172,10 +193,19 @@ func setupBackendTLSPolicyIndices(mgr ctrl.Manager) error {
 	if err := mgr.GetCache().IndexField(
 		context.Background(),
 		&gatewayapi.BackendTLSPolicy{},
-		backendTLSPolicyValidationCARefIndexKey,
-		indexBackendTLSPolicyOnValidationCACertificateRef,
+		backendTLSPolicyValidationCARefConfigMapIndexKey,
+		indexBackendTLSPolicyOnValidationCACertificateConfigMapRef,
 	); err != nil {
 		return fmt.Errorf("failed to index backendTLSPolicies on validation CA configmap reference: %w", err)
+	}
+
+	if err := mgr.GetCache().IndexField(
+		context.Background(),
+		&gatewayapi.BackendTLSPolicy{},
+		backendTLSPolicyValidationCARefSecretIndexKey,
+		indexBackendTLSPolicyOnValidationCACertificateSecretRef,
+	); err != nil {
+		return fmt.Errorf("failed to index backendTLSPolicies on validation CA secret reference: %w", err)
 	}
 
 	if err := mgr.GetCache().IndexField(
@@ -213,9 +243,33 @@ func (r *BackendTLSPolicyReconciler) listBackendTLSPoliciesForConfigMaps(ctx con
 	policies := &gatewayapi.BackendTLSPolicyList{}
 	if err := r.List(ctx, policies,
 		client.InNamespace(cm.Namespace),
-		client.MatchingFields{backendTLSPolicyValidationCARefIndexKey: cm.Name},
+		client.MatchingFields{backendTLSPolicyValidationCARefConfigMapIndexKey: cm.Name},
 	); err != nil {
 		r.Log.Error(err, "Failed to list BackendTLSPolicies for ConfigMap", "configmap", cm)
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(policies.Items))
+	for _, policy := range policies.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&policy),
+		})
+	}
+	return requests
+}
+
+// listBackendTLSPoliciesForConfigMaps returns the list of BackendTLSPolicies that targets the given ConfigMap.
+func (r *BackendTLSPolicyReconciler) listBackendTLSPoliciesForSecrets(ctx context.Context, obj client.Object) []reconcile.Request {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		r.Log.Error(fmt.Errorf("invalid type"), "Found invalid type in event handlers", "expected", "Secret", "found", reflect.TypeOf(obj))
+		return nil
+	}
+	policies := &gatewayapi.BackendTLSPolicyList{}
+	if err := r.List(ctx, policies,
+		client.InNamespace(secret.Namespace),
+		client.MatchingFields{backendTLSPolicyValidationCARefSecretIndexKey: secret.Name},
+	); err != nil {
+		r.Log.Error(err, "Failed to list BackendTLSPolicies for Secret", "Secret", secret)
 		return nil
 	}
 	requests := make([]reconcile.Request, 0, len(policies.Items))
@@ -320,7 +374,7 @@ func (r *BackendTLSPolicyReconciler) listBackendTLSPoliciesForGateways(ctx conte
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes;gateways;gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=backendtlspolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=backendtlspolicies/status,verbs=patch;update
-// +kubebuilder:rbac:groups="",resources=services;configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=services;configmaps;secrets,verbs=get;list;watch
 
 // Reconcile processes the watched objects.
 func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -356,7 +410,7 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 
 			// Update references to ConfigMaps in the dataplane cache.
-			referredConfigMapNames := listConfigMapNamesReferredByBackendTLSPolicy(backendTLSPolicy)
+			referredConfigMapNames := listCaCertNamespacedNamesReferredByBackendTLSPolicy(backendTLSPolicy, ctrlref.KindConfigMap)
 			if err := ctrlref.UpdateReferencesToSecretOrConfigMap(
 				ctx,
 				r.Client,
@@ -369,6 +423,22 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 					return ctrl.Result{Requeue: true}, nil
 				}
 			}
+
+			// Update references to Secrets in the dataplane cache.
+			referredSecretNames := listCaCertNamespacedNamesReferredByBackendTLSPolicy(backendTLSPolicy, ctrlref.KindSecret)
+			if err := ctrlref.UpdateReferencesToSecretOrConfigMap(
+				ctx,
+				r.Client,
+				r.ReferenceIndexers,
+				r.DataplaneClient,
+				backendTLSPolicy,
+				referredSecretNames,
+				&corev1.Secret{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
+			}
+
 		} else {
 			// In case the policy is not accepted, ensure it gets deleted from the dataplane cache
 			if err := r.DataplaneClient.DeleteObject(backendTLSPolicy); err != nil {

--- a/internal/controllers/gateway/backendtlspolicy_controller.go
+++ b/internal/controllers/gateway/backendtlspolicy_controller.go
@@ -240,8 +240,8 @@ func (r *BackendTLSPolicyReconciler) listBackendTLSPoliciesForConfigMaps(ctx con
 		r.Log.Error(fmt.Errorf("invalid type"), "Found invalid type in event handlers", "expected", "ConfigMap", "found", reflect.TypeOf(obj))
 		return nil
 	}
-	policies := &gatewayapi.BackendTLSPolicyList{}
-	if err := r.List(ctx, policies,
+	policies := gatewayapi.BackendTLSPolicyList{}
+	if err := r.List(ctx, &policies,
 		client.InNamespace(cm.Namespace),
 		client.MatchingFields{backendTLSPolicyValidationCARefConfigMapIndexKey: cm.Name},
 	); err != nil {
@@ -264,8 +264,8 @@ func (r *BackendTLSPolicyReconciler) listBackendTLSPoliciesForSecrets(ctx contex
 		r.Log.Error(fmt.Errorf("invalid type"), "Found invalid type in event handlers", "expected", "Secret", "found", reflect.TypeOf(obj))
 		return nil
 	}
-	policies := &gatewayapi.BackendTLSPolicyList{}
-	if err := r.List(ctx, policies,
+	policies := gatewayapi.BackendTLSPolicyList{}
+	if err := r.List(ctx, &policies,
 		client.InNamespace(secret.Namespace),
 		client.MatchingFields{backendTLSPolicyValidationCARefSecretIndexKey: secret.Name},
 	); err != nil {

--- a/internal/controllers/gateway/backendtlspolicy_utils_test.go
+++ b/internal/controllers/gateway/backendtlspolicy_utils_test.go
@@ -858,8 +858,8 @@ func TestValidateBackendTLSPolicy(t *testing.T) {
 				).
 				WithIndex(
 					&gatewayapi.BackendTLSPolicy{},
-					backendTLSPolicyValidationCARefIndexKey,
-					indexBackendTLSPolicyOnValidationCACertificateRef,
+					backendTLSPolicyValidationCARefConfigMapIndexKey,
+					indexBackendTLSPolicyOnValidationCACertificateConfigMapRef,
 				).
 				Build()
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -816,6 +816,8 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 		return &corev1.Service{}, nil
 	case corev1.SchemeGroupVersion.WithKind("Secret"):
 		return &corev1.Secret{}, nil
+	case corev1.SchemeGroupVersion.WithKind("ConfigMap"):
+		return &corev1.ConfigMap{}, nil
 	// ----------------------------------------------------------------------------
 	// Kubernetes Discovery APIs
 	// ----------------------------------------------------------------------------

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -719,8 +719,7 @@ func (s Store) ListCACerts() ([]*corev1.Secret, []*corev1.ConfigMap, error) {
 	err = cache.ListAll(s.stores.Secret,
 		labels.NewSelector().Add(*req),
 		func(ob interface{}) {
-			p, ok := ob.(*corev1.Secret)
-			if ok && s.isValidIngressClass(&p.ObjectMeta, annotations.IngressClassKey, s.getIngressClassHandling()) {
+			if p, ok := ob.(*corev1.Secret); ok {
 				secrets = append(secrets, p)
 			}
 		})
@@ -730,9 +729,7 @@ func (s Store) ListCACerts() ([]*corev1.Secret, []*corev1.ConfigMap, error) {
 	err = cache.ListAll(s.stores.ConfigMap,
 		labels.NewSelector().Add(*req),
 		func(ob interface{}) {
-			p, ok := ob.(*corev1.ConfigMap)
-			// We don't check the ingressClass here, as configmaps as CA certs are used for Gateway API BackendTLSPolicies.
-			if ok {
+			if p, ok := ob.(*corev1.ConfigMap); ok {
 				configMaps = append(configMaps, p)
 			}
 		})

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -3667,6 +3667,7 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - secrets
   - services
   verbs:
   - get


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

`Secret`s can be set in the `BackendTLSPolicy` `CACertificateRefs` field.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**: 
Fixes #6834

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
