### PR TITLE
chore: don't use KonnectClient in ClientsProvider

### DIFF
--- a/internal/clients/config_status.go
+++ b/internal/clients/config_status.go
@@ -32,6 +32,7 @@ type GatewayConfigApplyStatus struct {
 
 // KonnectConfigUploadStatus stores the status of uploading configuration to Konnect.
 type KonnectConfigUploadStatus struct {
+	// Failed indicates whether the config upload to Konnect failed.
 	Failed bool
 }
 

--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -31,7 +31,6 @@ type ClientFactory interface {
 // AdminAPIClientsProvider allows fetching the most recent list of Admin API clients of Gateways that
 // we should configure.
 type AdminAPIClientsProvider interface {
-	KonnectClient() *adminapi.KonnectClient
 	GatewayClients() []*adminapi.Client
 	GatewayClientsToConfigure() []*adminapi.Client
 }
@@ -74,10 +73,6 @@ type AdminAPIClientsManager struct {
 
 	// readinessReconciliationTicker is used to run readiness reconciliation loop.
 	readinessReconciliationTicker Ticker
-
-	// konnectClient represents a special-case of the data-plane which is Konnect cloud.
-	// This client is used to synchronise configuration with Konnect's Control Plane Admin API.
-	konnectClient *adminapi.KonnectClient
 
 	// lock prevents concurrent access to the manager's fields.
 	lock sync.RWMutex
@@ -175,20 +170,6 @@ func (c *AdminAPIClientsManager) Notify(discoveredAPIs []adminapi.DiscoveredAdmi
 	case <-c.ctx.Done():
 	case c.discoveredAdminAPIsNotifyChan <- discoveredAPIs:
 	}
-}
-
-// SetKonnectClient sets a client that will be used to communicate with Konnect Control Plane Admin API.
-// If called multiple times, it will override the client.
-func (c *AdminAPIClientsManager) SetKonnectClient(client *adminapi.KonnectClient) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.konnectClient = client
-}
-
-func (c *AdminAPIClientsManager) KonnectClient() *adminapi.KonnectClient {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return c.konnectClient
 }
 
 // GatewayClients returns a copy of current client's slice. Konnect client won't be included.

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -207,12 +207,6 @@ func TestAdminAPIClientsManager_Clients(t *testing.T) {
 	require.Len(t, m.GatewayClients(), 1, "expecting one initial client")
 	require.Equal(t, m.GatewayClientsCount(), 1, "expecting one initial client")
 	require.Len(t, m.GatewayClientsToConfigure(), 1, "Expecting one initial client")
-
-	konnectTestClient := &adminapi.KonnectClient{}
-	m.SetKonnectClient(konnectTestClient)
-	require.Len(t, m.GatewayClients(), 1, "konnect client should not be returned from GatewayClients")
-	require.Equal(t, m.GatewayClientsCount(), 1, "konnect client should not be counted in GatewayClientsCount")
-	require.Equal(t, konnectTestClient, m.KonnectClient(), "konnect client should be returned from KonnectClient")
 }
 
 func TestAdminAPIClientsManager_Clients_DBMode(t *testing.T) {

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -517,7 +517,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 		return gatewaysSyncErr
 	}
 
-	// Send configuration to Konnect only when successfully applied configuration to gateways.
+	// Send configuration to Konnect only when successfully applied configuration to Kong Gateways run in cluster.
 	c.maybeUpdateKonnectKongState(parsingResult.KongState, isFallback)
 	// Gateways were successfully synced with the current configuration, so we can update the last valid cache snapshot.
 	c.maybePreserveTheLastValidConfigCache(cacheSnapshot)

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -35,7 +35,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
@@ -82,6 +81,11 @@ type FallbackConfigGenerator interface {
 		lastValidCache *store.CacheStores,
 		brokenObjects []fallback.ObjectHash,
 	) (store.CacheStores, fallback.GeneratedCacheMetadata, error)
+}
+
+// KonnectKongStateUpdater is an interface for updating the current state of configuration seen by Konnect.
+type KonnectKongStateUpdater interface {
+	UpdateKongState(kongState *kongstate.KongState, isFallback bool)
 }
 
 // KongClient is a threadsafe high level API client for the Kong data-plane(s)
@@ -180,9 +184,9 @@ type KongClient struct {
 	// lastValidCacheSnapshot can also represent the fallback cache snapshot that was successfully synced with gateways.
 	lastValidCacheSnapshot *store.CacheStores
 
-	// konnectConfigSynchronizer receives latest successfully applied Kong configuration from KongClient
-	// and uploads it to Konnect.
-	konnectConfigSynchronizer *konnect.ConfigSynchronizer
+	// konnectKongStateUpdater is used to update the current state seen by Konnect that will be picked asynchronously
+	// by the Konnect config synchronization loop.
+	konnectKongStateUpdater KonnectKongStateUpdater
 }
 
 // NewKongClient provides a new KongClient object after connecting to the
