### PR TITLE
chore(tests): fix flake due to missing HTTPRoute CRD

### DIFF
--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -493,11 +493,18 @@ func setupControllers(
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/BackendTLSPolicy"),
 				CacheSyncTimeout: c.CacheSyncTimeout,
-				RequiredCRDs: append(baseGatewayCRDs(), schema.GroupVersionResource{
-					Group:    gatewayv1alpha3.GroupVersion.Group,
-					Version:  gatewayv1alpha3.GroupVersion.Version,
-					Resource: "backendtlspolicies",
-				}),
+				RequiredCRDs: append(
+					baseGatewayCRDs(),
+					schema.GroupVersionResource{
+						Group:    gatewayv1.GroupVersion.Group,
+						Version:  gatewayv1.GroupVersion.Version,
+						Resource: "httproutes",
+					},
+					schema.GroupVersionResource{
+						Group:    gatewayv1alpha3.GroupVersion.Group,
+						Version:  gatewayv1alpha3.GroupVersion.Version,
+						Resource: "backendtlspolicies",
+					}),
 				Controller: &gateway.BackendTLSPolicyReconciler{
 					Client:            mgr.GetClient(),
 					Log:               ctrl.LoggerFrom(ctx).WithName("controllers").WithName("BackendTLSPolicy"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

The source of error is this function. 

https://github.com/Kong/kubernetes-ingress-controller/blob/6c787c10e85724d99b142737aaa0a9c2fe5aca75/internal/controllers/gateway/backendtlspolicy_controller.go#L182-L230

See that it requires not only `gatewayapi.BackendTLSPolicy` but also `gatewayapi.HTTPRoute`, thus this PR adds it to the list of `RequiredCRDs` for the start of this controller. In other words, the creation of the controller will start when all required CRDs are available in the cluster.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/6854

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

