### PR TITLE
chore(ci): run go mod tidy during regeneration

### DIFF
--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -29,6 +29,9 @@ jobs:
       - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install: false
+      
+      - name: go mod tidy
+        run: go mod tidy
 
       - name: regenerate
         run: make generate manifests


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR
- https://github.com/Kong/kubernetes-ingress-controller/pull/6951

does not pass checks, because there is inconsistency in `go.sum`

<img width="871" alt="image" src="https://github.com/user-attachments/assets/589247e0-bbad-40af-9614-7f0573a34911" />

[src](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/12739717282/job/35503837372?pr=6951#step:5:221)

Enhance workflow that regenerates manifests and code with `go mod tidy` to avoid such situation in the future 

