### PR TITLE
[Backport release/3.2.x] chore(ci): use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled

--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -1,7 +1,7 @@
 name: PRs labels check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
 
 jobs:

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -17,13 +17,14 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
 
     steps:
-    - uses: actions/checkout@v4
-    # Do not run e2e tests on GKE-based clusters for specific PR, because currently
-    # there is no way to use an image built from PR's code for those tests.
-    # https://github.com/Kong/kubernetes-testing-framework/issues/587
-    - run: |
-        gh workflow run ${WORKFLOW} --ref ${BRANCH} \
-          -f run-gke=false \
-          -f run-istio=true \
-          -f all-supported-k8s-versions=true \
-          -f pr-number=${PR_NUMBER}
+      - name: checkout repository
+        uses: actions/checkout@v4
+      # Do not run e2e tests on GKE-based clusters for specific PR, because currently
+      # there is no way to use an image built from PR's code for those tests.
+      # https://github.com/Kong/kubernetes-testing-framework/issues/587
+      - run: |
+          gh workflow run ${WORKFLOW} --ref ${BRANCH} \
+            -f run-gke=false \
+            -f run-istio=true \
+            -f all-supported-k8s-versions=true \
+            -f pr-number=${PR_NUMBER}


### PR DESCRIPTION
backport https://github.com/Kong/kubernetes-ingress-controller/commit/6533c42ef7582e7b169b342dcb1f1a7a77f08087 from https://github.com/Kong/kubernetes-ingress-controller/pull/6743