### PR TITLE
[Backport release/2.12.x] chore(ci): use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -1,7 +1,7 @@
 name: PRs labels check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
 
 jobs:


### PR DESCRIPTION
backport https://github.com/Kong/kubernetes-ingress-controller/commit/6533c42ef7582e7b169b342dcb1f1a7a77f08087 from https://github.com/Kong/kubernetes-ingress-controller/pull/6743