### PR TITLE
fix: no redundant space in header `Location` for `HTTPRoute` with requestRedirect filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,10 @@ Adding a new version? You'll need three changes:
 - Fixed validation of JWT credentials using non HMAC algorithms where `secret`
   field was incorrectly required.
   [#6848](https://github.com/Kong/kubernetes-ingress-controller/pull/6848)
+- There is no redundant space in header `Location` when `HTTPRoute` with
+  requestRedirect filter is used.
+  [#6855](https://github.com/Kong/kubernetes-ingress-controller/pull/6855)
+  
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,7 +204,6 @@ Adding a new version? You'll need three changes:
 - There is no redundant space in header `Location` when `HTTPRoute` with
   requestRedirect filter is used.
   [#6855](https://github.com/Kong/kubernetes-ingress-controller/pull/6855)
-  
 
 ### Added
 

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -141,7 +141,9 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 							Name: kong.String("response-transformer"),
 							Config: kong.Configuration{
 								"add": TransformerPluginConfig{
-									Headers: []string{`Location: http://a.foo.com/exact/0`},
+									Headers: []Header{
+										NewHeader("Location", "http://a.foo.com/exact/0"),
+									},
 								},
 							},
 						},
@@ -167,7 +169,9 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 							Name: kong.String("response-transformer"),
 							Config: kong.Configuration{
 								"add": TransformerPluginConfig{
-									Headers: []string{`Location: http://a.foo.com/exact/1`},
+									Headers: []Header{
+										NewHeader("Location", "http://a.foo.com/exact/1"),
+									},
 								},
 							},
 						},
@@ -203,7 +207,9 @@ func TestGenerateKongExpressionRoutesFromHTTPRouteMatches(t *testing.T) {
 							Name: kong.String("request-transformer"),
 							Config: kong.Configuration{
 								"append": TransformerPluginConfig{
-									Headers: []string{"foo:bar"},
+									Headers: []Header{
+										NewHeader("foo", "bar"),
+									},
 								},
 							},
 						},

--- a/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -62,23 +62,23 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 					Name: kong.String("request-transformer"),
 					Config: kong.Configuration{
 						"add": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-set:bar",
+							Headers: []Header{
+								NewHeader("header-to-set", "bar"),
 							},
 						},
 						"append": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-add:foo",
+							Headers: []Header{
+								NewHeader("header-to-add", "foo"),
 							},
 						},
 						"remove": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-remove",
+							Headers: []Header{
+								NewHeader("header-to-remove", ""),
 							},
 						},
 						"replace": TransformerPluginReplaceConfig{
-							Headers: []string{
-								"header-to-set:bar",
+							Headers: []Header{
+								NewHeader("header-to-set", "bar"),
 							},
 						},
 					},
@@ -108,8 +108,8 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 					Name: kong.String("response-transformer"),
 					Config: kong.Configuration{
 						"add": TransformerPluginConfig{
-							Headers: []string{
-								"Location: http://example.org/test",
+							Headers: []Header{
+								NewHeader("Location", "http://example.org/test"),
 							},
 						},
 					},
@@ -143,23 +143,23 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 					Name: kong.String("response-transformer"),
 					Config: kong.Configuration{
 						"add": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-set:bar",
+							Headers: []Header{
+								NewHeader("header-to-set", "bar"),
 							},
 						},
 						"append": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-add:foo",
+							Headers: []Header{
+								NewHeader("header-to-add", "foo"),
 							},
 						},
 						"remove": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-remove",
+							Headers: []Header{
+								NewHeader("header-to-remove", ""),
 							},
 						},
 						"replace": TransformerPluginReplaceConfig{
-							Headers: []string{
-								"header-to-set:bar",
+							Headers: []Header{
+								NewHeader("header-to-set", "bar"),
 							},
 						},
 					},
