### PR TITLE
feat: expose public manager api

### DIFF
--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // Client is a wrapper around raw *kong.Client. It's advised to pass this wrapper across the codebase, and
@@ -208,11 +209,11 @@ func (c *Client) PodReference() (k8stypes.NamespacedName, bool) {
 type ClientFactory struct {
 	logger     logr.Logger
 	workspace  string
-	opts       ClientOpts
+	opts       config.AdminAPIClientConfig
 	adminToken string
 }
 
-func NewClientFactoryForWorkspace(logger logr.Logger, workspace string, clientOpts ClientOpts, adminToken string) ClientFactory {
+func NewClientFactoryForWorkspace(logger logr.Logger, workspace string, clientOpts config.AdminAPIClientConfig, adminToken string) ClientFactory {
 	return ClientFactory{
 		logger:     logger,
 		workspace:  workspace,

--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -10,11 +10,12 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
 func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
-	factory := adminapi.NewClientFactoryForWorkspace(logr.Discard(), "workspace", adminapi.ClientOpts{}, "")
+	factory := adminapi.NewClientFactoryForWorkspace(logr.Discard(), "workspace", config.AdminAPIClientConfig{}, "")
 
 	adminAPIHandler := mocks.NewAdminAPIHandler(t)
 	adminAPIServer := httptest.NewServer(adminAPIHandler)

--- a/internal/adminapi/kong.go
+++ b/internal/adminapi/kong.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/tls"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // KongClientNotReadyError is returned when the Kong client is not ready to be used yet.
@@ -43,7 +44,7 @@ func (e KongGatewayUnsupportedVersionError) Error() string {
 
 // NewKongAPIClient returns a Kong API client for a given root API URL.
 // It ensures that proper User-Agent is set. Do not use kong.NewClient directly.
-func NewKongAPIClient(adminURL string, kongAdminAPIConfig ClientOpts, kongAdminToken string) (*kong.Client, error) {
+func NewKongAPIClient(adminURL string, kongAdminAPIConfig config.AdminAPIClientConfig, kongAdminToken string) (*kong.Client, error) {
 	httpClient, err := makeHTTPClient(kongAdminAPIConfig, kongAdminToken)
 	if err != nil {
 		return nil, err
@@ -62,7 +63,7 @@ func NewKongAPIClient(adminURL string, kongAdminAPIConfig ClientOpts, kongAdminT
 // or KongGatewayUnsupportedVersionError if it can't check Kong Gateway's version or it is not >= 3.4.1.
 // If the workspace does not already exist, NewKongClientForWorkspace will create it.
 func NewKongClientForWorkspace(
-	ctx context.Context, adminURL string, wsName string, kongAdminAPIConfig ClientOpts, kongAdminToken string,
+	ctx context.Context, adminURL string, wsName string, kongAdminAPIConfig config.AdminAPIClientConfig, kongAdminToken string,
 ) (*Client, error) {
 	// Create the base client, and if no workspace was provided then return that.
 	client, err := NewKongAPIClient(adminURL, kongAdminAPIConfig, kongAdminToken)
@@ -121,28 +122,12 @@ func NewKongClientForWorkspace(
 	return cl, nil
 }
 
-// ClientOpts defines parameters that configure a client for Kong Admin API.
-type ClientOpts struct {
-	// Disable verification of TLS certificate of Kong's Admin endpoint.
-	TLSSkipVerify bool
-	// SNI name to use to verify the certificate presented by Kong in TLS.
-	TLSServerName string
-	// Path to PEM-encoded CA certificate file to verify Kong's Admin SSL certificate.
-	CACertPath string
-	// PEM-encoded CA certificate to verify Kong's Admin SSL certificate.
-	CACert string
-	// Array of headers added to every Admin API call.
-	Headers []string
-	// TLSClient is TLS client config.
-	TLSClient TLSClientConfig
-}
-
 const (
 	HeaderNameAdminToken = "Kong-Admin-Token"
 )
 
 // makeHTTPClient returns an HTTP client with the specified mTLS/headers configuration.
-func makeHTTPClient(opts ClientOpts, kongAdminToken string) (*http.Client, error) {
+func makeHTTPClient(opts config.AdminAPIClientConfig, kongAdminToken string) (*http.Client, error) {
 	var tlsConfig tls.Config
 
 	if opts.TLSSkipVerify {

--- a/internal/adminapi/kong_test.go
+++ b/internal/adminapi/kong_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
@@ -25,12 +26,12 @@ func TestAdminAPIClientWithTLSOpts(t *testing.T) {
 	cert, key := certificate.MustGenerateCertPEMFormat(certificate.WithDNSNames(hostname))
 	caCert := cert
 
-	opts := adminapi.ClientOpts{
+	opts := config.AdminAPIClientConfig{
 		TLSServerName: hostname,
 		CACertPath:    "",
 		CACert:        string(caCert),
 		Headers:       nil,
-		TLSClient: adminapi.TLSClientConfig{
+		TLSClient: config.TLSClientConfig{
 			Cert: string(cert),
 			Key:  string(key),
 		},
@@ -71,12 +72,12 @@ func TestAdminAPIClientWithTLSOptsAndFilePaths(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, key, writtenBytes)
 
-	opts := adminapi.ClientOpts{
+	opts := config.AdminAPIClientConfig{
 		TLSServerName: hostname,
 		CACertPath:    caFile.Name(),
 		CACert:        "",
 		Headers:       nil,
-		TLSClient: adminapi.TLSClientConfig{
+		TLSClient: config.TLSClientConfig{
 			CertFile: certFile.Name(),
 			KeyFile:  certPrivateKeyFile.Name(),
 		},
@@ -206,7 +207,7 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 				context.Background(),
 				adminAPIServer.URL,
 				tc.workspace,
-				adminapi.ClientOpts{},
+				config.AdminAPIClientConfig{},
 				"",
 			)
 
@@ -232,7 +233,7 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 // whether the passed client can connect to it successfully.
 func validate(
 	t *testing.T,
-	opts adminapi.ClientOpts,
+	opts config.AdminAPIClientConfig,
 	caPEM []byte,
 	certPEM []byte,
 	certPrivateKeyPEM []byte,

--- a/internal/adminapi/konnect.go
+++ b/internal/adminapi/konnect.go
@@ -12,29 +12,13 @@ import (
 	"github.com/kong/go-kong/kong"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/tracing"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
-type KonnectConfig struct {
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/3922
-	// ConfigSynchronizationEnabled is the only toggle we had prior to the addition of the license agent.
-	// We likely want to combine these into a single Konnect toggle or piggyback off other Konnect functionality.
-	ConfigSynchronizationEnabled bool
-	ControlPlaneID               string
-	Address                      string
-	UploadConfigPeriod           time.Duration
-	RefreshNodePeriod            time.Duration
-	TLSClient                    TLSClientConfig
-
-	LicenseSynchronizationEnabled bool
-	InitialLicensePollingPeriod   time.Duration
-	LicensePollingPeriod          time.Duration
-	ConsumersSyncDisabled         bool
-}
-
-func NewKongClientForKonnectControlPlane(c KonnectConfig) (*KonnectClient, error) {
+func NewKongClientForKonnectControlPlane(c config.KonnectConfig) (*KonnectClient, error) {
 	client, err := NewKongAPIClient(
 		fmt.Sprintf("%s/%s/%s", c.Address, "kic/api/control-planes", c.ControlPlaneID),
-		ClientOpts{
+		config.AdminAPIClientConfig{
 			TLSClient: c.TLSClient,
 		},
 		"",
@@ -97,12 +81,12 @@ func KonnectHTTPDoer() kong.Doer {
 
 // KonnectClientFactory is a factory to create KonnectClient instances.
 type KonnectClientFactory struct {
-	konnectConfig KonnectConfig
+	konnectConfig config.KonnectConfig
 	logger        logr.Logger
 }
 
 // NewKonnectClientFactory creates a new KonnectClientFactory instance.
-func NewKonnectClientFactory(konnectConfig KonnectConfig, logger logr.Logger) *KonnectClientFactory {
+func NewKonnectClientFactory(konnectConfig config.KonnectConfig, logger logr.Logger) *KonnectClientFactory {
 	return &KonnectClientFactory{
 		konnectConfig: konnectConfig,
 		logger:        logger,

--- a/internal/adminapi/konnect_test.go
+++ b/internal/adminapi/konnect_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 func TestNewKongClientForKonnectControlPlane(t *testing.T) {
@@ -18,11 +19,11 @@ func TestNewKongClientForKonnectControlPlane(t *testing.T) {
 	ctx := context.Background()
 	const controlPlaneID = "adf78c28-5763-4394-a9a4-a9436a1bea7d"
 
-	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectControlPlane(config.KonnectConfig{
 		ConfigSynchronizationEnabled: true,
 		ControlPlaneID:               controlPlaneID,
 		Address:                      "https://us.kic.api.konghq.tech",
-		TLSClient: adminapi.TLSClientConfig{
+		TLSClient: config.TLSClientConfig{
 			Cert: os.Getenv("KONG_TEST_KONNECT_TLS_CLIENT_CERT"),
 			Key:  os.Getenv("KONG_TEST_KONNECT_TLS_CLIENT_KEY"),
 		},

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 var (
@@ -23,19 +25,9 @@ const (
 	DefaultAdmissionWebhookKeyPath  = "/admission-webhook/tls.key"
 )
 
-type ServerConfig struct {
-	ListenAddr string
-
-	CertPath string
-	Cert     string
-
-	KeyPath string
-	Key     string
-}
-
 func MakeTLSServer(
 	ctx context.Context,
-	config *ServerConfig,
+	config *config.AdmissionServerConfig,
 	handler http.Handler,
 	logger logr.Logger,
 ) (*http.Server, error) {
@@ -52,7 +44,7 @@ func MakeTLSServer(
 	}, nil
 }
 
-func serverConfigToTLSConfig(ctx context.Context, sc *ServerConfig, logger logr.Logger) (*tls.Config, error) {
+func serverConfigToTLSConfig(ctx context.Context, sc *config.AdmissionServerConfig, logger logr.Logger) (*tls.Config, error) {
 	var watcher *certwatcher.CertWatcher
 	var cert, key []byte
 	switch {

--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -13,14 +13,7 @@ import (
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
-)
-
-const (
-	// DefaultReadinessReconciliationInterval is the interval at which the manager will run readiness reconciliation loop.
-	// It's the same as the default interval of a Kubernetes container's readiness probe.
-	DefaultReadinessReconciliationInterval = 10 * time.Second
-	// MinReadinessReconciliationInterval is the minimum interval of readiness reconciliation loop.
-	MinReadinessReconciliationInterval = 3 * time.Second
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // ClientFactory is responsible for creating Admin API clients.
@@ -122,7 +115,7 @@ func NewAdminAPIClientsManager(
 	c := &AdminAPIClientsManager{
 		readyGatewayClients:             readyClients,
 		pendingGatewayClients:           make(map[string]adminapi.DiscoveredAdminAPI),
-		readinessReconciliationInterval: DefaultReadinessReconciliationInterval,
+		readinessReconciliationInterval: config.DefaultDataPlanesReadinessReconciliationInterval,
 		readinessChecker:                readinessChecker,
 		readinessReconciliationTicker:   clock.NewTicker(),
 		discoveredAdminAPIsNotifyChan:   make(chan []adminapi.DiscoveredAdminAPI),

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -511,7 +512,7 @@ func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
 	}
 
 	// Trigger the first readiness check.
-	readinessTicker.Add(clients.DefaultReadinessReconciliationInterval)
+	readinessTicker.Add(config.DefaultDataPlanesReadinessReconciliationInterval)
 	readinessCheckCallEventuallyMatches(readinessCheckCall{
 		AlreadyCreatedURLs: []string{testURL1},
 		PendingURLs:        []string{},
@@ -528,7 +529,7 @@ func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
 
 	// Trigger a next readiness check which will make testURL2 ready.
 	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL2)})
-	readinessTicker.Add(clients.DefaultReadinessReconciliationInterval)
+	readinessTicker.Add(config.DefaultDataPlanesReadinessReconciliationInterval)
 	readinessCheckCallEventuallyMatches(readinessCheckCall{
 		AlreadyCreatedURLs: []string{testURL1},
 		PendingURLs:        []string{testURL2},

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -13,12 +13,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 )
 
-const (
-	// DefaultReadinessCheckTimeout is the default timeout of readiness check.
-	// When a readiness check request did not get response within the timeout, the gateway instance will turn into `Pending` status.
-	DefaultReadinessCheckTimeout = 5 * time.Second
-)
-
 // ReadinessCheckResult represents the result of a readiness check.
 type ReadinessCheckResult struct {
 	// ClientsTurnedReady are the clients that were pending and are now ready to be used.

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 type mockClientFactory struct {
@@ -254,7 +255,7 @@ func TestDefaultReadinessChecker(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			factory := newMockClientFactory(t, tc.pendingClientsReadiness)
-			checker := clients.NewDefaultReadinessChecker(factory, clients.DefaultReadinessCheckTimeout, logr.Discard())
+			checker := clients.NewDefaultReadinessChecker(factory, config.DefaultDataPlanesReadinessCheckTimeout, logr.Discard())
 			result := checker.CheckReadiness(context.Background(), tc.alreadyCreatedClients, tc.pendingClients)
 
 			turnedPending := lo.Map(result.ClientsTurnedPending, func(c adminapi.DiscoveredAdminAPI, _ int) string { return c.Address })

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os/signal"
 
-	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
@@ -26,15 +25,6 @@ func Run(ctx context.Context, c managercfg.Config, output io.Writer) error {
 		return fmt.Errorf("failed to setup signal handler: %w", err)
 	}
 	defer signal.Ignore(shutdownSignals...)
-
-	return RunWithLogger(ctx, c, logger)
-}
-
-// RunWithLogger starts the controller manager with a provided logger.
-func RunWithLogger(ctx context.Context, c managercfg.Config, logger logr.Logger) error {
-	if err := c.Validate(); err != nil {
-		return fmt.Errorf("config invalid: %w", err)
-	}
 
 	return manager.Run(ctx, c, logger)
 }

--- a/internal/dataplane/configfetcher/config_fetcher_test.go
+++ b/internal/dataplane/configfetcher/config_fetcher_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -29,7 +30,7 @@ func TestTryFetchingValidConfigFromGateways(t *testing.T) {
 		// the status of the Kong Gateway but just returns the client.
 		client, err := adminapi.NewKongAPIClient(
 			adminAPIServer.URL,
-			adminapi.ClientOpts{},
+			config.AdminAPIClientConfig{},
 			"",
 		)
 		require.NoError(t, err)

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -42,7 +42,7 @@ var (
 
 	// defaultFeatureFlags is the default set of Translator feature flags to use in tests. Can be overridden in a test case.
 	defaultFeatureFlags = func() translator.FeatureFlags {
-		defaults := featuregates.GetFeatureGatesDefaults()
+		defaults := featuregates.FeatureGates(config.GetFeatureGatesDefaults())
 		return translator.FeatureFlags{
 			// We do not verify configuration reports in golden tests.
 			ReportConfiguredKubernetesObjects: false,

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -47,9 +48,9 @@ var (
 			ReportConfiguredKubernetesObjects: false,
 
 			// Feature flags that are directly propagated from the feature gates get their defaults.
-			FillIDs:           defaults.Enabled(featuregates.FillIDsFeature),
-			KongServiceFacade: defaults.Enabled(featuregates.KongServiceFacade),
-			KongCustomEntity:  defaults.Enabled(featuregates.KongCustomEntity),
+			FillIDs:           defaults.Enabled(config.FillIDsFeature),
+			KongServiceFacade: defaults.Enabled(config.KongServiceFacadeFeature),
+			KongCustomEntity:  defaults.Enabled(config.KongCustomEntityFeature),
 		}
 	}
 )

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // -----------------------------------------------------------------------------
@@ -192,7 +192,7 @@ func (i *ingressTranslationIndex) getIngressPathBackend(namespace string, httpIn
 			return ingressTranslationMetaBackend{}, fmt.Errorf("unknown resource type %s", gk)
 		}
 		if !i.featureFlags.KongServiceFacade {
-			return ingressTranslationMetaBackend{}, fmt.Errorf("KongServiceFacade is not enabled, please set the %q feature gate to 'true' to enable it", featuregates.KongServiceFacade)
+			return ingressTranslationMetaBackend{}, fmt.Errorf("KongServiceFacade is not enabled, please set the %q feature gate to 'true' to enable it", config.KongServiceFacadeFeature)
 		}
 
 		serviceFacade, err := i.storer.GetKongServiceFacade(namespace, resource.Name)

--- a/internal/dataplane/translator/translate_ingress.go
+++ b/internal/dataplane/translator/translate_ingress.go
@@ -14,9 +14,9 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/atc"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/subtranslator"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 func (t *Translator) ingressRulesFromIngressV1() ingressRules {
@@ -138,7 +138,7 @@ func translateIngressDefaultBackendResource(
 	}
 	if !features.KongServiceFacade {
 		failuresCollector.PushResourceFailure(
-			fmt.Sprintf("default backend: KongServiceFacade is not enabled, please set the %q feature gate to 'true' to enable it", featuregates.KongServiceFacade),
+			fmt.Sprintf("default backend: KongServiceFacade is not enabled, please set the %q feature gate to 'true' to enable it", config.KongServiceFacadeFeature),
 			&ingress,
 		)
 		return kongstate.Service{}, false

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // -----------------------------------------------------------------------------
@@ -74,11 +75,11 @@ func NewFeatureFlags(
 		ReportConfiguredKubernetesObjects:       updateStatusFlag,
 		ExpressionRoutes:                        dpconf.ShouldEnableExpressionRoutes(routerFlavor),
 		EnterpriseEdition:                       enterpriseEdition,
-		FillIDs:                                 featureGates.Enabled(featuregates.FillIDsFeature),
-		RewriteURIs:                             featureGates.Enabled(featuregates.RewriteURIsFeature),
-		KongServiceFacade:                       featureGates.Enabled(featuregates.KongServiceFacade),
-		KongCustomEntity:                        featureGates.Enabled(featuregates.KongCustomEntity),
-		CombinedServicesFromDifferentHTTPRoutes: featureGates.Enabled(featuregates.CombinedServicesFromDifferentHTTPRoutes),
+		FillIDs:                                 featureGates.Enabled(config.FillIDsFeature),
+		RewriteURIs:                             featureGates.Enabled(config.RewriteURIsFeature),
+		KongServiceFacade:                       featureGates.Enabled(config.KongServiceFacadeFeature),
+		KongCustomEntity:                        featureGates.Enabled(config.KongCustomEntityFeature),
+		CombinedServicesFromDifferentHTTPRoutes: featureGates.Enabled(config.CombinedServicesFromDifferentHTTPRoutesFeature),
 		SupportRedirectPlugin:                   supportRedirectPlugin,
 	}
 }

--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -31,11 +31,11 @@ import (
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
 )
 
@@ -4776,7 +4776,7 @@ func TestNewFeatureFlags(t *testing.T) {
 		{
 			name: "ServiceFacade enabled and enterprise edition",
 			featureGates: map[string]bool{
-				featuregates.KongServiceFacade: true,
+				config.KongServiceFacadeFeature: true,
 			},
 			enterpriseEdition: true,
 			expectedFeatureFlags: FeatureFlags{

--- a/internal/konnect/config_synchronizer.go
+++ b/internal/konnect/config_synchronizer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/kong/go-database-reconciler/pkg/file"
@@ -22,13 +21,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
-)
-
-const (
-	// MinConfigUploadPeriod is the minimum period between operations to upload Kong configuration to Konnect.
-	MinConfigUploadPeriod = 10 * time.Second
-	// DefaultConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
-	DefaultConfigUploadPeriod = 30 * time.Second
 )
 
 type ClientFactory interface {

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
 
@@ -249,7 +250,7 @@ func TestConfigSynchronizer_StatusNotificationIsSent(t *testing.T) {
 
 func mustSampleKonnectClient(t *testing.T) *adminapi.KonnectClient {
 	t.Helper()
-	c, err := adminapi.NewKongAPIClient(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString()), adminapi.ClientOpts{}, "")
+	c, err := adminapi.NewKongAPIClient(fmt.Sprintf("https://%s.konghq.tech", uuid.NewString()), config.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 	rgID := uuid.NewString()
 	return adminapi.NewKonnectClient(c, rgID, false)

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/samber/mo"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/tracing"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/useragent"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/tls"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // Client interacts with the Konnect license API.
@@ -31,7 +31,7 @@ type Client struct {
 var KICLicenseAPIPathPattern = "%s/kic/api/control-planes/%s/v1/licenses"
 
 // NewClient creates a License API Konnect client.
-func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {
+func NewClient(cfg config.KonnectConfig) (*Client, error) {
 	tlsConfig := tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}

--- a/internal/konnect/license/client_test.go
+++ b/internal/konnect/license/client_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 type mockKonnectLicenseServer struct {
@@ -158,7 +158,7 @@ func TestLicenseClient(t *testing.T) {
 			ts := httptest.NewServer(server)
 			defer ts.Close()
 
-			c, err := license.NewClient(adminapi.KonnectConfig{Address: ts.URL})
+			c, err := license.NewClient(config.KonnectConfig{Address: ts.URL})
 			require.NoError(t, err)
 			tc.assertions(t, c)
 		})

--- a/internal/konnect/nodes/client.go
+++ b/internal/konnect/nodes/client.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/tracing"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/useragent"
 	tlsutil "github.com/kong/kubernetes-ingress-controller/v3/internal/util/tls"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // Client is used for sending requests to Konnect Node API.
@@ -30,7 +30,7 @@ type Client struct {
 var KicNodeAPIPathPattern = "%s/kic/api/control-planes/%s/v1/kic-nodes"
 
 // NewClient creates a Node API Konnect client.
-func NewClient(cfg adminapi.KonnectConfig) (*Client, error) {
+func NewClient(cfg config.KonnectConfig) (*Client, error) {
 	tlsConfig := tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}

--- a/internal/konnect/nodes/client_test.go
+++ b/internal/konnect/nodes/client_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/nodes"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 type mockNodesServer struct {
@@ -31,7 +31,7 @@ func TestNodesClientUserAgent(t *testing.T) {
 	ts := httptest.NewServer(newMockNodesServer(t))
 	t.Cleanup(ts.Close)
 
-	c, err := nodes.NewClient(adminapi.KonnectConfig{Address: ts.URL})
+	c, err := nodes.NewClient(config.KonnectConfig{Address: ts.URL})
 	require.NoError(t, err)
 
 	_, err = c.GetNode(context.Background(), "test-node-id")

--- a/internal/manager/config/cli_validation.go
+++ b/internal/manager/config/cli_validation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/samber/mo"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	cfgtypes "github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config/types"
+	cfgtypes "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // https://github.com/kubernetes-sigs/gateway-api/blob/547122f7f55ac0464685552898c560658fb40073/apis/v1beta1/shared_types.go#L448-L463

--- a/internal/manager/controllerdef.go
+++ b/internal/manager/controllerdef.go
@@ -276,7 +276,7 @@ func setupControllers(
 				Scheme:                   mgr.GetScheme(),
 				DataplaneClient:          dataplaneClient,
 				CacheSyncTimeout:         c.CacheSyncTimeout,
-				KongServiceFacadeEnabled: featureGates.Enabled(featuregates.KongServiceFacade) && c.KongServiceFacadeEnabled,
+				KongServiceFacadeEnabled: featureGates.Enabled(managercfg.KongServiceFacadeFeature) && c.KongServiceFacadeEnabled,
 				StatusQueue:              kubernetesStatusQueue,
 				HTTPRouteEnabled: utils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
 					Group:    gatewayv1.GroupVersion.Group,
@@ -288,7 +288,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates.Enabled(featuregates.KongServiceFacade) && c.KongServiceFacadeEnabled,
+			Enabled: featureGates.Enabled(managercfg.KongServiceFacadeFeature) && c.KongServiceFacadeEnabled,
 			Controller: &configuration.IncubatorV1Alpha1KongServiceFacadeReconciler{
 				Client:                     mgr.GetClient(),
 				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongServiceFacade"),
@@ -314,7 +314,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates.Enabled(featuregates.KongCustomEntity) && c.KongCustomEntityEnabled,
+			Enabled: featureGates.Enabled(managercfg.KongCustomEntityFeature) && c.KongCustomEntityEnabled,
 			Controller: &configuration.KongV1Alpha1KongCustomEntityReconciler{
 				Client:           mgr.GetClient(),
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongCustomEntity"),
@@ -421,7 +421,7 @@ func setupControllers(
 		// Gateway API Controllers - Alpha APIs
 		// ---------------------------------------------------------------------------
 		{
-			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
+			Enabled: featureGates.Enabled(managercfg.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/UDPRoute"),
@@ -443,7 +443,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
+			Enabled: featureGates.Enabled(managercfg.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/TCPRoute"),
@@ -465,7 +465,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature),
+			Enabled: featureGates.Enabled(managercfg.GatewayAlphaFeature),
 			Controller: &crds.DynamicCRDController{
 				Manager:          mgr,
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/TLSRoute"),
@@ -487,7 +487,7 @@ func setupControllers(
 			},
 		},
 		{
-			Enabled: featureGates.Enabled(featuregates.GatewayAlphaFeature) &&
+			Enabled: featureGates.Enabled(managercfg.GatewayAlphaFeature) &&
 				c.GatewayAPIGatewayController &&
 				c.GatewayAPIHTTPRouteController,
 			Controller: &crds.DynamicCRDController{

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // -----------------------------------------------------------------------------
@@ -13,33 +15,25 @@ import (
 const (
 	// GatewayAlphaFeature is the name of the feature-gate for enabling or
 	// disabling the Alpha maturity APIs and relevant features for Gateway API.
-	GatewayAlphaFeature = "GatewayAlpha"
 
 	// FillIDsFeature is the name of the feature-gate that makes KIC fill in the ID fields of Kong entities (Services,
 	// Routes, and Consumers). It ensures that IDs remain stable across restarts of the controller.
-	FillIDsFeature = "FillIDs"
 
 	// RewriteURIsFeature is the name of the feature-gate for enabling/disabling konghq.com/rewrite annotation.
-	RewriteURIsFeature = "RewriteURIs"
 
 	// KongServiceFacade is the name of the feature-gate for enabling KongServiceFacade CR reconciliation.
-	KongServiceFacade = "KongServiceFacade"
 
 	// SanitizeKonnectConfigDumps is the name of the feature-gate that enables sanitization of Konnect config dumps.
-	SanitizeKonnectConfigDumps = "SanitizeKonnectConfigDumps"
 
 	// FallbackConfiguration is the name of the feature-gate that enables generating fallback configuration in the case
 	// of entity errors returned by the Kong Admin API.
-	FallbackConfiguration = "FallbackConfiguration"
 
 	// KongCustomEntity is the name of the feature-gate for enabling KongCustomEntity CR reconciliation
 	// for configuring custom Kong entities that KIC does not support yet.
 	// Requires feature gate `FillIDs` to be enabled.
-	KongCustomEntity = "KongCustomEntity"
 
 	// CombinedServicesFromDifferentHTTPRoutes is the name of the feature gate that enables combining rules sharing the same backendRefs
 	// from different HTTPRoutes in the same namespace into one Kong gateway service to reduce total number of Kong gateway services.
-	CombinedServicesFromDifferentHTTPRoutes = "CombinedServicesFromDifferentHTTPRoutes"
 
 	// DocsURL provides a link to the documentation for feature gates in the KIC repository.
 	DocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
@@ -63,8 +57,8 @@ func New(setupLog logr.Logger, featureGates map[string]bool) (FeatureGates, erro
 	}
 
 	// KongCustomEntity requires FillIDs to be enabled, because custom entities requires stable IDs to fill in its "foreign" fields.
-	if ctrlMap.Enabled(KongCustomEntity) && !ctrlMap.Enabled(FillIDsFeature) {
-		return nil, fmt.Errorf("%s is required if %s is enabled", FillIDsFeature, KongCustomEntity)
+	if ctrlMap.Enabled(config.KongCustomEntityFeature) && !ctrlMap.Enabled(config.FillIDsFeature) {
+		return nil, fmt.Errorf("%s is required if %s is enabled", config.FillIDsFeature, config.KongCustomEntityFeature)
 	}
 
 	return ctrlMap, nil
@@ -81,13 +75,13 @@ func (fg FeatureGates) Enabled(feature string) bool {
 // NOTE: if you're adding a new feature gate, it needs to be added here.
 func GetFeatureGatesDefaults() FeatureGates {
 	return map[string]bool{
-		GatewayAlphaFeature:                     false,
-		FillIDsFeature:                          true,
-		RewriteURIsFeature:                      false,
-		KongServiceFacade:                       false,
-		SanitizeKonnectConfigDumps:              true,
-		FallbackConfiguration:                   false,
-		KongCustomEntity:                        true,
-		CombinedServicesFromDifferentHTTPRoutes: false,
+		config.GatewayAlphaFeature:                            false,
+		config.FillIDsFeature:                                 true,
+		config.RewriteURIsFeature:                             false,
+		config.KongServiceFacadeFeature:                       false,
+		config.SanitizeKonnectConfigDumpsFeature:              true,
+		config.FallbackConfigurationFeature:                   false,
+		config.KongCustomEntityFeature:                        true,
+		config.CombinedServicesFromDifferentHTTPRoutesFeature: false,
 	}
 }

--- a/internal/manager/featuregates/feature_gates.go
+++ b/internal/manager/featuregates/feature_gates.go
@@ -8,33 +8,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
-// -----------------------------------------------------------------------------
-// Feature Gates - Vars & Consts
-// -----------------------------------------------------------------------------
-
 const (
-	// GatewayAlphaFeature is the name of the feature-gate for enabling or
-	// disabling the Alpha maturity APIs and relevant features for Gateway API.
-
-	// FillIDsFeature is the name of the feature-gate that makes KIC fill in the ID fields of Kong entities (Services,
-	// Routes, and Consumers). It ensures that IDs remain stable across restarts of the controller.
-
-	// RewriteURIsFeature is the name of the feature-gate for enabling/disabling konghq.com/rewrite annotation.
-
-	// KongServiceFacade is the name of the feature-gate for enabling KongServiceFacade CR reconciliation.
-
-	// SanitizeKonnectConfigDumps is the name of the feature-gate that enables sanitization of Konnect config dumps.
-
-	// FallbackConfiguration is the name of the feature-gate that enables generating fallback configuration in the case
-	// of entity errors returned by the Kong Admin API.
-
-	// KongCustomEntity is the name of the feature-gate for enabling KongCustomEntity CR reconciliation
-	// for configuring custom Kong entities that KIC does not support yet.
-	// Requires feature gate `FillIDs` to be enabled.
-
-	// CombinedServicesFromDifferentHTTPRoutes is the name of the feature gate that enables combining rules sharing the same backendRefs
-	// from different HTTPRoutes in the same namespace into one Kong gateway service to reduce total number of Kong gateway services.
-
 	// DocsURL provides a link to the documentation for feature gates in the KIC repository.
 	DocsURL = "https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md"
 )
@@ -44,7 +18,7 @@ type FeatureGates map[string]bool
 // New creates FeatureGates from the given feature gate map, overriding the default settings.
 func New(setupLog logr.Logger, featureGates map[string]bool) (FeatureGates, error) {
 	// generate a map of feature gates by string names to their controller enablement
-	ctrlMap := GetFeatureGatesDefaults()
+	ctrlMap := FeatureGates(config.GetFeatureGatesDefaults())
 
 	// override the default settings
 	for feature, enabled := range featureGates {
@@ -66,22 +40,4 @@ func New(setupLog logr.Logger, featureGates map[string]bool) (FeatureGates, erro
 
 func (fg FeatureGates) Enabled(feature string) bool {
 	return fg[feature]
-}
-
-// GetFeatureGatesDefaults initializes a feature gate map given the currently
-// supported feature gates options and derives defaults for them based on
-// manager configuration options if present.
-//
-// NOTE: if you're adding a new feature gate, it needs to be added here.
-func GetFeatureGatesDefaults() FeatureGates {
-	return map[string]bool{
-		config.GatewayAlphaFeature:                            false,
-		config.FillIDsFeature:                                 true,
-		config.RewriteURIsFeature:                             false,
-		config.KongServiceFacadeFeature:                       false,
-		config.SanitizeKonnectConfigDumpsFeature:              true,
-		config.FallbackConfigurationFeature:                   false,
-		config.KongCustomEntityFeature:                        true,
-		config.CombinedServicesFromDifferentHTTPRoutesFeature: false,
-	}
 }

--- a/internal/manager/featuregates/feature_gates_test.go
+++ b/internal/manager/featuregates/feature_gates_test.go
@@ -19,7 +19,7 @@ func TestFeatureGates(t *testing.T) {
 	t.Log("Verifying feature gates setup defaults when no feature gates are configured")
 	fgs, err := New(setupLog, nil)
 	assert.NoError(t, err)
-	assert.Len(t, fgs, len(GetFeatureGatesDefaults()))
+	assert.Len(t, fgs, len(config.GetFeatureGatesDefaults()))
 
 	t.Log("Verifying feature gates setup results when valid feature gates options are present")
 	featureGates := map[string]bool{config.GatewayAlphaFeature: true}

--- a/internal/manager/featuregates/feature_gates_test.go
+++ b/internal/manager/featuregates/feature_gates_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 func TestFeatureGates(t *testing.T) {
@@ -20,16 +22,16 @@ func TestFeatureGates(t *testing.T) {
 	assert.Len(t, fgs, len(GetFeatureGatesDefaults()))
 
 	t.Log("Verifying feature gates setup results when valid feature gates options are present")
-	featureGates := map[string]bool{GatewayAlphaFeature: true}
+	featureGates := map[string]bool{config.GatewayAlphaFeature: true}
 	fgs, err = New(setupLog, featureGates)
 	assert.NoError(t, err)
-	assert.True(t, fgs[GatewayAlphaFeature])
+	assert.True(t, fgs[config.GatewayAlphaFeature])
 
 	t.Log("Verifying feature gates setup will return error when settings has conflicts")
-	featureGates = map[string]bool{KongCustomEntity: true, FillIDsFeature: false}
+	featureGates = map[string]bool{config.KongCustomEntityFeature: true, config.FillIDsFeature: false}
 	_, err = New(setupLog, featureGates)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("%s is required if %s is enabled", FillIDsFeature, KongCustomEntity))
+	assert.Contains(t, err.Error(), fmt.Sprintf("%s is required if %s is enabled", config.FillIDsFeature, config.KongCustomEntityFeature))
 
 	t.Log("Configuring several invalid feature gates options")
 	featureGates = map[string]bool{"invalidGateway": true}

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -42,8 +42,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 	config2 "github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config"
-	cfgtypes "github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config/types"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/scheme"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/clock"
@@ -97,9 +97,9 @@ func setupManagerOptions(ctx context.Context, logger logr.Logger, c managercfg.C
 			BindAddress: c.MetricsAddr,
 			FilterProvider: func() func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
 				switch c.MetricsAccessFilter {
-				case cfgtypes.MetricsAccessFilterOff:
+				case managercfg.MetricsAccessFilterOff:
 					return nil
-				case cfgtypes.MetricsAccessFilterRBAC:
+				case managercfg.MetricsAccessFilterRBAC:
 					return filters.WithAuthenticationAndAuthorization
 				default:
 					// This is checked in flags validation so this should never happen.
@@ -333,7 +333,7 @@ func adminAPIClients(
 	// If kong-admin-svc flag has been specified then use it to get the list
 	// of Kong Admin API endpoints.
 	if kongAdminSvc, ok := c.KongAdminSvc.Get(); ok {
-		kubeClient, err := managercfg.GetKubeClient(c)
+		kubeClient, err := utils.GetKubeClient(c)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get kubernetes client: %w", err)
 		}

--- a/internal/manager/utils/kubeconfig.go
+++ b/internal/manager/utils/kubeconfig.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+)
+
+// GetKubeconfig returns a Kubernetes REST config object based on the configuration.
+func GetKubeconfig(c config.Config) (*rest.Config, error) {
+	config, err := clientcmd.BuildConfigFromFlags(c.APIServerHost, c.KubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure k8s client rate-limiting
+	config.QPS = float32(c.APIServerQPS)
+	config.Burst = c.APIServerBurst
+
+	if c.APIServerCertData != nil {
+		config.CertData = c.APIServerCertData
+	}
+	if c.APIServerCAData != nil {
+		config.CAData = c.APIServerCAData
+	}
+	if c.APIServerKeyData != nil {
+		config.KeyData = c.APIServerKeyData
+	}
+	if c.Impersonate != "" {
+		config.Impersonate.UserName = c.Impersonate
+	}
+
+	config.UserAgent = metadata.UserAgent()
+
+	return config, err
+}
+
+// GetKubeClient returns a Kubernetes client based on the configuration.
+func GetKubeClient(c config.Config) (client.Client, error) {
+	conf, err := GetKubeconfig(c)
+	if err != nil {
+		return nil, err
+	}
+	return client.New(conf, client.Options{})
+}

--- a/internal/manager/utils/kubeconfig.go
+++ b/internal/manager/utils/kubeconfig.go
@@ -16,7 +16,7 @@ func GetKubeconfig(c config.Config) (*rest.Config, error) {
 		return nil, err
 	}
 
-	// Configure k8s client rate-limiting
+	// Configure K8s client rate-limiting.
 	config.QPS = float32(c.APIServerQPS)
 	config.Burst = c.APIServerBurst
 

--- a/internal/manager/utils/kubeconfig.go
+++ b/internal/manager/utils/kubeconfig.go
@@ -16,6 +16,9 @@ func GetKubeconfig(c config.Config) (*rest.Config, error) {
 		return nil, err
 	}
 
+	// Set the user agent so it's possible to identify the controller in the API server logs.
+	config.UserAgent = metadata.UserAgent()
+
 	// Configure K8s client rate-limiting.
 	config.QPS = float32(c.APIServerQPS)
 	config.Burst = c.APIServerBurst
@@ -32,8 +35,6 @@ func GetKubeconfig(c config.Config) (*rest.Config, error) {
 	if c.Impersonate != "" {
 		config.Impersonate.UserName = c.Impersonate
 	}
-
-	config.UserAgent = metadata.UserAgent()
 
 	return config, err
 }

--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/cmd/rootcmd"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
@@ -137,7 +136,7 @@ func DeployControllerManagerForCluster(
 	go func() {
 		defer os.Remove(kubeconfig.Name())
 		fmt.Fprintf(os.Stderr, "INFO: Starting Controller Manager for Cluster %s with Configuration: %+v\n", cluster.Name(), clicfg)
-		if err := rootcmd.RunWithLogger(ctx, *clicfg.Config, logger); err != nil {
+		if err := manager.Run(ctx, *clicfg.Config, logger); err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Problems with Controller Manager: %s\n", err)
 			os.Exit(1)
 		}

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -7,13 +7,14 @@ import (
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
-// Note: NewConfig is not implemented in the `pkg/manager/config` package to avoid cyclic dependencies:
-// for now, it depends on `internal/manager/config` to set defaults using CLI flags parsing.
-
-// NewConfig is used to create a new configuration object with default values.
-// Values can be overridden by passing `managercfg.Opt` options.
+// NewConfig is used to create a new configuration object with default values. Values can be overridden by passing
+// `managercfg.Opt` options.
+//
+// Note: the default values binding happens in `internal/manager/config` package and this function relies on it. Because
+// of that, NewConfig is not implemented in the `pkg/manager/config` package as that would impose a cyclic dependency.
+// We might want to move the default values binding to `pkg/manager/config` in the future and implement NewConfig there.
 func NewConfig(opts ...managercfg.Opt) (managercfg.Config, error) {
-	cfg, err := NewDefaultConfig()
+	cfg, err := newDefaultConfig()
 	if err != nil {
 		return managercfg.Config{}, fmt.Errorf("failed to create default manager config: %w", err)
 	}
@@ -25,7 +26,7 @@ func NewConfig(opts ...managercfg.Opt) (managercfg.Config, error) {
 	return cfg, nil
 }
 
-func NewDefaultConfig() (managercfg.Config, error) {
+func newDefaultConfig() (managercfg.Config, error) {
 	// Set default values relying on CLI flags parsing.
 	cliCfg := config.NewCLIConfig()
 	flags := cliCfg.FlagSet()

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -1,6 +1,8 @@
 package manager
 
 import (
+	"fmt"
+
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/config"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
@@ -11,17 +13,28 @@ import (
 // NewConfig is used to create a new configuration object with default values.
 // Values can be overridden by passing `managercfg.Opt` options.
 func NewConfig(opts ...managercfg.Opt) (managercfg.Config, error) {
+	cfg, err := NewDefaultConfig()
+	if err != nil {
+		return managercfg.Config{}, fmt.Errorf("failed to create default manager config: %w", err)
+	}
+
+	// Override default values with the provided options.
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg, nil
+}
+
+func NewDefaultConfig() (managercfg.Config, error) {
 	// Set default values relying on CLI flags parsing.
 	cliCfg := config.NewCLIConfig()
 	flags := cliCfg.FlagSet()
 	if err := flags.Parse([]string{}); err != nil {
-		return managercfg.Config{}, err
+		return managercfg.Config{}, fmt.Errorf("failed to parse CLI flags: %w", err)
 	}
 
-	// Override default values with the provided options.
-	cfg := cliCfg.Config
-	for _, opt := range opts {
-		opt(cfg)
-	}
-	return *cfg, nil
+	// Set default feature gates values as they're not populated by the CLI flags parsing.
+	cliCfg.FeatureGates = managercfg.GetFeatureGatesDefaults()
+
+	return *cliCfg.Config, nil
 }

--- a/pkg/manager/config/adminapi.go
+++ b/pkg/manager/config/adminapi.go
@@ -1,4 +1,20 @@
-package adminapi
+package config
+
+// AdminAPIClientConfig defines parameters that configure a client for Kong Admin API.
+type AdminAPIClientConfig struct {
+	// Disable verification of TLS certificate of Kong's Admin endpoint.
+	TLSSkipVerify bool
+	// SNI name to use to verify the certificate presented by Kong in TLS.
+	TLSServerName string
+	// Path to PEM-encoded CA certificate file to verify Kong's Admin SSL certificate.
+	CACertPath string
+	// PEM-encoded CA certificate to verify Kong's Admin SSL certificate.
+	CACert string
+	// Array of headers added to every Admin API call.
+	Headers []string
+	// TLSClient is TLS client config.
+	TLSClient TLSClientConfig
+}
 
 // TLSClientConfig contains TLS client certificate and client key to be used when connecting with Admin APIs.
 // It's validated with manager.validateClientTLS before passing it further down. It guarantees that only the

--- a/pkg/manager/config/admission.go
+++ b/pkg/manager/config/admission.go
@@ -1,0 +1,12 @@
+package config
+
+// AdmissionServerConfig defines parameters that configure the Admission Server run by the controller.
+type AdmissionServerConfig struct {
+	ListenAddr string
+
+	CertPath string
+	Cert     string
+
+	KeyPath string
+	Key     string
+}

--- a/pkg/manager/config/consts.go
+++ b/pkg/manager/config/consts.go
@@ -1,0 +1,28 @@
+package config
+
+import "time"
+
+const (
+	// LeaderElectionEnabled is a constant that represents a value that should be used to enable leader election.
+	LeaderElectionEnabled = "enabled"
+	// LeaderElectionDisabled is a constant that represents a value that should be used to disable leader election.
+	LeaderElectionDisabled = "disabled"
+)
+
+const (
+	// DefaultDataPlanesReadinessReconciliationInterval is the interval at which the manager will run DPs readiness reconciliation loop.
+	// It's the same as the default interval of a Kubernetes container's readiness probe.
+	DefaultDataPlanesReadinessReconciliationInterval = 10 * time.Second
+	// MinDataPlanesReadinessReconciliationInterval is the minimum interval of DPs readiness reconciliation loop.
+	MinDataPlanesReadinessReconciliationInterval = 3 * time.Second
+	// DefaultDataPlanesReadinessCheckTimeout is the default timeout of readiness check.
+	// When a readiness check request did not get response within the timeout, the gateway instance will turn into `Pending` status.
+	DefaultDataPlanesReadinessCheckTimeout = 5 * time.Second
+)
+
+const (
+	// MinKonnectConfigUploadPeriod is the minimum period between operations to upload Kong configuration to Konnect.
+	MinKonnectConfigUploadPeriod = 10 * time.Second
+	// DefaultKonnectConfigUploadPeriod is the default period between operations to upload Kong configuration to Konnect.
+	DefaultKonnectConfigUploadPeriod = 30 * time.Second
+)

--- a/pkg/manager/config/featuregates.go
+++ b/pkg/manager/config/featuregates.go
@@ -31,3 +31,19 @@ const (
 	// from different HTTPRoutes in the same namespace into one Kong gateway service to reduce total number of Kong gateway services.
 	CombinedServicesFromDifferentHTTPRoutesFeature = "CombinedServicesFromDifferentHTTPRoutes"
 )
+
+// GetFeatureGatesDefaults returns the default values for all feature gates.
+//
+// NOTE: if you're adding a new feature gate, it needs to be added here.
+func GetFeatureGatesDefaults() map[string]bool {
+	return map[string]bool{
+		GatewayAlphaFeature:                            false,
+		FillIDsFeature:                                 true,
+		RewriteURIsFeature:                             false,
+		KongServiceFacadeFeature:                       false,
+		SanitizeKonnectConfigDumpsFeature:              true,
+		FallbackConfigurationFeature:                   false,
+		KongCustomEntityFeature:                        true,
+		CombinedServicesFromDifferentHTTPRoutesFeature: false,
+	}
+}

--- a/pkg/manager/config/featuregates.go
+++ b/pkg/manager/config/featuregates.go
@@ -1,0 +1,33 @@
+package config
+
+const (
+	// GatewayAlphaFeature is the name of the feature-gate for enabling or
+	// disabling the Alpha maturity APIs and relevant features for Gateway API.
+	GatewayAlphaFeature = "GatewayAlpha"
+
+	// FillIDsFeature is the name of the feature-gate that makes KIC fill in the ID fields of Kong entities (Services,
+	// Routes, and Consumers). It ensures that IDs remain stable across restarts of the controller.
+	FillIDsFeature = "FillIDs"
+
+	// RewriteURIsFeature is the name of the feature-gate for enabling/disabling konghq.com/rewrite annotation.
+	RewriteURIsFeature = "RewriteURIs"
+
+	// KongServiceFacadeFeature is the name of the feature-gate for enabling KongServiceFacade CR reconciliation.
+	KongServiceFacadeFeature = "KongServiceFacade"
+
+	// SanitizeKonnectConfigDumpsFeature is the name of the feature-gate that enables sanitization of Konnect config dumps.
+	SanitizeKonnectConfigDumpsFeature = "SanitizeKonnectConfigDumps"
+
+	// FallbackConfigurationFeature is the name of the feature-gate that enables generating fallback configuration in the case
+	// of entity errors returned by the Kong Admin API.
+	FallbackConfigurationFeature = "FallbackConfiguration"
+
+	// KongCustomEntityFeature is the name of the feature-gate for enabling KongCustomEntity CR reconciliation
+	// for configuring custom Kong entities that KIC does not support yet.
+	// Requires feature gate `FillIDs` to be enabled.
+	KongCustomEntityFeature = "KongCustomEntity"
+
+	// CombinedServicesFromDifferentHTTPRoutesFeature is the name of the feature gate that enables combining rules sharing the same backendRefs
+	// from different HTTPRoutes in the same namespace into one Kong gateway service to reduce total number of Kong gateway services.
+	CombinedServicesFromDifferentHTTPRoutesFeature = "CombinedServicesFromDifferentHTTPRoutes"
+)

--- a/pkg/manager/config/konnect.go
+++ b/pkg/manager/config/konnect.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"time"
+)
+
+type KonnectConfig struct {
+	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/3922
+	// ConfigSynchronizationEnabled is the only toggle we had prior to the addition of the license agent.
+	// We likely want to combine these into a single Konnect toggle or piggyback off other Konnect functionality.
+	ConfigSynchronizationEnabled bool
+	ControlPlaneID               string
+	Address                      string
+	UploadConfigPeriod           time.Duration
+	RefreshNodePeriod            time.Duration
+	TLSClient                    TLSClientConfig
+
+	LicenseSynchronizationEnabled bool
+	InitialLicensePollingPeriod   time.Duration
+	LicensePollingPeriod          time.Duration
+	ConsumersSyncDisabled         bool
+}

--- a/pkg/manager/config/konnect.go
+++ b/pkg/manager/config/konnect.go
@@ -5,7 +5,7 @@ import (
 )
 
 type KonnectConfig struct {
-	// TODO https://github.com/Kong/kubernetes-ingress-controller/issues/3922
+	// TODO: https://github.com/Kong/kubernetes-ingress-controller/issues/3922
 	// ConfigSynchronizationEnabled is the only toggle we had prior to the addition of the license agent.
 	// We likely want to combine these into a single Konnect toggle or piggyback off other Konnect functionality.
 	ConfigSynchronizationEnabled bool

--- a/pkg/manager/config/metricsfilter.go
+++ b/pkg/manager/config/metricsfilter.go
@@ -1,4 +1,4 @@
-package types
+package config
 
 // MetricsAccessFilter defines the access filter function for the metrics endpoint.
 type MetricsAccessFilter string

--- a/pkg/manager/config_test.go
+++ b/pkg/manager/config_test.go
@@ -102,7 +102,7 @@ func TestNewConfig(t *testing.T) {
 			EnableConfigDumps:    false,
 			DumpSensitiveConfig:  false,
 			DiagnosticServerPort: consts.DiagnosticsPort,
-			FeatureGates:         nil,
+			FeatureGates:         managercfg.GetFeatureGatesDefaults(),
 			TermDelay:            0,
 			Konnect: managercfg.KonnectConfig{
 				Address:                     "https://us.kic.api.konghq.com",

--- a/pkg/manager/config_test.go
+++ b/pkg/manager/config_test.go
@@ -6,10 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
@@ -28,7 +25,7 @@ func TestNewConfig(t *testing.T) {
 		require.Equal(t, defaultConfig, managercfg.Config{
 			LogLevel:                               "info",
 			LogFormat:                              "text",
-			KongAdminAPIConfig:                     adminapi.ClientOpts{},
+			KongAdminAPIConfig:                     managercfg.AdminAPIClientConfig{},
 			KongAdminInitializationRetries:         60,
 			KongAdminInitializationRetryDelay:      time.Second,
 			KongAdminToken:                         "",
@@ -52,8 +49,8 @@ func TestNewConfig(t *testing.T) {
 			ProbeAddr:                              ":10254",
 			KongAdminURLs:                          []string{"http://localhost:8001"},
 			KongAdminSvc:                           managercfg.OptionalNamespacedName{},
-			GatewayDiscoveryReadinessCheckInterval: clients.DefaultReadinessReconciliationInterval,
-			GatewayDiscoveryReadinessCheckTimeout:  clients.DefaultReadinessCheckTimeout,
+			GatewayDiscoveryReadinessCheckInterval: managercfg.DefaultDataPlanesReadinessReconciliationInterval,
+			GatewayDiscoveryReadinessCheckTimeout:  managercfg.DefaultDataPlanesReadinessCheckTimeout,
 			KongAdminSvcPortNames:                  []string{"admin-tls", "kong-admin-tls"},
 			ProxySyncSeconds:                       dataplane.DefaultSyncSeconds,
 			InitCacheSyncDuration:                  dataplane.DefaultCacheSyncWaitDuration,
@@ -98,7 +95,7 @@ func TestNewConfig(t *testing.T) {
 			GatewayToReconcile:                     managercfg.OptionalNamespacedName{},
 			SecretLabelSelector:                    "",
 			ConfigMapLabelSelector:                 consts.DefaultConfigMapSelector,
-			AdmissionServer: admission.ServerConfig{
+			AdmissionServer: managercfg.AdmissionServerConfig{
 				ListenAddr: "off",
 			},
 			EnableProfiling:      false,
@@ -107,11 +104,11 @@ func TestNewConfig(t *testing.T) {
 			DiagnosticServerPort: consts.DiagnosticsPort,
 			FeatureGates:         nil,
 			TermDelay:            0,
-			Konnect: adminapi.KonnectConfig{
+			Konnect: managercfg.KonnectConfig{
 				Address:                     "https://us.kic.api.konghq.com",
 				InitialLicensePollingPeriod: license.DefaultInitialPollingPeriod,
 				LicensePollingPeriod:        license.DefaultPollingPeriod,
-				UploadConfigPeriod:          konnect.DefaultConfigUploadPeriod,
+				UploadConfigPeriod:          managercfg.DefaultKonnectConfigUploadPeriod,
 				RefreshNodePeriod:           konnect.DefaultRefreshNodePeriod,
 			},
 			SplunkEndpoint:                   "",

--- a/pkg/manager/id.go
+++ b/pkg/manager/id.go
@@ -1,0 +1,30 @@
+package manager
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// ID is a unique identifier for the Kong Ingress Controller instance.
+// It can be an arbitrary string that is unique across all instances.
+type ID struct {
+	id string
+}
+
+// NewRandomID generates a new random manager ID.
+func NewRandomID() ID {
+	return ID{id: uuid.NewString()}
+}
+
+// NewID creates a new manager ID from a string (e.g. a Kubernetes object UID).
+func NewID(s string) (ID, error) {
+	if s == "" {
+		return ID{}, errors.New("manager ID cannot be empty")
+	}
+	return ID{id: s}, nil
+}
+
+func (id ID) String() string {
+	return id.id
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,0 +1,40 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	managerinternal "github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
+	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+)
+
+// Manager is an object representing an instance of the Kong Ingress Controller.
+type Manager struct {
+	id     ID
+	config managercfg.Config
+	logger logr.Logger
+}
+
+// NewManager creates a new instance of the Kong Ingress Controller. It does not start the controller.
+func NewManager(id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
+	cfg, err := NewConfig(configOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager config: %w", err)
+	}
+
+	return &Manager{
+		id:     id,
+		config: cfg,
+		logger: logger.WithValues("managerID", id.String()),
+	}, nil
+}
+
+// Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
+// It should be called only once per Manager instance.
+func (m *Manager) Run(ctx context.Context) error {
+	return managerinternal.Run(ctx, m.config, m.logger)
+}
+
+// TODO(czeslavo): expose healthcheck/readiness check methods from the manager

--- a/scripts/cli-arguments-docs-gen/main.go
+++ b/scripts/cli-arguments-docs-gen/main.go
@@ -73,7 +73,7 @@ func getTypeForHuman(flag *pflag.Flag) string {
 		return "bools"
 	case "mapStringBool":
 		return "list of string=bool"
-	case "types.MetricsAccessFilter":
+	case "config.MetricsAccessFilter":
 		return "string"
 	// The below are types that are human readable out-of-the-box, in case of missing one extend the list.
 	case "bool", "string", "int", "uint", "duration", "namespaced-name":

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
@@ -350,7 +351,7 @@ func ensureAllProxyReplicasAreConfigured(ctx context.Context, t *testing.T, env 
 
 			// Anything related to TLS can be ignored, because only availability is being tested here.
 			// Testing communicating over TLS is done as part of actual E2E test.
-			kongClient, err := adminapi.NewKongAPIClient(address, adminapi.ClientOpts{TLSSkipVerify: true}, "")
+			kongClient, err := adminapi.NewKongAPIClient(address, config.AdminAPIClientConfig{TLSSkipVerify: true}, "")
 			require.NoError(t, err)
 
 			verifyIngressWithEchoBackendsInAdminAPI(ctx, t, kongClient, numberOfEchoBackends)

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -33,8 +33,8 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
@@ -253,7 +253,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 				controllerDeployment.Spec.Template.Spec.Containers[i].Env,
 				corev1.EnvVar{
 					Name:  "CONTROLLER_FEATURE_GATES",
-					Value: fmt.Sprintf("%s=true", featuregates.GatewayAlphaFeature),
+					Value: fmt.Sprintf("%s=true", config.GatewayAlphaFeature),
 				},
 			)
 		}

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/nodes"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	testkonnect "github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers/konnect"
 )
 
@@ -197,10 +198,10 @@ func createKonnectClientSecretAndConfigMap(ctx context.Context, t *testing.T, en
 func createKonnectAdminAPIClient(t *testing.T, rgID, cert, key string) *adminapi.KonnectClient {
 	t.Helper()
 
-	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectControlPlane(config.KonnectConfig{
 		ControlPlaneID: rgID,
 		Address:        konnectControlPlaneAdminAPIBaseURL,
-		TLSClient: adminapi.TLSClientConfig{
+		TLSClient: config.TLSClientConfig{
 			Cert: cert,
 			Key:  key,
 		},
@@ -211,12 +212,12 @@ func createKonnectAdminAPIClient(t *testing.T, rgID, cert, key string) *adminapi
 
 // createKonnectNodeClient creates a konnect.NodeClient to get nodes in konnect control plane.
 func createKonnectNodeClient(t *testing.T, rgID, cert, key string) *nodes.Client {
-	cfg := adminapi.KonnectConfig{
+	cfg := config.KonnectConfig{
 		ConfigSynchronizationEnabled: true,
 		ControlPlaneID:               rgID,
 		Address:                      konnectControlPlaneAdminAPIBaseURL,
 		RefreshNodePeriod:            konnect.MinRefreshNodePeriod,
-		TLSClient: adminapi.TLSClientConfig{
+		TLSClient: config.TLSClientConfig{
 			Cert: cert,
 			Key:  key,
 		},
@@ -304,7 +305,7 @@ func requireAllProxyReplicasIDsConsistentWithKonnect(
 
 		// Anything related to TLS can be ignored, because only availability is being tested here.
 		// Testing communicating as part of actual E2E test.
-		kongClient, err := adminapi.NewKongAPIClient(address, adminapi.ClientOpts{TLSSkipVerify: true}, "")
+		kongClient, err := adminapi.NewKongAPIClient(address, config.AdminAPIClientConfig{TLSSkipVerify: true}, "")
 		require.NoError(t, err)
 
 		nodeID, err := adminapi.NewClient(kongClient).NodeID(ctx)

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -50,7 +50,7 @@ func TestAdmissionWebhook_KongVault(t *testing.T) {
 		kongContainer = runKongEnterprise(ctx, t)
 	)
 
-	_, logs := RunManager(ctx, t, envcfg,
+	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
 		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
@@ -195,7 +195,7 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 		kongContainer = runKongEnterprise(ctx, t)
 	)
 
-	_, logs := RunManager(ctx, t, envcfg,
+	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
 		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
@@ -449,7 +449,7 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 		kongContainer = runKongEnterprise(ctx, t)
 	)
 
-	_, logs := RunManager(ctx, t, envcfg,
+	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
 		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
@@ -713,7 +713,7 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 		kongContainer = runKongEnterprise(ctx, t)
 	)
 
-	_, logs := RunManager(ctx, t, envcfg,
+	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
 		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
@@ -1054,7 +1054,7 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 		kongContainer = runKongEnterprise(ctx, t)
 	)
 
-	_, logs := RunManager(ctx, t, envcfg,
+	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
 		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
@@ -1222,7 +1222,7 @@ func TestAdmissionWebhook_KongCustomEntities(t *testing.T) {
 		kongContainer = runKongEnterprise(ctx, t)
 	)
 
-	_, logs := RunManager(ctx, t, envcfg,
+	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
 		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -19,6 +19,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
@@ -98,8 +99,8 @@ func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	logger := zapr.NewLogger(zap.NewNop())
+	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))
+	ctx, logger, _ := CreateTestLogger(ctx)
 	adminAPIServerURL := StartAdminAPIServerMock(t).URL
 
 	cfg, err := manager.NewConfig(

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -43,7 +43,7 @@ func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
 	t.Log("Replacing Kubernetes API server address with the proxy address")
 	envcfg.Host = fmt.Sprintf("https://%s", apiServerProxy.Address())
 
-	_, loggerHook := RunManager(ctx, t, envcfg, AdminAPIOptFns())
+	loggerHook := RunManager(ctx, t, envcfg, AdminAPIOptFns())
 	hasLog := func(expectedLog string) bool {
 		return lo.ContainsBy(loggerHook.All(), func(entry observer.LoggedEntry) bool {
 			return strings.Contains(entry.Message, expectedLog)

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -96,7 +96,7 @@ func TestMetricsAreServed(t *testing.T) {
 				)
 			}
 			addr := fmt.Sprintf("localhost:%d", helpers.GetFreePort(t))
-			_, _ = RunManager(ctx, t, envcfg,
+			_ = RunManager(ctx, t, envcfg,
 				AdminAPIOptFns(adminAPIOpts...),
 				func(cfg *managercfg.Config) {
 					cfg.FeatureGates[managercfg.FallbackConfigurationFeature] = tc.fallbackConfigurationEnabled

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
@@ -100,7 +99,7 @@ func TestMetricsAreServed(t *testing.T) {
 			_, _ = RunManager(ctx, t, envcfg,
 				AdminAPIOptFns(adminAPIOpts...),
 				func(cfg *managercfg.Config) {
-					cfg.FeatureGates[featuregates.FallbackConfiguration] = tc.fallbackConfigurationEnabled
+					cfg.FeatureGates[managercfg.FallbackConfigurationFeature] = tc.fallbackConfigurationEnabled
 				},
 				WithMetricsAddr(addr),
 			)

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -86,7 +86,7 @@ func ConfigForEnvConfig(t *testing.T, envcfg *rest.Config, opts ...mocks.AdminAP
 type ModifyManagerConfigFn func(cfg *managercfg.Config)
 
 func WithGatewayFeatureEnabled(cfg *managercfg.Config) {
-	cfg.FeatureGates[featuregates.GatewayAlphaFeature] = true
+	cfg.FeatureGates[managercfg.GatewayAlphaFeature] = true
 }
 
 func WithGatewayAPIControllers() func(cfg *managercfg.Config) {
@@ -165,7 +165,7 @@ func WithUpdateStatus() func(cfg *managercfg.Config) {
 
 func WithKongServiceFacadeFeatureEnabled() func(cfg *managercfg.Config) {
 	return func(cfg *managercfg.Config) {
-		cfg.FeatureGates[featuregates.KongServiceFacade] = true
+		cfg.FeatureGates[managercfg.KongServiceFacadeFeature] = true
 	}
 }
 

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -29,9 +29,8 @@ import (
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils"
-	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
 )
 
@@ -58,19 +57,20 @@ func TestTelemetry(t *testing.T) {
 	t.Log("configuring envtest and creating K8s objects for telemetry test")
 	envcfg := Setup(t, scheme.Scheme)
 	// Let's have long duration due too rate limiter in K8s client.
-	cfg := configForEnvTestTelemetry(t, envcfg, telemetryServerListener.Addr().String(), 100*time.Millisecond)
+	cfg, err := manager.NewConfig(
+		WithDefaultEnvTestsConfig(envcfg),
+	)
+	require.NoError(t, err)
 	c, err := utils.GetKubeconfig(cfg)
 	require.NoError(t, err)
 	createK8sObjectsForTelemetryTest(ctx, t, c)
 
 	t.Log("starting the controller manager")
 	go func() {
-		logger, err := manager.SetupLoggers(cfg, io.Discard)
-		if !assert.NoError(t, err) {
-			return
-		}
-		err = manager.Run(ctx, cfg, logger)
-		assert.NoError(t, err)
+		RunManager(ctx, t, envcfg, AdminAPIOptFns(),
+			WithDefaultEnvTestsConfig(envcfg),
+			WithTelemetry(telemetryServerListener.Addr().String(), 100*time.Millisecond),
+		)
 	}()
 
 	dcl, err := discoveryclient.NewDiscoveryClientForConfig(envcfg)
@@ -91,20 +91,6 @@ func TestTelemetry(t *testing.T) {
 			return false
 		}
 	}, waitTime, tickTime, "telemetry report never matched expected value")
-}
-
-func configForEnvTestTelemetry(t *testing.T, envcfg *rest.Config, splunkEndpoint string, telemetryPeriod time.Duration) managercfg.Config {
-	t.Helper()
-
-	cfg := ConfigForEnvConfig(t, envcfg)
-	cfg.AnonymousReports = true
-	cfg.SplunkEndpoint = splunkEndpoint
-	cfg.SplunkEndpointInsecureSkipVerify = true
-	cfg.TelemetryPeriod = telemetryPeriod
-	cfg.EnableProfiling = false
-	cfg.EnableConfigDumps = false
-
-	return cfg
 }
 
 func createK8sObjectsForTelemetryTest(ctx context.Context, t *testing.T, cfg *rest.Config) {

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
 )
@@ -58,7 +59,7 @@ func TestTelemetry(t *testing.T) {
 	envcfg := Setup(t, scheme.Scheme)
 	// Let's have long duration due too rate limiter in K8s client.
 	cfg := configForEnvTestTelemetry(t, envcfg, telemetryServerListener.Addr().String(), 100*time.Millisecond)
-	c, err := managercfg.GetKubeconfig(cfg)
+	c, err := utils.GetKubeconfig(cfg)
 	require.NoError(t, err)
 	createK8sObjectsForTelemetryTest(ctx, t, c)
 

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kong/kubernetes-configuration/pkg/clientset"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
@@ -1072,7 +1072,7 @@ func TestIngressMatchByHost(t *testing.T) {
 func TestIngressRewriteURI(t *testing.T) {
 	ctx := context.Background()
 
-	if !strings.Contains(testenv.ControllerFeatureGates(), featuregates.RewriteURIsFeature) {
+	if !strings.Contains(testenv.ControllerFeatureGates(), config.RewriteURIsFeature) {
 		t.Skipf("rewrite uri feature is disabled")
 	}
 

--- a/test/integration/isolated/examples_httproute_test.go
+++ b/test/integration/isolated/examples_httproute_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/featuregates"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
@@ -66,7 +66,7 @@ func TestHTTPRouteWithBrokenPluginFallback(t *testing.T) {
 			withControllerManagerOpts(
 				helpers.ControllerManagerOptAdditionalWatchNamespace("default"),
 			),
-			withControllerManagerFeatureGates(map[string]string{featuregates.FallbackConfiguration: "true"}),
+			withControllerManagerFeatureGates(map[string]string{config.FallbackConfigurationFeature: "true"}),
 		)).
 		Assess("deploying to cluster works and HTTP requests are routed properly",
 			runHTTPRouteExampleTestScenario(httprouteWithBrokenPluginFallback),
@@ -167,7 +167,7 @@ func TestHTTPRouteUseLastValidConfigWithBrokenPluginFallback(t *testing.T) {
 				helpers.ControllerManagerOptAdditionalWatchNamespace(namespace),
 				helpers.ControllerManagerOptFlagUseLastValidConfigForFallback(),
 			),
-			withControllerManagerFeatureGates(map[string]string{featuregates.FallbackConfiguration: "true"}),
+			withControllerManagerFeatureGates(map[string]string{config.FallbackConfigurationFeature: "true"}),
 		)).
 		Assess("deploying to cluster works and HTTP requests are routed properly", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			runHTTPRouteExampleTestScenario(httprouteExampleManifest)(ctx, t, c)

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -13,11 +13,12 @@ import (
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils/kongconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
 // GetKongRootConfig gets version and root configurations of Kong from / endpoint of the provided Admin API URL.
 func GetKongRootConfig(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) (map[string]any, error) {
-	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), adminapi.ClientOpts{}, kongTestPassword)
+	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), config.AdminAPIClientConfig{}, kongTestPassword)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating Kong API client for URL: %q: %w", proxyAdminURL, err)
 	}
@@ -96,7 +97,7 @@ func GetKongRouterFlavor(ctx context.Context, proxyAdminURL *url.URL, kongTestPa
 
 // GetKongLicenses fetches all licenses applied to Kong gateway.
 func GetKongLicenses(ctx context.Context, proxyAdminURL *url.URL, kongTestPassword string) ([]*kong.License, error) {
-	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), adminapi.ClientOpts{}, kongTestPassword)
+	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), config.AdminAPIClientConfig{}, kongTestPassword)
 	if err != nil {
 		return nil, err
 	}

--- a/test/internal/helpers/konnect/control_plane.go
+++ b/test/internal/helpers/konnect/control_plane.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/sdk"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
@@ -144,10 +145,10 @@ func generateTestKonnectControlPlaneDescription(t *testing.T) string {
 func CreateKonnectAdminAPIClient(t *testing.T, cpID, cert, key string) *adminapi.KonnectClient {
 	t.Helper()
 
-	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{
+	c, err := adminapi.NewKongClientForKonnectControlPlane(config.KonnectConfig{
 		ControlPlaneID: cpID,
 		Address:        konnectControlPlaneAdminAPIBaseURL(),
-		TLSClient: adminapi.TLSClientConfig{
+		TLSClient: config.TLSClientConfig{
 			Cert: cert,
 			Key:  key,
 		},

--- a/test/kongintegration/dbmode_update_strategy_test.go
+++ b/test/kongintegration/dbmode_update_strategy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/kongintegration/containers"
 )
 
@@ -40,7 +41,7 @@ func TestUpdateStrategyDBMode(t *testing.T) {
 	_ = containers.NewPostgres(ctx, t, net)
 	kongC := containers.NewKong(ctx, t, containers.KongWithDBMode(net.Name))
 
-	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), config.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 
 	logbase, err := zap.NewDevelopment()

--- a/test/kongintegration/expression_router_test.go
+++ b/test/kongintegration/expression_router_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator/atc"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/kongintegration/containers"
 )
@@ -32,7 +33,7 @@ func TestExpressionsRouterMatchers_GenerateValidExpressions(t *testing.T) {
 	ctx := context.Background()
 
 	kongC := containers.NewKong(ctx, t)
-	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), config.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 
 	httpBinC := containers.NewHTTPBin(ctx, t)

--- a/test/kongintegration/inmemory_update_strategy_test.go
+++ b/test/kongintegration/inmemory_update_strategy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/failures"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/kongintegration/containers"
 )
 
@@ -38,7 +39,7 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 	ctx := context.Background()
 
 	kongC := containers.NewKong(ctx, t)
-	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), config.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 
 	logbase, err := zap.NewDevelopment()

--- a/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/kongintegration/containers"
@@ -65,7 +66,7 @@ func TestKongClientGoldenTestsOutputs(t *testing.T) {
 
 		kongC := containers.NewKong(ctx, t, containers.KongWithRouterFlavor("expressions"))
 
-		kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")
+		kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), config.AdminAPIClientConfig{}, "")
 		require.NoError(t, err)
 
 		for _, goldenTestOutputPath := range expressionRoutesOutputsPaths {
@@ -79,7 +80,7 @@ func TestKongClientGoldenTestsOutputs(t *testing.T) {
 		t.Parallel()
 
 		kongC := containers.NewKong(ctx, t, containers.KongWithRouterFlavor("traditional"))
-		kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")
+		kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), config.AdminAPIClientConfig{}, "")
 		require.NoError(t, err)
 
 		for _, goldenTestOutputPath := range defaultOutputsPaths {

--- a/test/kongintegration/kongupstreampolicy_test.go
+++ b/test/kongintegration/kongupstreampolicy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/kongstate"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/kongintegration/containers"
 )
 
@@ -34,7 +35,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 	ctx := context.Background()
 
 	kongC := containers.NewKong(ctx, t)
-	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")
+	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), config.AdminAPIClientConfig{}, "")
 	require.NoError(t, err)
 	updateStrategy := sendconfig.NewUpdateStrategyInMemory(
 		kongClient,


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes public `manager.Manager` API for running KIC instances from external modules. Also, moves all remaining consts/structs that were part of the `managercfg.Config` struct to the public `config` package.  It's an initial step - things like health checks, unifying servers into one per process, etc. will come in the next PRs. 

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7040.
