### PR TITLE
fix: do not unregister Kong DPs metrics when Konnect integration is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,18 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+> Release date: TBD
+
+### Fixed
+
+- Custom Prometheus metrics (e.g. `ingress_controller_configuration_push_count`,
+  `ingress_controller_configuration_push_broken_resource_count`, etc.) were not
+  collected properly when the Konnect integration was enabled (only Konnect-related
+  metrics were collected, omitting regular DP metrics). This has been fixed.
+  [#6881](https://github.com/Kong/kubernetes-ingress-controller/pull/6881)
+
 ## [3.4.0]
 
 > Release date: 2024-12-18

--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -311,6 +311,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 		p,
 		&cacheStores,
 		fallbackConfigGenerator,
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -884,6 +884,7 @@ func setupTestKongClient(
 		configBuilder,
 		&cacheStores,
 		newMockFallbackConfigGenerator(),
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 	return kongClient
@@ -914,6 +915,7 @@ func attachKonnectConfigSynchronizer(
 		updateStrategyResolver,
 		configChangeDetector,
 		configStatusNotifier,
+		mocks.MetricsRecorder{},
 	)
 	kc.SetKonnectConfigSynchronizer(konnectConfigSynchronizer)
 	err := konnectConfigSynchronizer.Start(ctx)
@@ -1190,6 +1192,7 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 				configBuilder,
 				&originalCache,
 				fallbackConfigGenerator,
+				mocks.MetricsRecorder{},
 			)
 			require.NoError(t, err)
 
@@ -1325,6 +1328,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		configBuilder,
 		&originalCache,
 		fallbackConfigGenerator,
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 
@@ -1471,6 +1475,7 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 		configBuilder,
 		&originalCache,
 		fallbackConfigGenerator,
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 
@@ -1580,6 +1585,7 @@ func TestKongClient_LastValidCacheSnapshot(t *testing.T) {
 				configBuilder,
 				&originalCache,
 				fallbackConfigGenerator,
+				mocks.MetricsRecorder{},
 			)
 			require.NoError(t, err)
 
@@ -1802,6 +1808,7 @@ func TestKongClient_RecoveringFromGatewaySyncError(t *testing.T) {
 				configBuilder,
 				&originalCache,
 				fallbackConfigGenerator,
+				mocks.MetricsRecorder{},
 			)
 			require.NoError(t, err)
 

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -46,7 +46,7 @@ func PerformUpdate(
 	config Config,
 	targetContent *file.Content,
 	customEntities CustomEntitiesByType,
-	promMetrics *metrics.CtrlFuncMetrics,
+	promMetrics metrics.Recorder,
 	updateStrategyResolver UpdateStrategyResolver,
 	configChangeDetector ConfigurationChangeDetector,
 	diagnostic *diagnostics.ClientDiagnostic,

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -31,7 +31,7 @@ type ConfigSynchronizer struct {
 	syncTicker             *time.Ticker
 	kongConfig             sendconfig.Config
 	konnectClient          *adminapi.KonnectClient
-	prometheusMetrics      *metrics.CtrlFuncMetrics
+	metricsRecorder        metrics.Recorder
 	updateStrategyResolver sendconfig.UpdateStrategyResolver
 	configChangeDetector   sendconfig.ConfigurationChangeDetector
 	configStatusNotifier   clients.ConfigStatusNotifier
@@ -48,13 +48,14 @@ func NewConfigSynchronizer(
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configChangeDetector sendconfig.ConfigurationChangeDetector,
 	configStatusNotifier clients.ConfigStatusNotifier,
+	metricsRecorder metrics.Recorder,
 ) *ConfigSynchronizer {
 	return &ConfigSynchronizer{
 		logger:                 logger,
 		syncTicker:             time.NewTicker(configUploadPeriod),
 		kongConfig:             kongConfig,
 		konnectClient:          konnectClient,
-		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
+		metricsRecorder:        metricsRecorder,
 		updateStrategyResolver: updateStrategyResolver,
 		configChangeDetector:   configChangeDetector,
 		configStatusNotifier:   configStatusNotifier,
@@ -134,7 +135,7 @@ func (s *ConfigSynchronizer) uploadConfig(ctx context.Context, client *adminapi.
 		targetContent,
 		// Konnect client does not upload custom entities.
 		sendconfig.CustomEntitiesByType{},
-		s.prometheusMetrics,
+		s.metricsRecorder,
 		s.updateStrategyResolver,
 		s.configChangeDetector,
 		nil,

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -69,7 +68,7 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 		logger:                 logr.Discard(),
 		syncTicker:             time.NewTicker(sendConfigPeriod),
 		konnectClient:          testKonnectClient,
-		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
+		metricsRecorder:        mocks.MetricsRecorder{},
 		updateStrategyResolver: resolver,
 		configChangeDetector:   sendconfig.NewDefaultConfigurationChangeDetector(log),
 		configStatusNotifier:   clients.NoOpConfigStatusNotifier{},

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/telemetry"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils/kongconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
@@ -200,6 +201,7 @@ func Run(
 	configurationChangeDetector := sendconfig.NewDefaultConfigurationChangeDetector(logger)
 	kongConfigFetcher := configfetcher.NewDefaultKongLastGoodConfigFetcher(translatorFeatureFlags.FillIDs, c.KongWorkspace)
 	fallbackConfigGenerator := fallback.NewGenerator(fallback.NewDefaultCacheGraphProvider(), logger)
+	metricsRecorder := metrics.NewGlobalCtrlRuntimeMetricsRecorder()
 	dataplaneClient, err := dataplane.NewKongClient(
 		logger,
 		time.Duration(c.ProxyTimeoutSeconds*float32(time.Second)),
@@ -214,6 +216,7 @@ func Run(
 		configTranslator,
 		&cache,
 		fallbackConfigGenerator,
+		metricsRecorder,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize kong data-plane client: %w", err)
@@ -293,6 +296,7 @@ func Run(
 			clientsManager,
 			updateStrategyResolver,
 			configStatusNotifier,
+			metricsRecorder,
 		)
 		if err != nil {
 			setupLog.Error(err, "Failed to setup Konnect configuration synchronizer with manager, skipping")

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
 )
@@ -495,6 +496,7 @@ func setupKonnectConfigSynchronizer(
 	clientsProvider clients.AdminAPIClientsProvider,
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configStatusNotifier clients.ConfigStatusNotifier,
+	metricsRecorder metrics.Recorder,
 ) (*konnect.ConfigSynchronizer, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer")
 	s := konnect.NewConfigSynchronizer(
@@ -505,6 +507,7 @@ func setupKonnectConfigSynchronizer(
 		updateStrategyResolver,
 		sendconfig.NewDefaultConfigurationChangeDetector(logger),
 		configStatusNotifier,
+		metricsRecorder,
 	)
 	err := mgr.Add(s)
 	if err != nil {

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -10,24 +10,59 @@ import (
 
 	deckutils "github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/kong/go-kong/kong"
+	prom "github.com/prometheus/client_model/go"
+	"github.com/samber/lo"
 	"github.com/samber/mo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckerrors"
 )
 
-func TestNewCtrlFuncMetricsDoesNotPanicWhenCalledTwice(t *testing.T) {
+func TestNewGlobalCtrlRuntimeMetricsRecorder_DoesNotPanicWhenCalledTwice(t *testing.T) {
 	require.NotPanics(t, func() {
-		_ = NewCtrlFuncMetrics()
+		_ = NewGlobalCtrlRuntimeMetricsRecorder()
 	})
 	require.NotPanics(t, func() {
-		_ = NewCtrlFuncMetrics()
+		_ = NewGlobalCtrlRuntimeMetricsRecorder()
 	})
+}
+
+func TestGlobalCtrlRuntimeMetricsRecorder_AnyInstanceWritesToTheSameRegistry(t *testing.T) {
+	m1 := NewGlobalCtrlRuntimeMetricsRecorder()
+	m2 := NewGlobalCtrlRuntimeMetricsRecorder()
+
+	const (
+		firstDPHost  = "https://1.host"
+		secondDPHost = "https://2.host"
+	)
+	m1.RecordPushSuccess(ProtocolDBLess, time.Millisecond, mo.Some(22), firstDPHost)
+	m2.RecordPushSuccess(ProtocolDBLess, time.Millisecond, mo.Some(22), secondDPHost)
+
+	// Verify that both instances write to the same registry (the controller-runtime's global registry).
+	ctrlRuntimeGlobalRegistry := metrics.Registry
+	metricFamilies, err := ctrlRuntimeGlobalRegistry.Gather()
+	require.NoError(t, err)
+	metricFamily, ok := lo.Find(metricFamilies, func(family *prom.MetricFamily) bool {
+		return family.Name != nil && *family.Name == MetricNameConfigPushCount
+	})
+	require.True(t, ok, "expected to find %q metric", MetricNameConfigPushCount)
+
+	assertMetricsContainHost := func(host string) {
+		assert.True(t, lo.ContainsBy(metricFamily.Metric, func(metric *prom.Metric) bool {
+			return lo.ContainsBy(metric.Label, func(label *prom.LabelPair) bool {
+				return label.GetName() == DataplaneKey && label.GetValue() == host
+			})
+		}), "expected to find %q metric with dataplane label %q", MetricNameConfigPushCount, host)
+	}
+	assertMetricsContainHost(firstDPHost)
+	assertMetricsContainHost(secondDPHost)
 }
 
 func TestRecordPush(t *testing.T) {
 	mockSizeOfCfg := mo.Some(22)
-	m := NewCtrlFuncMetrics()
+	m := NewGlobalCtrlRuntimeMetricsRecorder()
 
 	t.Run("recording push success works", func(t *testing.T) {
 		require.NotPanics(t, func() {
@@ -39,8 +74,8 @@ func TestRecordPush(t *testing.T) {
 			m.RecordPushFailure(ProtocolDBLess, time.Millisecond, mockSizeOfCfg, "https://10.0.0.1:8080", 5, fmt.Errorf("custom error"))
 		})
 	})
-	// Verify that multiple call of NewCtrlFuncMetrics keeps all created metrics work.
-	m2 := NewCtrlFuncMetrics()
+	// Verify that multiple call of NewGlobalCtrlRuntimeMetricsRecorder keeps all created metrics work.
+	m2 := NewGlobalCtrlRuntimeMetricsRecorder()
 	t.Run("recording push success works for old metrics", func(t *testing.T) {
 		require.NotPanics(t, func() {
 			m.RecordPushSuccess(ProtocolDBLess, time.Millisecond, mockSizeOfCfg, "https://10.0.0.1:8080")
@@ -54,7 +89,7 @@ func TestRecordPush(t *testing.T) {
 }
 
 func TestRecordTranslation(t *testing.T) {
-	m := NewCtrlFuncMetrics()
+	m := NewGlobalCtrlRuntimeMetricsRecorder()
 	t.Run("recording translation success works", func(t *testing.T) {
 		require.NotPanics(t, func() {
 			m.RecordTranslationSuccess(10 * time.Millisecond)

--- a/test/mocks/metrics_recorder.go
+++ b/test/mocks/metrics_recorder.go
@@ -1,0 +1,51 @@
+package mocks
+
+import (
+	"time"
+
+	"github.com/samber/mo"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+)
+
+// MetricsRecorder is a mock implementation of metrics.Recorder.
+type MetricsRecorder struct{}
+
+func (m MetricsRecorder) RecordPushFailure(metrics.Protocol, time.Duration, mo.Option[int], string, int, error) {
+}
+
+func (m MetricsRecorder) RecordPushSuccess(metrics.Protocol, time.Duration, mo.Option[int], string) {
+}
+
+func (m MetricsRecorder) RecordFallbackPushSuccess(metrics.Protocol, time.Duration, mo.Option[int], string) {
+}
+
+func (m MetricsRecorder) RecordFallbackPushFailure(metrics.Protocol, time.Duration, mo.Option[int], string, int, error) {
+}
+
+func (m MetricsRecorder) RecordProcessedConfigSnapshotCacheHit() {
+}
+
+func (m MetricsRecorder) RecordProcessedConfigSnapshotCacheMiss() {
+}
+
+func (m MetricsRecorder) RecordTranslationFailure(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordTranslationBrokenResources(int) {
+}
+
+func (m MetricsRecorder) RecordTranslationSuccess(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordFallbackTranslationBrokenResources(int) {
+}
+
+func (m MetricsRecorder) RecordFallbackTranslationFailure(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordFallbackTranslationSuccess(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordFallbackCacheGenerationDuration(time.Duration, error) {
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes a bug discovered during a refactor in which metrics related to regular DPs are not collected when Konnect integration is turned on.

The root issue was caused by creating two separate instances of `CtrlFuncMetrics` (one for the [KongClient](https://github.com/Kong/kubernetes-ingress-controller/blob/425d3ef39a411fea73bd9c3b61a726d7254578a5/internal/dataplane/kong_client.go#L209) and another for the newly introduced [konnect.ConfigSynchronizer](https://github.com/Kong/kubernetes-ingress-controller/blob/844c2910951b12fc4564886fbf5122d5b9dc5928/internal/konnect/config_synchronizer.go#L57)) where the latter was [unregistering](https://github.com/Kong/kubernetes-ingress-controller/blob/12a4875cc97a84ae0ca58fb5e74356db3c260a9d/internal/metrics/prometheus.go#L389) the first one's metrics. It was effectively making KongClient push its metrics into void as they were not registered in any registry.

The bug [was introduced](https://github.com/Kong/kubernetes-ingress-controller/commit/d63ce1de6228723f93173efd761d42c7591a0c10) in KIC 3.3, so it has to be backported to both 3.3 and 3.4 release branches.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