@@ -167,7 +167,7 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "valid extensionrefs filters",
+			name: "valid extension refs filters",
 			filters: []gatewayapi.HTTPRouteFilter{
 				{
 					Type: gatewayapi.HTTPRouteFilterExtensionRef,
@@ -196,7 +196,7 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 			expectedPlugins: nil,
 		},
 		{
-			name: "invalid extensionrefs filter group",
+			name: "invalid extension refs filter group",
 			filters: []gatewayapi.HTTPRouteFilter{
 				{
 					Type: gatewayapi.HTTPRouteFilterExtensionRef,
@@ -210,7 +210,7 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 			expectedErr: errors.New("plugin wrong.group/KongPlugin unsupported"),
 		},
 		{
-			name: "invalid extensionrefs filter kind",
+			name: "invalid extension refs filter kind",
 			filters: []gatewayapi.HTTPRouteFilter{
 				{
 					Type: gatewayapi.HTTPRouteFilterExtensionRef,
@@ -253,14 +253,14 @@ func TestGeneratePluginsFromHTTPRouteFilters(t *testing.T) {
 					Name: kong.String("request-transformer"),
 					Config: kong.Configuration{
 						"add": TransformerPluginConfig{
-							Headers: []string{
-								"header-to-set:bar",
+							Headers: []Header{
+								NewHeader("header-to-set", "bar"),
 							},
 						},
 						"replace": TransformerPluginReplaceConfig{
 							URI: "/new$(uri_captures[1])",
-							Headers: []string{
-								"header-to-set:bar",
+							Headers: []Header{
+								NewHeader("header-to-set", "bar"),
 							},
 						},
 					},
@@ -494,13 +494,13 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 			expected: []transformerPlugin{{
 				Type: transformerPluginTypeRequest,
 				Replace: TransformerPluginReplaceConfig{
-					Headers: []string{
-						"host:replaced.host",
+					Headers: []Header{
+						NewHeader("host", "replaced.host"),
 					},
 				},
 				Add: TransformerPluginConfig{
-					Headers: []string{
-						"host:replaced.host",
+					Headers: []Header{
+						NewHeader("host", "replaced.host"),
 					},
 				},
 			}},
@@ -526,13 +526,13 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 				{
 					Type: transformerPluginTypeRequest,
 					Replace: TransformerPluginReplaceConfig{
-						Headers: []string{
-							"host:replaced.host",
+						Headers: []Header{
+							NewHeader("host", "replaced.host"),
 						},
 					},
 					Add: TransformerPluginConfig{
-						Headers: []string{
-							"host:replaced.host",
+						Headers: []Header{
+							NewHeader("host", "replaced.host"),
 						},
 					},
 				},
@@ -679,7 +679,7 @@ func TestMergePluginsOfTheSameType(t *testing.T) {
 				{
 					Type: transformerPluginTypeRequest,
 					Add: TransformerPluginConfig{
-						Headers: []string{"header1:value1"},
+						Headers: []Header{NewHeader("header1", "value1")},
 					},
 					Replace: TransformerPluginReplaceConfig{
 						URI: "path1",
@@ -688,7 +688,7 @@ func TestMergePluginsOfTheSameType(t *testing.T) {
 				{
 					Type: transformerPluginTypeRequest,
 					Add: TransformerPluginConfig{
-						Headers: []string{"header2:value2"},
+						Headers: []Header{NewHeader("header2", "value2")},
 					},
 					Replace: TransformerPluginReplaceConfig{
 						URI: "path2",
@@ -699,7 +699,7 @@ func TestMergePluginsOfTheSameType(t *testing.T) {
 				{
 					Type: transformerPluginTypeRequest,
 					Add: TransformerPluginConfig{
-						Headers: []string{"header1:value1", "header2:value2"},
+						Headers: []Header{NewHeader("header1", "value1"), NewHeader("header2", "value2")},
 					},
 					Replace: TransformerPluginReplaceConfig{
 						URI: "path1",
@@ -1022,7 +1022,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 		Kind:       "Service",
 	}
 
-	refernceGrantTypeMeta := metav1.TypeMeta{
+	referenceGrantTypeMeta := metav1.TypeMeta{
 		APIVersion: "gateway.networking.k8s.io/v1beta1",
 		Kind:       "ReferenceGrant",
 	}
@@ -1271,7 +1271,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 			},
 			referenceGrants: []*gatewayapi.ReferenceGrant{
 				{
-					TypeMeta: refernceGrantTypeMeta,
+					TypeMeta: referenceGrantTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "grant-from-httproute-to-service",
@@ -1507,7 +1507,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 			},
 			referenceGrants: []*gatewayapi.ReferenceGrant{
 				{
-					TypeMeta: refernceGrantTypeMeta,
+					TypeMeta: referenceGrantTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "grant-from-httproute-to-service",
@@ -1684,7 +1684,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := logr.Discard()
-			fakestore, err := store.NewFakeStore(store.FakeObjects{
+			fakeStore, err := store.NewFakeStore(store.FakeObjects{
 				Services:        tc.k8sServices,
 				ReferenceGrants: tc.referenceGrants,
 			})
@@ -1700,7 +1700,7 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 				ExpressionRoutes:                        false,
 				SupportRedirectPlugin:                   false,
 			}
-			translationResult := TranslateHTTPRoutesToKongstateServices(logger, fakestore, tc.httpRoutes, translateOptions)
+			translationResult := TranslateHTTPRoutesToKongstateServices(logger, fakeStore, tc.httpRoutes, translateOptions)
 			require.Len(t, translationResult.HTTPRouteNameToTranslationErrors, 0, "Should not get translation errors in translating")
 
 			kongstateServices := translationResult.ServiceNameToKongstateService
@@ -1712,10 +1712,10 @@ func TestTranslateHTTPRoutesToKongstateServices(t *testing.T) {
 				require.Equal(t, *expectedService.Name, *s.Name, "Service %s should have expected name inside", serviceName)
 				require.Equal(t, *expectedService.Host, *s.Host, "Service %s should have expected host", serviceName)
 				// compare backends.
-				require.Lenf(t, s.Backends, len(expectedService.Backends), "Service %s should have expected number of backends")
+				require.Len(t, s.Backends, len(expectedService.Backends), "Service %s should have expected number of backends", serviceName)
 				backendCompareMsg := `Service %s backend %d should have expected %s` // service name, backend index, field name
 				for i, expectedBackend := range expectedService.Backends {
-					require.Equalf(t, s.Backends[i].Namespace(), expectedBackend.Namespace(), backendCompareMsg, serviceName, i, "namespace")
+					require.Equal(t, s.Backends[i].Namespace(), expectedBackend.Namespace(), backendCompareMsg, serviceName, i, "namespace")
 					require.Equal(t, s.Backends[i].Name(), expectedBackend.Name(), backendCompareMsg, serviceName, i, "name")
 					require.Equal(t, s.Backends[i].PortDef(), expectedBackend.PortDef(), backendCompareMsg, serviceName, i, "port")
 					require.Equal(t, s.Backends[i].Weight(), expectedBackend.Weight(), backendCompareMsg, serviceName, i, "weight")

--- a/internal/dataplane/translator/translate_httproute_test.go
+++ b/internal/dataplane/translator/translate_httproute_test.go
@@ -1052,7 +1052,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
 												"append": subtranslator.TransformerPluginConfig{
-													Headers: []string{"X-Test-Header-1:test-value-1"},
+													Headers: []subtranslator.Header{subtranslator.NewHeader("X-Test-Header-1", "test-value-1")},
 												},
 											},
 											Tags: []*string{
@@ -1092,7 +1092,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
 												"append": subtranslator.TransformerPluginConfig{
-													Headers: []string{"X-Test-Header-2:test-value-2"},
+													Headers: []subtranslator.Header{subtranslator.NewHeader("X-Test-Header-2", "test-value-2")},
 												},
 											},
 											Tags: []*string{
@@ -1476,7 +1476,7 @@ func TestIngressRulesFromHTTPRoutes(t *testing.T) {
 											Name: kong.String("request-transformer"),
 											Config: kong.Configuration{
 												"append": subtranslator.TransformerPluginConfig{
-													Headers: []string{"X-Test-Header-1:test-value-1"},
+													Headers: []subtranslator.Header{subtranslator.NewHeader("X-Test-Header-1", "test-value-1")},
 												},
 											},
 											Tags: []*string{
@@ -2101,7 +2101,9 @@ func TestIngressRulesFromHTTPRoutesCombinedServicesAcrossHTTPRoutes(t *testing.T
 											Name: kong.String("response-transformer"),
 											Config: kong.Configuration{
 												"add": subtranslator.TransformerPluginConfig{
-													Headers: []string{"Location: http://konghq.com/kong"},
+													Headers: []subtranslator.Header{
+														subtranslator.NewHeader("Location", "http://konghq.com/kong"),
+													},
 												},
 											},
 											Tags: []*string{
@@ -2153,7 +2155,9 @@ func TestIngressRulesFromHTTPRoutesCombinedServicesAcrossHTTPRoutes(t *testing.T
 											Name: kong.String("response-transformer"),
 											Config: kong.Configuration{
 												"add": subtranslator.TransformerPluginConfig{
-													Headers: []string{"Location: http://kumahq.com/kuma"},
+													Headers: []subtranslator.Header{
+														subtranslator.NewHeader("Location", "http://kumahq.com/kuma"),
+													},
 												},
 											},
 											Tags: []*string{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

As described in the reported issue https://github.com/Kong/kubernetes-ingress-controller/issues/6851 header (port `:443` is missing due to changes from https://github.com/Kong/kubernetes-ingress-controller/pull/6804)

```
Location:  https://demo.example.com/path
```

two spaces after colon instead of expected

```
Location: https://demo.example.com/path
```

Unfortunately, not all programs ignore whitespaces in headers (they should), thus it's problematic.

This PR fixes it. 




<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6851

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

The actual root cause was [here](https://github.com/Kong/kubernetes-ingress-controller/pull/6855/files#diff-df2a67c9ede8d32433f70281fa4979f7c97dc5229fbf51458d01be729ee2bedeL1132-L1134), all other changes are a parto of an opprotunistic refactor to avoid such problems in the future.

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
