### PR TITLE
ci(github): use pull_request for backport

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled


### PR DESCRIPTION
**What this PR does / why we need it**:

This is what is done in main and should have been fixed
as a part of the backport of https://github.com/Kong/kubernetes-ingress-controller/pull/6743