@@ -492,7 +496,7 @@ func (c *KongClient) Update(ctx context.Context) error {
 	const isFallback = false
 	shas, gatewaysSyncErr := c.sendOutToGatewayClients(ctx, parsingResult.KongState, c.kongConfig, isFallback)
 
-	// Taking into account the results of syncing configuration with Gateways and Konnect, and potential translation
+	// Taking into account the results of syncing configuration with Gateways and potential translation
 	// failures, calculate the config status and update it.
 	c.configStatusNotifier.NotifyGatewayConfigStatus(ctx, clients.GatewayConfigApplyStatus{
 		TranslationFailuresOccurred: len(parsingResult.TranslationFailures) > 0,
@@ -513,8 +517,8 @@ func (c *KongClient) Update(ctx context.Context) error {
 		return gatewaysSyncErr
 	}
 
-	// Send configuration to Konnect ONLY when successfully applied configuration to gateways.
-	c.maybeSendOutToKonnectClient(ctx, parsingResult.KongState, c.kongConfig, isFallback)
+	// Send configuration to Konnect only when successfully applied configuration to gateways.
+	c.maybeUpdateKonnectKongState(parsingResult.KongState, isFallback)
 	// Gateways were successfully synced with the current configuration, so we can update the last valid cache snapshot.
 	c.maybePreserveTheLastValidConfigCache(cacheSnapshot)
 
@@ -634,7 +638,7 @@ func (c *KongClient) tryRecoveringWithFallbackConfiguration(
 	if gatewaysSyncErr != nil {
 		return fmt.Errorf("failed to sync fallback configuration with gateways: %w", gatewaysSyncErr)
 	}
-	c.maybeSendOutToKonnectClient(ctx, fallbackParsingResult.KongState, c.kongConfig, isFallback)
+	c.maybeUpdateKonnectKongState(fallbackParsingResult.KongState, isFallback)
 
 	// Configuration was successfully recovered with the fallback configuration. Store the last valid configuration.
 	c.maybePreserveTheLastValidConfigCache(fallbackCache)
@@ -731,34 +735,12 @@ func (c *KongClient) sendOutToGatewayClients(
 	return previousSHAs, nil
 }
 
-// maybeSendOutToKonnectClient sends out the configuration to Konnect when KonnectClient is provided.
-// It's a noop when Konnect integration is not enabled.
-func (c *KongClient) maybeSendOutToKonnectClient(
-	ctx context.Context,
-	s *kongstate.KongState,
-	config sendconfig.Config,
-	_ bool,
-) {
-	if c.konnectConfigSynchronizer == nil {
+// maybeUpdateKonnectKongState updates the KongState seen by Konnect if the konnectKongStateUpdater is set.
+func (c *KongClient) maybeUpdateKonnectKongState(s *kongstate.KongState, isFallback bool) {
+	if c.konnectKongStateUpdater == nil {
 		return
 	}
-	konnectClient := c.clientsProvider.KonnectClient()
-	if konnectClient == nil {
-		return
-	}
-
-	if config.SanitizeKonnectConfigDumps {
-		s = s.SanitizedCopy(util.DefaultUUIDGenerator{})
-	}
-
-	deckGenParams := deckgen.GenerateDeckContentParams{
-		SelectorTags:                    config.FilterTags,
-		ExpressionRoutes:                config.ExpressionRoutes,
-		PluginSchemas:                   konnectClient.PluginSchemaStore(),
-		AppendStubEntityWhenConfigEmpty: false,
-	}
-	targetContent := deckgen.ToDeckContent(ctx, c.logger, s, deckGenParams)
-	c.konnectConfigSynchronizer.SetTargetContent(targetContent)
+	c.konnectKongStateUpdater.UpdateKongState(s, isFallback)
 }
 
 func (c *KongClient) sendToClient(
@@ -770,16 +752,11 @@ func (c *KongClient) sendToClient(
 ) (string, error) {
 	logger := c.logger.WithValues("url", client.AdminAPIClient().BaseRootURL())
 
-	// If the client is Konnect and the feature flag is turned on,
-	// we should sanitize the configuration before sending it out.
-	if client.IsKonnect() && config.SanitizeKonnectConfigDumps {
-		s = s.SanitizedCopy(util.DefaultUUIDGenerator{})
-	}
 	deckGenParams := deckgen.GenerateDeckContentParams{
 		SelectorTags:                    config.FilterTags,
 		ExpressionRoutes:                config.ExpressionRoutes,
 		PluginSchemas:                   client.PluginSchemaStore(),
-		AppendStubEntityWhenConfigEmpty: !client.IsKonnect() && config.InMemory,
+		AppendStubEntityWhenConfigEmpty: config.InMemory,
 	}
 	targetContent := deckgen.ToDeckContent(ctx, logger, s, deckGenParams)
 	customEntities := make(sendconfig.CustomEntitiesByType)
@@ -846,7 +823,7 @@ func (c *KongClient) sendToClient(
 }
 
 // SetConfigStatusNotifier sets a notifier which notifies subscribers about configuration sending results.
-// Currently it is used for uploading the node status to konnect control plane.
+// Currently, it is used for uploading the node status to Konnect control plane.
 func (c *KongClient) SetConfigStatusNotifier(n clients.ConfigStatusNotifier) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -854,11 +831,11 @@ func (c *KongClient) SetConfigStatusNotifier(n clients.ConfigStatusNotifier) {
 	c.configStatusNotifier = n
 }
 
-func (c *KongClient) SetKonnectConfigSynchronizer(s *konnect.ConfigSynchronizer) {
+// SetKonnectKongStateUpdater sets the KonnectKongStateUpdater which updates the KongState seen by Konnect.
+func (c *KongClient) SetKonnectKongStateUpdater(u KonnectKongStateUpdater) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	c.konnectConfigSynchronizer = s
+	c.konnectKongStateUpdater = u
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/dataplane/sendconfig/dbmode.go
+++ b/internal/dataplane/sendconfig/dbmode.go
@@ -35,7 +35,7 @@ type UpdateStrategyDBMode struct {
 	isKonnect         bool
 	logger            logr.Logger
 	resourceErrors    []ResourceError
-	resourceErrorLock *sync.Mutex
+	resourceErrorLock sync.Mutex
 }
 
 // UpdateStrategyDBModeOpt is a functional option for UpdateStrategyDBMode.
@@ -57,13 +57,11 @@ func NewUpdateStrategyDBMode(
 	opts ...UpdateStrategyDBModeOpt,
 ) *UpdateStrategyDBMode {
 	s := &UpdateStrategyDBMode{
-		client:            client,
-		dumpConfig:        dumpConfig,
-		version:           version,
-		concurrency:       concurrency,
-		logger:            logger,
-		resourceErrors:    []ResourceError{},
-		resourceErrorLock: &sync.Mutex{},
+		client:      client,
+		dumpConfig:  dumpConfig,
+		version:     version,
+		concurrency: concurrency,
+		logger:      logger,
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -108,20 +108,6 @@ func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(
 			},
 			r.config.Version,
 			r.config.Concurrency,
-			// The DB mode update strategy is used for both DB mode gateways and Konnect-integrated controllers. In the
-			// Konnect case, we don't actually want to collect diffs, and don't actually provide a diagnostic when setting
-			// it up, so we only collect and send diffs if we're talking to a gateway.
-			//
-			// TODO maybe this is wrong? I'm not sure if we actually support (or if not, explicitly prohibit)
-			// configuring a controller to use both DB mode and talk to Konnect, or if we only support DB-less when using
-			// Konnect. If those are mutually exclusive, maybe we can just collect diffs for Konnect mode? If they're
-			// not mutually exclusive, trying to do diagnostics diff updates for both the updates would have both attempt
-			// to store diffs. This is... maybe okay. They should be identical, but that's a load-bearing "should": we know
-			// Konnect can sometimes differ in what it accepts versus the gateway, and we have some Konnect configuration
-			// (consumer exclude, sensitive value mask) where they're _definitely_ different. That same configuration could
-			// make the diff confusing even if it's DB mode only, since it doesn't reflect what we're sending to the gateway
-			// in some cases.
-			nil,
 			r.logger,
 		)
 	}
@@ -136,8 +122,8 @@ func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(
 			},
 			r.config.Version,
 			r.config.Concurrency,
-			diagnostic,
 			r.logger,
+			WithDiagnostic(diagnostic),
 		)
 	}
 

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -3,19 +3,25 @@ package konnect
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/mo"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckerrors"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckgen"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
 const (
@@ -25,103 +31,206 @@ const (
 	DefaultConfigUploadPeriod = 30 * time.Second
 )
 
-// ConfigSynchronizer runs a loop to upload the traslated Kong configuration to Konnect in the given period.
+type ClientFactory interface {
+	NewKonnectClient(ctx context.Context) (*adminapi.KonnectClient, error)
+}
+
+// ConfigSynchronizer runs a loop to upload the translated Kong configuration to Konnect periodically.
 type ConfigSynchronizer struct {
-	logger                 logr.Logger
-	syncTicker             *time.Ticker
-	kongConfig             sendconfig.Config
-	konnectClient          *adminapi.KonnectClient
+	logger               logr.Logger
+	kongConfig           sendconfig.Config
+	konnectClientFactory ClientFactory
+
 	metricsRecorder        metrics.Recorder
 	updateStrategyResolver sendconfig.UpdateStrategyResolver
 	configChangeDetector   sendconfig.ConfigurationChangeDetector
 	configStatusNotifier   clients.ConfigStatusNotifier
-	targetContent          *file.Content
 
-	lock sync.RWMutex
+	syncTicker Ticker
+
+	konnectAdminClient     *adminapi.KonnectClient
+	konnectAdminClientLock sync.RWMutex
+
+	targetKongState mo.Option[TargetKongState]
+	configLock      sync.RWMutex
 }
 
-func NewConfigSynchronizer(
-	logger logr.Logger,
-	kongConfig sendconfig.Config,
-	configUploadPeriod time.Duration,
-	konnectClient *adminapi.KonnectClient,
-	updateStrategyResolver sendconfig.UpdateStrategyResolver,
-	configChangeDetector sendconfig.ConfigurationChangeDetector,
-	configStatusNotifier clients.ConfigStatusNotifier,
-	metricsRecorder metrics.Recorder,
-) *ConfigSynchronizer {
+// TargetKongState wraps the Kong state to be uploaded to Konnect and indicates whether the configuration is a fallback
+// configuration.
+type TargetKongState struct {
+	*kongstate.KongState
+
+	// IsFallback indicates whether the configuration is a fallback configuration.
+	IsFallback bool
+}
+
+// TargetContent wraps the deck content to be uploaded to Konnect and indicates whether the configuration is a fallback
+// configuration.
+type TargetContent struct {
+	*file.Content
+
+	// IsFallback indicates whether the configuration is a fallback configuration.
+	IsFallback bool
+}
+
+type ConfigSynchronizerParams struct {
+	Logger                 logr.Logger
+	KongConfig             sendconfig.Config
+	ConfigUploadTicker     Ticker
+	KonnectClientFactory   ClientFactory
+	UpdateStrategyResolver sendconfig.UpdateStrategyResolver
+	ConfigChangeDetector   sendconfig.ConfigurationChangeDetector
+	ConfigStatusNotifier   clients.ConfigStatusNotifier
+	MetricsRecorder        metrics.Recorder
+}
+
+func NewConfigSynchronizer(p ConfigSynchronizerParams) *ConfigSynchronizer {
 	return &ConfigSynchronizer{
-		logger:                 logger,
-		syncTicker:             time.NewTicker(configUploadPeriod),
-		kongConfig:             kongConfig,
-		konnectClient:          konnectClient,
-		metricsRecorder:        metricsRecorder,
-		updateStrategyResolver: updateStrategyResolver,
-		configChangeDetector:   configChangeDetector,
-		configStatusNotifier:   configStatusNotifier,
+		logger:                 p.Logger,
+		kongConfig:             p.KongConfig,
+		syncTicker:             p.ConfigUploadTicker,
+		konnectClientFactory:   p.KonnectClientFactory,
+		updateStrategyResolver: p.UpdateStrategyResolver,
+		configChangeDetector:   p.ConfigChangeDetector,
+		configStatusNotifier:   p.ConfigStatusNotifier,
+		metricsRecorder:        p.MetricsRecorder,
 	}
 }
 
-var _ manager.Runnable = &ConfigSynchronizer{}
+var _ manager.LeaderElectionRunnable = &ConfigSynchronizer{}
 
 // Start starts the loop to receive configuration and uplaod configuration to Konnect.
 func (s *ConfigSynchronizer) Start(ctx context.Context) error {
-	s.logger.Info("Started Konnect configuration synchronizer")
-	go s.runKonnectUpdateServer(ctx)
+	s.logger.Info("Starting Konnect configuration synchronizer")
+
+	konnectAdminClient, err := s.konnectClientFactory.NewKonnectClient(ctx)
+	if err != nil {
+		s.logger.Error(err, "Failed to create Konnect client, skipping Konnect configuration synchronization")
+
+		// We failed to set up Konnect client. We cannot proceed with running the synchronizer.
+		// As it's a manager runnable, we'll wait for the context to be done and return only then to not break the
+		// manager's start process.
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// Set the Konnect client to be used to upload configuration and start the synchronizer main loop.
+	s.konnectAdminClientLock.Lock()
+	s.konnectAdminClient = konnectAdminClient
+	s.konnectAdminClientLock.Unlock()
+	s.logger.Info("Konnect client initialized, starting Konnect configuration synchronization")
+	s.run(ctx)
+
 	return nil
 }
 
-// SetTargetContent stores the latest configuration in `file.Content` format.
-// REVIEW: should we use channel to receive the configuration?
-func (s *ConfigSynchronizer) SetTargetContent(targetContent *file.Content) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	s.targetContent = targetContent
+// NeedLeaderElection returns true to indicate that this runnable requires leader election.
+// This is required to ensure that only one instance of the synchronizer is running at a time.
+func (s *ConfigSynchronizer) NeedLeaderElection() bool {
+	return true
 }
 
-// GetTargetContentCopy returns a copy of the latest configuration in `file.Content` format
-// to prevent data race and long duration of occupying lock.
-func (s *ConfigSynchronizer) GetTargetContentCopy() *file.Content {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.targetContent.DeepCopy()
+// UpdateKongState updates the Kong state to be uploaded to Konnect asynchronously. It may not update the state if
+// the Konnect client is not initialized yet.
+func (s *ConfigSynchronizer) UpdateKongState(ks *kongstate.KongState, isFallbackConfig bool) {
+	// Running the update in a goroutine to not block the caller (i.e. KongClient) as we want to make Konnect updates
+	// affect the critical path as little as possible.
+	go func() {
+		// Update the target configuration to be picked up by the synchronizer loop.
+		s.configLock.Lock()
+		defer s.configLock.Unlock()
+		s.targetKongState = mo.Some(TargetKongState{
+			KongState:  ks,
+			IsFallback: isFallbackConfig,
+		})
+	}()
 }
 
-// runKonnectUpdateServer starts the loop to receive configuration and send configuration to Konenct.
-func (s *ConfigSynchronizer) runKonnectUpdateServer(ctx context.Context) {
+// currentContent takes the current KongState (if available) and generates the deck content to be uploaded to Konnect.
+// It returns the deck content and a boolean indicating whether the configuration is available or not.
+func (s *ConfigSynchronizer) currentContent(ctx context.Context) (TargetContent, bool) {
+	// Konnect client may not be initialized yet as that happens asynchronously after the synchronizer is started.
+	// UpdateKongState may be called before the initialization completes.
+	s.konnectAdminClientLock.RLock()
+	defer s.konnectAdminClientLock.RUnlock()
+	if s.konnectAdminClient == nil {
+		// Konnect client not initialized yet. Cannot generate deck content yet.
+		return TargetContent{}, false
+	}
+
+	s.configLock.RLock()
+	defer s.configLock.RUnlock()
+	targetKongState, ok := s.targetKongState.Get()
+	if !ok {
+		// No configuration received yet.
+		return TargetContent{}, false
+	}
+	ks := targetKongState.KongState
+
+	// Sanitize the configuration dumps if configured to do so.
+	if s.kongConfig.SanitizeKonnectConfigDumps {
+		ks = ks.SanitizedCopy(util.DefaultUUIDGenerator{})
+	}
+
+	// Generate the deck content to be uploaded to Konnect. It may issue some API calls to Konnect to get additional
+	// information like plugin schemas.
+	deckGenParams := deckgen.GenerateDeckContentParams{
+		SelectorTags:     s.kongConfig.FilterTags,
+		ExpressionRoutes: s.kongConfig.ExpressionRoutes,
+		PluginSchemas:    s.konnectAdminClient.PluginSchemaStore(),
+	}
+	return TargetContent{
+		Content:    deckgen.ToDeckContent(ctx, s.logger, ks, deckGenParams),
+		IsFallback: targetKongState.IsFallback,
+	}, true
+}
+
+// KonnectClientInitialized returns true if the Konnect client is initialized and ready to upload configuration.
+func (s *ConfigSynchronizer) KonnectClientInitialized() bool {
+	s.konnectAdminClientLock.RLock()
+	defer s.konnectAdminClientLock.RUnlock()
+	return s.konnectAdminClient != nil
+}
+
+// run starts the loop uploading the current configuration to Konnect.
+func (s *ConfigSynchronizer) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			s.logger.Info("Context done: shutting down the Konnect update server")
+			s.logger.Info("Context done: shutting down the Konnect configuration synchronizer")
 			s.syncTicker.Stop()
-		case <-s.syncTicker.C:
-			s.logger.Info("Start uploading to Konnect")
-			client := s.konnectClient
-			if client == nil {
-				s.logger.Info("Konnect client not ready, skipping")
-				continue
-			}
-			// Copy target content to upload here because uploading full configuration to Konnect may cost too much time.
-			targetContent := s.GetTargetContentCopy()
-			if targetContent == nil {
-				s.logger.Info("No target content received, skipping")
-				continue
-			}
-			err := s.uploadConfig(ctx, client, targetContent)
-			if err != nil {
-				s.logger.Error(err, "failed to upload configuration to Konnect")
-				logKonnectErrors(s.logger, err)
-			}
-			s.configStatusNotifier.NotifyKonnectConfigStatus(ctx, clients.KonnectConfigUploadStatus{
-				Failed: err != nil,
-			})
+			return
+		case <-s.syncTicker.Channel():
+			s.handleConfigSynchronizationTick(ctx)
 		}
 	}
 }
 
+func (s *ConfigSynchronizer) handleConfigSynchronizationTick(ctx context.Context) {
+	s.logger.V(logging.DebugLevel).Info("Start uploading configuration to Konnect")
+
+	// Get the latest configuration copy to upload to Konnect. We don't want to hold the lock for a long time to prevent
+	// blocking the update of the configuration.
+	targetCfg, ok := s.currentContent(ctx)
+	if !ok {
+		s.logger.Info("No configuration received yet, skipping Konnect configuration synchronization")
+		return
+	}
+
+	// Upload the configuration to Konnect.
+	err := s.uploadConfig(ctx, s.konnectAdminClient, targetCfg)
+	if err != nil {
+		s.logger.Error(err, "Failed to upload configuration to Konnect")
+		logKonnectErrors(s.logger, err)
+	}
+}
+
 // uploadConfig sends the given configuration to Konnect.
-func (s *ConfigSynchronizer) uploadConfig(ctx context.Context, client *adminapi.KonnectClient, targetContent *file.Content) error {
-	const isFallback = false
+func (s *ConfigSynchronizer) uploadConfig(
+	ctx context.Context,
+	client *adminapi.KonnectClient,
+	targetContent TargetContent,
+) error {
 	// Remove consumers in target content if consumer sync is disabled.
 	if client.ConsumersSyncDisabled() {
 		targetContent.Consumers = []file.FConsumer{}
@@ -132,26 +241,28 @@ func (s *ConfigSynchronizer) uploadConfig(ctx context.Context, client *adminapi.
 		s.logger,
 		client,
 		s.kongConfig,
-		targetContent,
+		targetContent.Content,
 		// Konnect client does not upload custom entities.
 		sendconfig.CustomEntitiesByType{},
 		s.metricsRecorder,
 		s.updateStrategyResolver,
 		s.configChangeDetector,
 		nil,
-		isFallback,
+		targetContent.IsFallback,
 	)
+	noConfigAcceptedYet := newSHA == nil
+	s.configStatusNotifier.NotifyKonnectConfigStatus(ctx, clients.KonnectConfigUploadStatus{
+		Failed: err != nil || noConfigAcceptedYet,
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to perform update: %w", err)
 	}
+
 	client.SetLastConfigSHA(newSHA)
 	return nil
 }
 
 // logKonnectErrors logs details of each error response returned from Konnect API.
-// TODO: This is copied from internal/dataplane package.
-// Remove the definition in dataplane package after using separate loop to upload config to Konnect:
-// https://github.com/Kong/kubernetes-ingress-controller/issues/6338
 func logKonnectErrors(logger logr.Logger, err error) {
 	if crudActionErrors := deckerrors.ExtractCRUDActionErrors(err); len(crudActionErrors) > 0 {
 		for _, actionErr := range crudActionErrors {

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -99,7 +99,7 @@ func NewConfigSynchronizer(p ConfigSynchronizerParams) *ConfigSynchronizer {
 
 var _ manager.LeaderElectionRunnable = &ConfigSynchronizer{}
 
-// Start starts the loop to receive configuration and uplaod configuration to Konnect.
+// Start starts the loop to receive configuration and upload configuration to Konnect.
 func (s *ConfigSynchronizer) Start(ctx context.Context) error {
 	s.logger.Info("Starting Konnect configuration synchronizer")
 
@@ -218,8 +218,7 @@ func (s *ConfigSynchronizer) handleConfigSynchronizationTick(ctx context.Context
 	}
 
 	// Upload the configuration to Konnect.
-	err := s.uploadConfig(ctx, s.konnectAdminClient, targetCfg)
-	if err != nil {
+	if err := s.uploadConfig(ctx, s.konnectAdminClient, targetCfg); err != nil {
 		s.logger.Error(err, "Failed to upload configuration to Konnect")
 		logKonnectErrors(s.logger, err)
 	}

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -1,4 +1,4 @@
-package konnect
+package konnect_test
 
 import (
 	"context"
@@ -17,74 +17,47 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
-func mustSampleKonnectClient(t *testing.T) *adminapi.KonnectClient {
-	t.Helper()
+const (
+	testSendConfigPeriod           = 10 * time.Millisecond
+	testSendConfigAssertionTimeout = 10 * testSendConfigPeriod
+	testSendConfigAssertionTick    = testSendConfigPeriod
+)
 
-	c, err := adminapi.NewKongAPIClient(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString()), &http.Client{})
-	require.NoError(t, err)
-
-	rgID := uuid.NewString()
-	return adminapi.NewKonnectClient(c, rgID, false)
-}
-
-func TestConfigSynchronizer_GetTargetContentCopy(t *testing.T) {
-	content := &file.Content{
-		FormatVersion: "3.0",
-		Services: []file.FService{
-			{
-				Service: kong.Service{
-					Name: kong.String("service1"),
-					Host: kong.String("example.com"),
-				},
-				Routes: []*file.FRoute{
-					{
-						Route: kong.Route{
-							Name:       kong.String("route1"),
-							Expression: kong.String("http.path == \"/foo\""),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	s := &ConfigSynchronizer{}
-	s.SetTargetContent(content)
-	copiedContent := s.GetTargetContentCopy()
-	require.Equal(t, content, copiedContent, "Copied content should have values with same fields with original content")
-	require.NotSame(t, content, copiedContent, "Copied content should not point to the same object with the original content")
-}
-
-func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
-	sendConfigPeriod := 10 * time.Millisecond
+func TestConfigSynchronizer_UpdatesKongConfigAccordingly(t *testing.T) {
+	log := logr.Discard()
 	testKonnectClient := mustSampleKonnectClient(t)
 	resolver := mocks.NewUpdateStrategyResolver()
-	log := logr.Discard()
-	s := &ConfigSynchronizer{
-		logger:                 logr.Discard(),
-		syncTicker:             time.NewTicker(sendConfigPeriod),
-		konnectClient:          testKonnectClient,
-		metricsRecorder:        mocks.MetricsRecorder{},
-		updateStrategyResolver: resolver,
-		configChangeDetector:   sendconfig.NewDefaultConfigurationChangeDetector(log),
-		configStatusNotifier:   clients.NoOpConfigStatusNotifier{},
-	}
+	configStatusNotifier := clients.NewChannelConfigNotifier(log)
+	s := konnect.NewConfigSynchronizer(
+		konnect.ConfigSynchronizerParams{
+			Logger:                 log,
+			ConfigUploadTicker:     clock.NewTickerWithDuration(testSendConfigPeriod),
+			KonnectClientFactory:   &mocks.KonnectClientFactory{Client: testKonnectClient},
+			UpdateStrategyResolver: resolver,
+			ConfigChangeDetector:   sendconfig.NewDefaultConfigurationChangeDetector(log),
+			ConfigStatusNotifier:   configStatusNotifier,
+			MetricsRecorder:        &mocks.MetricsRecorder{},
+		},
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	err := s.Start(ctx)
-	require.NoError(t, err)
+	defer cancel()
+	runSynchronizer(ctx, t, s)
 
 	t.Logf("Verifying that no URL are updated when no configuration received")
 	require.Never(t, func() bool {
 		return len(resolver.GetUpdateCalledForURLs()) != 0
-	}, 10*sendConfigPeriod, sendConfigPeriod, "Should not update any URL when no configuration received")
+	}, testSendConfigAssertionTimeout, testSendConfigAssertionTick, "Should not update any URL when no configuration received")
 
 	t.Logf("Verifying that the new config updated when received")
-	content := &file.Content{
+	expectedContent := &file.Content{
 		FormatVersion: "3.0",
 		Services: []file.FService{
 			{
@@ -92,47 +65,48 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 					Name: kong.String("service1"),
 					Host: kong.String("example.com"),
 				},
-				Routes: []*file.FRoute{
-					{
-						Route: kong.Route{
-							Name:       kong.String("route1"),
-							Expression: kong.String("http.path == \"/foo\""),
-						},
-					},
-				},
 			},
 		},
 	}
-	s.SetTargetContent(content)
+	kongState := func() *kongstate.KongState {
+		return &kongstate.KongState{
+			Services: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name: kong.String("service1"),
+						Host: kong.String("example.com"),
+					},
+				},
+			},
+		}
+	}
+	s.UpdateKongState(kongState(), false)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		urls := resolver.GetUpdateCalledForURLs()
 		require.Len(t, urls, 1, "should update only one URL (Konnect)")
 		url := urls[0]
 		contentWithHash, ok := resolver.LastUpdatedContentForURL(url)
 		require.True(t, ok, "should have last updated content for the URL")
-		require.Empty(t, cmp.Diff(content, contentWithHash.Content), "should send expected configuration")
-	}, 10*sendConfigPeriod, sendConfigPeriod)
+		require.Empty(t, cmp.Diff(expectedContent, contentWithHash.Content), "should send expected configuration")
+	}, testSendConfigAssertionTimeout, testSendConfigAssertionTick)
 
 	t.Logf("Verifying that update is not called when config not changed")
 	l := len(resolver.GetUpdateCalledForURLs())
-	s.SetTargetContent(content)
+	s.UpdateKongState(kongState(), false)
 	require.Never(t, func() bool {
 		return len(resolver.GetUpdateCalledForURLs()) != l
-	}, 10*sendConfigPeriod, sendConfigPeriod)
+	}, testSendConfigAssertionTimeout, testSendConfigAssertionTick)
 
 	t.Logf("Verifying that new config are not sent after context cancelled")
 	cancel()
 	<-ctx.Done()
-	// modify content
-	newContent := content.DeepCopy()
-	newContent.Consumers = []file.FConsumer{
-		{
-			Consumer: kong.Consumer{
-				Username: kong.String("consumer-1"),
-			},
-		},
-	}
-	s.SetTargetContent(newContent)
+
+	// Modify the Kong state and expected content and update it again.
+	state := kongState()
+	state.Services[0].Host = kong.String("example.org")
+	expectedContent.Services[0].Host = kong.String("example.org")
+	s.UpdateKongState(state, false)
+
 	// The latest updated content should always be the content in the previous update
 	// because it should not update new content after context cancelled.
 	require.Never(t, func() bool {
@@ -149,6 +123,143 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 		if !ok {
 			return false
 		}
-		return !(assert.ObjectsAreEqual(content, contentWithHash.Content))
-	}, 10*sendConfigPeriod, sendConfigPeriod, "Should not send new updates after context cancelled")
+		return assert.ObjectsAreEqual(expectedContent, contentWithHash.Content)
+	}, testSendConfigAssertionTimeout, testSendConfigAssertionTick, "Should not send new updates after context cancelled")
+}
+
+func TestConfigSynchronizer_ConfigIsSanitizedWhenConfiguredSo(t *testing.T) {
+	log := logr.Discard()
+	testKonnectClient := mustSampleKonnectClient(t)
+	resolver := mocks.NewUpdateStrategyResolver()
+	configStatusNotifier := clients.NewChannelConfigNotifier(log)
+	s := konnect.NewConfigSynchronizer(
+		konnect.ConfigSynchronizerParams{
+			Logger: log,
+			KongConfig: sendconfig.Config{
+				SanitizeKonnectConfigDumps: true,
+			},
+			ConfigUploadTicker:     clock.NewTickerWithDuration(testSendConfigPeriod),
+			KonnectClientFactory:   &mocks.KonnectClientFactory{Client: testKonnectClient},
+			UpdateStrategyResolver: resolver,
+			ConfigChangeDetector:   sendconfig.NewDefaultConfigurationChangeDetector(log),
+			ConfigStatusNotifier:   configStatusNotifier,
+			MetricsRecorder:        &mocks.MetricsRecorder{},
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runSynchronizer(ctx, t, s)
+
+	t.Log("Updating Kong state with sensitive information")
+	kongState := &kongstate.KongState{
+		Certificates: []kongstate.Certificate{
+			{
+				Certificate: kong.Certificate{
+					ID:  kong.String("new_cert"),
+					Key: kong.String(`private-key-string`), // This should be redacted.
+				},
+			},
+		},
+	}
+
+	s.UpdateKongState(kongState, false)
+
+	t.Log("Verifying that the sensitive information is redacted")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		konnectContent, ok := resolver.LastUpdatedContentForURL(testKonnectClient.BaseRootURL())
+		require.True(t, ok, "should have last updated content for the URL")
+
+		require.Len(t, konnectContent.Content.Certificates, 1, "expected 1 certificate")
+		cert := konnectContent.Content.Certificates[0]
+		require.NotNil(t, cert.Key, "expected certificate key")
+		require.Equal(t, "{vault://redacted-value}", *cert.Key, "expected redacted certificate key")
+	}, testSendConfigAssertionTimeout, testSendConfigAssertionTick)
+}
+
+func TestConfigSynchronizer_StatusNotificationIsSent(t *testing.T) {
+	testCases := []struct {
+		name                string
+		returnErrorOnUpdate bool
+		expectedStatus      clients.KonnectConfigUploadStatus
+	}{
+		{
+			name:                "success",
+			returnErrorOnUpdate: false,
+			expectedStatus: clients.KonnectConfigUploadStatus{
+				Failed: false,
+			},
+		},
+		{
+			name:                "failure",
+			returnErrorOnUpdate: true,
+			expectedStatus: clients.KonnectConfigUploadStatus{
+				Failed: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testKonnectClient := mustSampleKonnectClient(t)
+			resolver := mocks.NewUpdateStrategyResolver()
+			if tc.returnErrorOnUpdate {
+				resolver.ReturnErrorOnUpdate(testKonnectClient.BaseRootURL())
+			}
+			configStatusNotifier := &mocks.ConfigStatusNotifier{}
+			s := konnect.NewConfigSynchronizer(
+				konnect.ConfigSynchronizerParams{
+					Logger: logr.Discard(),
+					KongConfig: sendconfig.Config{
+						SanitizeKonnectConfigDumps: true,
+					},
+					ConfigUploadTicker:     clock.NewTickerWithDuration(testSendConfigPeriod),
+					KonnectClientFactory:   &mocks.KonnectClientFactory{Client: testKonnectClient},
+					UpdateStrategyResolver: resolver,
+					ConfigChangeDetector:   &mocks.ConfigurationChangeDetector{ConfigurationChanged: true},
+					ConfigStatusNotifier:   configStatusNotifier,
+					MetricsRecorder:        &mocks.MetricsRecorder{},
+				},
+			)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			runSynchronizer(ctx, t, s)
+
+			kongState := func() *kongstate.KongState {
+				return &kongstate.KongState{
+					Services: []kongstate.Service{
+						{
+							Service: kong.Service{
+								Name: kong.String("service1"),
+								Host: kong.String("example.com"),
+							},
+						},
+					},
+				}
+			}
+			s.UpdateKongState(kongState(), false)
+
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
+				status, ok := configStatusNotifier.FirstKonnectConfigStatus()
+				require.True(t, ok, "should have received Konnect config status")
+				require.Equal(t, tc.expectedStatus, status, "should have received expected Konnect config status")
+			}, testSendConfigAssertionTimeout, testSendConfigAssertionTick)
+		})
+	}
+}
+
+func mustSampleKonnectClient(t *testing.T) *adminapi.KonnectClient {
+	t.Helper()
+	c, err := adminapi.NewKongAPIClient(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString()), &http.Client{})
+	require.NoError(t, err)
+	rgID := uuid.NewString()
+	return adminapi.NewKonnectClient(c, rgID, false)
+}
+
+func runSynchronizer(ctx context.Context, t *testing.T, s *konnect.ConfigSynchronizer) {
+	t.Log("Running Konnect config synchronizer")
+	go func() {
+		err := s.Start(ctx)
+		require.NoError(t, err)
+	}()
 }

--- a/internal/konnect/node_agent.go
+++ b/internal/konnect/node_agent.go
@@ -143,7 +143,7 @@ func (a *NodeAgent) Start(ctx context.Context) error {
 
 	// We're waiting here as that's the manager.Runnable interface requirement to block until the context is done.
 	<-ctx.Done()
-	return nil
+	return ctx.Err()
 }
 
 // NeedLeaderElection implements LeaderElectionRunnable interface to ensure that the node agent is run only when

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
@@ -363,7 +362,7 @@ func TestNodeAgent_StartDoesntReturnUntilContextGetsCancelled(t *testing.T) {
 	agentReturned := make(chan struct{})
 	go func() {
 		err := nodeAgent.Start(ctx)
-		assert.NoError(t, err, "expected no error even when the context is cancelled")
+		require.ErrorIs(t, err, context.Canceled)
 		close(agentReturned)
 	}()
 
@@ -621,7 +620,7 @@ func runAgent(t *testing.T, nodeAgent *konnect.NodeAgent) {
 	agentReturned := make(chan struct{})
 	go func() {
 		err := nodeAgent.Start(ctx)
-		require.NoError(t, err, "expected no error even when the context is cancelled")
+		require.ErrorIs(t, err, context.Canceled)
 		close(agentReturned)
 	}()
 

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
 )
 
@@ -502,32 +503,33 @@ func setupLicenseGetter(
 	return nil, nil
 }
 
-// setupKonnectConfigSynchronizer sets up Konnect config sychronizer and adds it to the manager runnables.
-func setupKonnectConfigSynchronizer(
+// setupKonnectConfigSynchronizerWithMgr sets up Konnect config sychronizer and adds it to the manager runnables.
+func setupKonnectConfigSynchronizerWithMgr(
 	ctx context.Context,
 	mgr manager.Manager,
-	configUploadPeriod time.Duration,
+	cfg *Config,
 	kongConfig sendconfig.Config,
-	clientsProvider clients.AdminAPIClientsProvider,
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configStatusNotifier clients.ConfigStatusNotifier,
 	metricsRecorder metrics.Recorder,
 ) (*konnect.ConfigSynchronizer, error) {
-	logger := ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer")
 	s := konnect.NewConfigSynchronizer(
-		ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer"),
-		kongConfig,
-		configUploadPeriod,
-		clientsProvider.KonnectClient(),
-		updateStrategyResolver,
-		sendconfig.NewDefaultConfigurationChangeDetector(logger),
-		configStatusNotifier,
-		metricsRecorder,
+		konnect.ConfigSynchronizerParams{
+			Logger:                 ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer"),
+			KongConfig:             kongConfig,
+			ConfigUploadTicker:     clock.NewTickerWithDuration(cfg.Konnect.UploadConfigPeriod),
+			KonnectClientFactory:   adminapi.NewKonnectClientFactory(cfg.Konnect, ctrl.LoggerFrom(ctx).WithName("konnect-client-factory")),
+			UpdateStrategyResolver: updateStrategyResolver,
+			ConfigChangeDetector: sendconfig.NewDefaultConfigurationChangeDetector(
+				ctrl.LoggerFrom(ctx).WithName("konnect-config-change-detector"),
+			),
+			ConfigStatusNotifier: configStatusNotifier,
+			MetricsRecorder:      metricsRecorder,
+		},
 	)
 	err := mgr.Add(s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not add Konnect config synchronizer to manager: %w", err)
 	}
-
 	return s, nil
 }

--- a/internal/util/clock/ticker.go
+++ b/internal/util/clock/ticker.go
@@ -17,6 +17,12 @@ func NewTicker() *TimeTicker {
 	}
 }
 
+func NewTickerWithDuration(d time.Duration) *TimeTicker {
+	return &TimeTicker{
+		ticker: time.NewTicker(d),
+	}
+}
+
 type TimeTicker struct {
 	ticker *time.Ticker
 }

--- a/test/kongintegration/dbmode_update_strategy_test.go
+++ b/test/kongintegration/dbmode_update_strategy_test.go
@@ -52,7 +52,6 @@ func TestUpdateStrategyDBMode(t *testing.T) {
 		dump.Config{},
 		semver.MustParse("3.6.0"),
 		10,
-		nil,
 		logger,
 	)
 

--- a/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -105,7 +105,7 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 	updateStrategy := sendconfig.NewUpdateStrategyDBModeKonnect(adminAPIClient.AdminAPIClient(), dump.Config{
 		SkipCACerts:         true,
 		KonnectControlPlane: cpID,
-	}, semver.MustParse("3.5.0"), 10, nil, logr.Discard())
+	}, semver.MustParse("3.5.0"), 10, logr.Discard())
 
 	for _, goldenTestOutputPath := range allGoldenTestsOutputsPaths(t) {
 		t.Run(goldenTestOutputPath, func(t *testing.T) {

--- a/test/mocks/config_status_notifier.go
+++ b/test/mocks/config_status_notifier.go
@@ -1,0 +1,42 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+)
+
+// ConfigStatusNotifier is a mock implementation of clients.ConfigStatusNotifier.
+type ConfigStatusNotifier struct {
+	lastGatewayConfigStatus     clients.GatewayConfigApplyStatus
+	receivedKonnectConfigStatus []clients.KonnectConfigUploadStatus
+	lock                        sync.RWMutex
+}
+
+func (c *ConfigStatusNotifier) NotifyGatewayConfigStatus(_ context.Context, status clients.GatewayConfigApplyStatus) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.lastGatewayConfigStatus = status
+}
+
+func (c *ConfigStatusNotifier) NotifyKonnectConfigStatus(_ context.Context, status clients.KonnectConfigUploadStatus) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.receivedKonnectConfigStatus = append(c.receivedKonnectConfigStatus, status)
+}
+
+func (c *ConfigStatusNotifier) LastGatewayConfigStatus() clients.GatewayConfigApplyStatus {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lastGatewayConfigStatus
+}
+
+func (c *ConfigStatusNotifier) FirstKonnectConfigStatus() (clients.KonnectConfigUploadStatus, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if len(c.receivedKonnectConfigStatus) == 0 {
+		return clients.KonnectConfigUploadStatus{}, false
+	}
+	return c.receivedKonnectConfigStatus[0], true
+}

--- a/test/mocks/konnect_client_factory.go
+++ b/test/mocks/konnect_client_factory.go
@@ -1,0 +1,16 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+)
+
+// KonnectClientFactory is a mock implementation of konnect.ClientFactory.
+type KonnectClientFactory struct {
+	Client *adminapi.KonnectClient
+}
+
+func (f *KonnectClientFactory) NewKonnectClient(context.Context) (*adminapi.KonnectClient, error) {
+	return f.Client, nil
+}

--- a/test/mocks/konnect_kongstate_updater.go
+++ b/test/mocks/konnect_kongstate_updater.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
+)
+
+// KonnectKongStateUpdater is a mock implementation of dataplane.KonnectKongStateUpdater.
+type KonnectKongStateUpdater struct {
+	calls []KonnectKongStateUpdaterCall
+}
+
+type KonnectKongStateUpdaterCall struct {
+	KongState  *kongstate.KongState
+	IsFallback bool
+}
+
+func (k *KonnectKongStateUpdater) UpdateKongState(kongState *kongstate.KongState, isFallback bool) {
+	k.calls = append(k.calls, KonnectKongStateUpdaterCall{
+		KongState:  kongState,
+		IsFallback: isFallback,
+	})
+}
+
+func (k *KonnectKongStateUpdater) Calls() []KonnectKongStateUpdaterCall {
+	return k.calls
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Stop using `KonnectClient` in the clients' provider. Make `konnect.ConfigSynchronizer` create one using a factory on its startup instead. Also:
- moves tests related to Konnect-specific behavior to `konnect.ConfigSynchronizer`.
- moves the call to `deckgen.ToDeckContent` from `KongClient` to `konnect.ConfigSynchronizer` as it may reach out to Konnect APIs while for plugins schemas, and we don't want to spend time on Konnect-related stuff in the critical path

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6340.
