### PR TITLE
chore(ci): add go.mod and go.sum to commit for regenerate

### DIFF
--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install: false
-      
+
       - name: go mod tidy
         run: go mod tidy
 
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
-          git add ./test/e2e/manifests ./config/crd
+          git add go.mod go.sum ./test/e2e/manifests ./config/crd
           git status
           git diff-index --quiet HEAD || \
           git commit -m "chore: regenerate" && \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Follow up for 

- https://github.com/Kong/kubernetes-ingress-controller/pull/6954

to get such PRs like https://github.com/Kong/kubernetes-ingress-controller/pull/6951 automatically mergable.



Files to commit are added explicitly, so `go.mod` and `go.sum` was omitted. This PR fixes it

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
