### PR TITLE
[backport release/3.3.x] fix: do not unregister Kong DPs metrics when Konnect integration is enabled (#6881)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -111,9 +111,9 @@ type KongClient struct {
 	// information during data-plane update runtime.
 	diagnostic diagnostics.ConfigDumpDiagnostic
 
-	// prometheusMetrics is the client for shipping metrics information
+	// metricsRecorder is the client for shipping metrics information
 	// updates to the prometheus exporter.
-	prometheusMetrics *metrics.CtrlFuncMetrics
+	metricsRecorder metrics.Recorder
 
 	// kubernetesObjectReportLock is a mutex for thread-safety of
 	// kubernetes object reporting functionality.
@@ -201,12 +201,13 @@ func NewKongClient(
 	kongConfigBuilder KongConfigBuilder,
 	cacheStores *store.CacheStores,
 	fallbackConfigGenerator FallbackConfigGenerator,
+	metricsRecorder metrics.Recorder,
 ) (*KongClient, error) {
 	c := &KongClient{
 		logger:                  logger,
 		requestTimeout:          timeout,
 		diagnostic:              diagnostic,
-		prometheusMetrics:       metrics.NewCtrlFuncMetrics(),
+		metricsRecorder:         metricsRecorder,
 		cache:                   cacheStores,
 		kongConfig:              kongConfig,
 		eventRecorder:           eventRecorder,
@@ -455,9 +456,9 @@ func (c *KongClient) Update(ctx context.Context) error {
 		}
 		hasNewSnapshotToBeProcessed := newSnapshotHash != store.SnapshotHashEmpty
 		if !hasNewSnapshotToBeProcessed {
-			c.prometheusMetrics.RecordProcessedConfigSnapshotCacheHit()
+			c.metricsRecorder.RecordProcessedConfigSnapshotCacheHit()
 		} else {
-			c.prometheusMetrics.RecordProcessedConfigSnapshotCacheMiss()
+			c.metricsRecorder.RecordProcessedConfigSnapshotCacheMiss()
 		}
 		if hasNewSnapshotToBeProcessed {
 			c.logger.V(logging.DebugLevel).Info("New configuration snapshot detected", "hash", newSnapshotHash)
@@ -479,13 +480,13 @@ func (c *KongClient) Update(ctx context.Context) error {
 	translationDuration := time.Since(translationStart)
 
 	if failuresCount := len(parsingResult.TranslationFailures); failuresCount > 0 {
-		c.prometheusMetrics.RecordTranslationFailure(translationDuration)
-		c.prometheusMetrics.RecordTranslationBrokenResources(failuresCount)
+		c.metricsRecorder.RecordTranslationFailure(translationDuration)
+		c.metricsRecorder.RecordTranslationBrokenResources(failuresCount)
 		c.recordResourceFailureEvents(parsingResult.TranslationFailures, KongConfigurationTranslationFailedEventReason)
 		c.logger.V(logging.DebugLevel).Info("Translation failures occurred when building data-plane configuration", "count", failuresCount)
 	} else {
-		c.prometheusMetrics.RecordTranslationSuccess(translationDuration)
-		c.prometheusMetrics.RecordTranslationBrokenResources(0)
+		c.metricsRecorder.RecordTranslationSuccess(translationDuration)
+		c.metricsRecorder.RecordTranslationBrokenResources(0)
 		c.logger.V(logging.DebugLevel).Info("Successfully built data-plane configuration", "duration", translationDuration.String())
 	}
 
@@ -617,12 +618,12 @@ func (c *KongClient) tryRecoveringWithFallbackConfiguration(
 
 	if failuresCount := len(fallbackParsingResult.TranslationFailures); failuresCount > 0 {
 		c.recordResourceFailureEvents(fallbackParsingResult.TranslationFailures, FallbackKongConfigurationTranslationFailedEventReason)
-		c.prometheusMetrics.RecordFallbackTranslationBrokenResources(failuresCount)
-		c.prometheusMetrics.RecordFallbackTranslationFailure(translationDuration)
+		c.metricsRecorder.RecordFallbackTranslationBrokenResources(failuresCount)
+		c.metricsRecorder.RecordFallbackTranslationFailure(translationDuration)
 		c.logger.V(logging.DebugLevel).Info("Translation failures occurred when building fallback data-plane configuration", "count", failuresCount, "duration", translationDuration.String())
 	} else {
-		c.prometheusMetrics.RecordFallbackTranslationBrokenResources(0)
-		c.prometheusMetrics.RecordFallbackTranslationSuccess(translationDuration)
+		c.metricsRecorder.RecordFallbackTranslationBrokenResources(0)
+		c.metricsRecorder.RecordFallbackTranslationSuccess(translationDuration)
 		c.logger.V(logging.DebugLevel).Info("Successfully built fallback configuration from caches", "duration", translationDuration.String())
 	}
 
@@ -647,7 +648,7 @@ func (c *KongClient) generateFallbackCache(
 ) (s store.CacheStores, metadata fallback.GeneratedCacheMetadata, err error) {
 	start := time.Now()
 	defer func() {
-		c.prometheusMetrics.RecordFallbackCacheGenerationDuration(time.Since(start), err)
+		c.metricsRecorder.RecordFallbackCacheGenerationDuration(time.Since(start), err)
 	}()
 	if c.kongConfig.UseLastValidConfigForFallback {
 		return c.fallbackConfigGenerator.GenerateBackfillingBrokenObjects(
@@ -798,7 +799,7 @@ func (c *KongClient) sendToClient(
 		config,
 		targetContent,
 		customEntities,
-		c.prometheusMetrics,
+		c.metricsRecorder,
 		c.updateStrategyResolver,
 		c.configChangeDetector,
 		isFallback,

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -310,6 +310,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 		p,
 		&cacheStores,
 		fallbackConfigGenerator,
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -1048,6 +1048,7 @@ func setupTestKongClient(
 		configBuilder,
 		&cacheStores,
 		newMockFallbackConfigGenerator(),
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 	return kongClient
@@ -1078,6 +1079,7 @@ func attachKonnectConfigSynchronizer(
 		updateStrategyResolver,
 		configChangeDetector,
 		configStatusNotifier,
+		mocks.MetricsRecorder{},
 	)
 	kc.SetKonnectConfigSynchronizer(konnectConfigSynchronizer)
 	err := konnectConfigSynchronizer.Start(ctx)
@@ -1355,6 +1357,7 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 				configBuilder,
 				&originalCache,
 				fallbackConfigGenerator,
+				mocks.MetricsRecorder{},
 			)
 			require.NoError(t, err)
 
@@ -1490,6 +1493,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		configBuilder,
 		&originalCache,
 		fallbackConfigGenerator,
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 
@@ -1636,6 +1640,7 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 		configBuilder,
 		&originalCache,
 		fallbackConfigGenerator,
+		mocks.MetricsRecorder{},
 	)
 	require.NoError(t, err)
 
@@ -1745,6 +1750,7 @@ func TestKongClient_LastValidCacheSnapshot(t *testing.T) {
 				configBuilder,
 				&originalCache,
 				fallbackConfigGenerator,
+				mocks.MetricsRecorder{},
 			)
 			require.NoError(t, err)
 
@@ -1967,6 +1973,7 @@ func TestKongClient_RecoveringFromGatewaySyncError(t *testing.T) {
 				configBuilder,
 				&originalCache,
 				fallbackConfigGenerator,
+				mocks.MetricsRecorder{},
 			)
 			require.NoError(t, err)
 

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -45,7 +45,7 @@ func PerformUpdate(
 	config Config,
 	targetContent *file.Content,
 	customEntities CustomEntitiesByType,
-	promMetrics *metrics.CtrlFuncMetrics,
+	promMetrics metrics.Recorder,
 	updateStrategyResolver UpdateStrategyResolver,
 	configChangeDetector ConfigurationChangeDetector,
 	isFallback bool,

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -31,7 +31,7 @@ type ConfigSynchronizer struct {
 	syncTicker             *time.Ticker
 	kongConfig             sendconfig.Config
 	clientsProvider        clients.AdminAPIClientsProvider
-	prometheusMetrics      *metrics.CtrlFuncMetrics
+	metricsRecorder        metrics.Recorder
 	updateStrategyResolver sendconfig.UpdateStrategyResolver
 	configChangeDetector   sendconfig.ConfigurationChangeDetector
 	configStatusNotifier   clients.ConfigStatusNotifier
@@ -49,13 +49,14 @@ func NewConfigSynchronizer(
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configChangeDetector sendconfig.ConfigurationChangeDetector,
 	configStatusNotifier clients.ConfigStatusNotifier,
+	metricsRecorder metrics.Recorder,
 ) *ConfigSynchronizer {
 	return &ConfigSynchronizer{
 		logger:                 logger,
 		syncTicker:             time.NewTicker(configUploadPeriod),
 		kongConfig:             kongConfig,
 		clientsProvider:        clientsProvider,
-		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
+		metricsRecorder:        metricsRecorder,
 		updateStrategyResolver: updateStrategyResolver,
 		configChangeDetector:   configChangeDetector,
 		configStatusNotifier:   configStatusNotifier,
@@ -135,7 +136,7 @@ func (s *ConfigSynchronizer) uploadConfig(ctx context.Context, client *adminapi.
 		targetContent,
 		// Konnect client does not upload custom entities.
 		sendconfig.CustomEntitiesByType{},
-		s.prometheusMetrics,
+		s.metricsRecorder,
 		s.updateStrategyResolver,
 		s.configChangeDetector,
 		isFallback,

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -21,6 +21,7 @@ import (
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
 func TestConfigSynchronizer_GetTargetContentCopy(t *testing.T) {
@@ -184,7 +185,7 @@ func TestConfigSynchronizer_RunKonnectUpdateServer(t *testing.T) {
 		clientsProvider: &mockGatewayClientsProvider{
 			konnectClient: testKonnectClient,
 		},
-		prometheusMetrics:      metrics.NewCtrlFuncMetrics(),
+		metricsRecorder:        mocks.MetricsRecorder{},
 		updateStrategyResolver: resolver,
 		configChangeDetector:   mockConfigurationChangeDetector{},
 		configStatusNotifier:   clients.NoOpConfigStatusNotifier{},

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/kubernetes/object/status"
 )
@@ -495,6 +496,7 @@ func setupKonnectConfigSynchronizer(
 	clientsProvider clients.AdminAPIClientsProvider,
 	updateStrategyResolver sendconfig.UpdateStrategyResolver,
 	configStatusNotifier clients.ConfigStatusNotifier,
+	metricsRecorder metrics.Recorder,
 ) (*konnect.ConfigSynchronizer, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("konnect-config-synchronizer")
 	s := konnect.NewConfigSynchronizer(
@@ -505,6 +507,7 @@ func setupKonnectConfigSynchronizer(
 		updateStrategyResolver,
 		sendconfig.NewDefaultConfigurationChangeDetector(logger),
 		configStatusNotifier,
+		metricsRecorder,
 	)
 	err := mgr.Add(s)
 	if err != nil {

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -10,22 +10,57 @@ import (
 
 	deckutils "github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/kong/go-kong/kong"
+	prom "github.com/prometheus/client_model/go"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckerrors"
 )
 
-func TestNewCtrlFuncMetricsDoesNotPanicWhenCalledTwice(t *testing.T) {
+func TestNewGlobalCtrlRuntimeMetricsRecorder_DoesNotPanicWhenCalledTwice(t *testing.T) {
 	require.NotPanics(t, func() {
-		_ = NewCtrlFuncMetrics()
+		_ = NewGlobalCtrlRuntimeMetricsRecorder()
 	})
 	require.NotPanics(t, func() {
-		_ = NewCtrlFuncMetrics()
+		_ = NewGlobalCtrlRuntimeMetricsRecorder()
 	})
 }
 
+func TestGlobalCtrlRuntimeMetricsRecorder_AnyInstanceWritesToTheSameRegistry(t *testing.T) {
+	m1 := NewGlobalCtrlRuntimeMetricsRecorder()
+	m2 := NewGlobalCtrlRuntimeMetricsRecorder()
+
+	const (
+		firstDPHost  = "https://1.host"
+		secondDPHost = "https://2.host"
+	)
+	m1.RecordPushSuccess(ProtocolDBLess, time.Millisecond, firstDPHost)
+	m2.RecordPushSuccess(ProtocolDBLess, time.Millisecond, secondDPHost)
+
+	// Verify that both instances write to the same registry (the controller-runtime's global registry).
+	ctrlRuntimeGlobalRegistry := metrics.Registry
+	metricFamilies, err := ctrlRuntimeGlobalRegistry.Gather()
+	require.NoError(t, err)
+	metricFamily, ok := lo.Find(metricFamilies, func(family *prom.MetricFamily) bool {
+		return family.Name != nil && *family.Name == MetricNameConfigPushCount
+	})
+	require.True(t, ok, "expected to find %q metric", MetricNameConfigPushCount)
+
+	assertMetricsContainHost := func(host string) {
+		assert.True(t, lo.ContainsBy(metricFamily.Metric, func(metric *prom.Metric) bool {
+			return lo.ContainsBy(metric.Label, func(label *prom.LabelPair) bool {
+				return label.GetName() == DataplaneKey && label.GetValue() == host
+			})
+		}), "expected to find %q metric with dataplane label %q", MetricNameConfigPushCount, host)
+	}
+	assertMetricsContainHost(firstDPHost)
+	assertMetricsContainHost(secondDPHost)
+}
+
 func TestRecordPush(t *testing.T) {
-	m := NewCtrlFuncMetrics()
+	m := NewGlobalCtrlRuntimeMetricsRecorder()
 	t.Run("recording push success works", func(t *testing.T) {
 		require.NotPanics(t, func() {
 			m.RecordPushSuccess(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080")
@@ -36,8 +71,8 @@ func TestRecordPush(t *testing.T) {
 			m.RecordPushFailure(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080", 5, fmt.Errorf("custom error"))
 		})
 	})
-	// Verify that multiple call of NewCtrlFuncMetrics keeps all created metrics work.
-	m2 := NewCtrlFuncMetrics()
+	// Verify that multiple call of NewGlobalCtrlRuntimeMetricsRecorder keeps all created metrics work.
+	m2 := NewGlobalCtrlRuntimeMetricsRecorder()
 	t.Run("recording push success works for old metrics", func(t *testing.T) {
 		require.NotPanics(t, func() {
 			m.RecordPushSuccess(ProtocolDBLess, time.Millisecond, "https://10.0.0.1:8080")
@@ -51,7 +86,7 @@ func TestRecordPush(t *testing.T) {
 }
 
 func TestRecordTranslation(t *testing.T) {
-	m := NewCtrlFuncMetrics()
+	m := NewGlobalCtrlRuntimeMetricsRecorder()
 	t.Run("recording translation success works", func(t *testing.T) {
 		require.NotPanics(t, func() {
 			m.RecordTranslationSuccess(10 * time.Millisecond)

--- a/test/mocks/metrics_recorder.go
+++ b/test/mocks/metrics_recorder.go
@@ -1,0 +1,49 @@
+package mocks
+
+import (
+	"time"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+)
+
+// MetricsRecorder is a mock implementation of metrics.Recorder.
+type MetricsRecorder struct{}
+
+func (m MetricsRecorder) RecordPushFailure(metrics.Protocol, time.Duration, string, int, error) {
+}
+
+func (m MetricsRecorder) RecordPushSuccess(metrics.Protocol, time.Duration, string) {
+}
+
+func (m MetricsRecorder) RecordFallbackPushSuccess(metrics.Protocol, time.Duration, string) {
+}
+
+func (m MetricsRecorder) RecordFallbackPushFailure(metrics.Protocol, time.Duration, string, int, error) {
+}
+
+func (m MetricsRecorder) RecordProcessedConfigSnapshotCacheHit() {
+}
+
+func (m MetricsRecorder) RecordProcessedConfigSnapshotCacheMiss() {
+}
+
+func (m MetricsRecorder) RecordTranslationFailure(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordTranslationBrokenResources(int) {
+}
+
+func (m MetricsRecorder) RecordTranslationSuccess(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordFallbackTranslationBrokenResources(int) {
+}
+
+func (m MetricsRecorder) RecordFallbackTranslationFailure(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordFallbackTranslationSuccess(time.Duration) {
+}
+
+func (m MetricsRecorder) RecordFallbackCacheGenerationDuration(time.Duration, error) {
+}


### PR DESCRIPTION
(cherry picked from commit 2c72b4079d8212741c15b8038ab93d51ed981eb0)
