### PR TITLE
chore: decouple health/readiness server from manager

### DIFF
--- a/internal/manager/health/health_check.go
+++ b/internal/manager/health/health_check.go
@@ -15,9 +15,9 @@ import (
 // initial kong clients, but we want the liveness probe be OK if
 // gateway discovery enabled, but 0 ready kong gateway endpoints detected.
 // https://github.com/Kong/kubernetes-ingress-controller/issues/3592
-// Furthermore, efforts to allow run controller code as a standalone instance
-// require health/readiness can be examined via Go API instead of HTTP, so
-// the server has to be decoupled from a manager.
+// Furthermore, efforts to allow running controller code as a standalone instance
+// require health/readiness examination via Go API instead of HTTP, so
+// the server has to be decoupled from the manager.
 // https://github.com/Kong/kubernetes-ingress-controller/issues/7044
 
 // TODO: let the manager not dependent on initial Kong clients

--- a/internal/manager/health/health_check.go
+++ b/internal/manager/health/health_check.go
@@ -20,10 +20,6 @@ import (
 // the server has to be decoupled from the manager.
 // https://github.com/Kong/kubernetes-ingress-controller/issues/7044
 
-// TODO: let the manager not dependent on initial Kong clients
-// then we could move back to the health check server inside manager:
-// https://github.com/Kong/kubernetes-ingress-controller/issues/3590
-
 // NewHealthCheckerFromFunc creates a new healthz.Checker from a function.
 func NewHealthCheckerFromFunc(check func() error) healthz.Checker {
 	return func(_ *http.Request) error {

--- a/internal/manager/health/health_check_test.go
+++ b/internal/manager/health/health_check_test.go
@@ -1,4 +1,4 @@
-package manager
+package health
 
 import (
 	"context"
@@ -56,9 +56,7 @@ func TestHealthCheckServer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := &healthCheckServer{}
-			h.setHealthzCheck(tc.healthzChecker)
-			h.setReadyzCheck(tc.readyzChecker)
+			h := NewHealthCheckServer(tc.healthzChecker, tc.readyzChecker)
 			s := httptest.NewServer(h)
 			defer s.Close()
 
@@ -76,8 +74,8 @@ func TestHealthCheckServer(t *testing.T) {
 }
 
 func TestHealthCheckServer_Start(t *testing.T) {
-	h := &healthCheckServer{}
-	h.setHealthzCheck(healthz.Ping)
+	// Parameter readyzChecker healthz.Checker does not matter for this test.
+	h := NewHealthCheckServer(healthz.Ping, nil)
 
 	// Get free local port.
 	port := helpers.GetFreePort(t)

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -60,6 +60,11 @@ type Manager struct {
 // Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
 // It should be called only once per Manager instance.
 func (m *Manager) Run(ctx context.Context) error {
+	defer func() {
+		if m.stopAnonymousReports != nil {
+			m.stopAnonymousReports()
+		}
+	}()
 	return m.m.Start(ctx)
 }
 
@@ -78,17 +83,6 @@ func (m *Manager) IsReady() error {
 	default:
 	}
 	return nil
-}
-
-// StopAnonymousReports stops the telemetry reporting. It's caller responsibility to call it when
-// the manager is no longer needed. It's safe to call it multiple times, when the telemetry
-// was not configured, or when the manager is already stopped (it will be no-op).
-// It makes sense to call it only after Run(ctx) method.
-func (m *Manager) StopAnonymousReports() {
-	if m.stopAnonymousReports != nil {
-		m.stopAnonymousReports()
-	}
-	m.stopAnonymousReports = nil
 }
 
 // New configures the controller manager call Start.

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -57,34 +57,6 @@ type Manager struct {
 	stopAnonymousReports func()
 }
 
-// Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
-// It should be called only once per Manager instance.
-func (m *Manager) Run(ctx context.Context) error {
-	defer func() {
-		if m.stopAnonymousReports != nil {
-			m.stopAnonymousReports()
-		}
-	}()
-	return m.m.Start(ctx)
-}
-
-// IsReady checks if the controller manager is ready to manage resources.
-// It's only valid to call this method after the controller manager has been started
-// with method Run(ctx).
-func (m *Manager) IsReady() error {
-	select {
-	// If we're elected as leader then report readiness based on the readiness
-	// of dataplane synchronizer.
-	case <-m.m.Elected():
-		if !m.synchronizer.IsReady() {
-			return errors.New("synchronizer not yet configured")
-		}
-	// If we're not the leader then just report as ready.
-	default:
-	}
-	return nil
-}
-
 // New configures the controller manager call Start.
 func New(
 	ctx context.Context,
@@ -513,4 +485,32 @@ func startDiagnosticsServer(
 		}
 	}()
 	return s
+}
+
+// Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
+// It should be called only once per Manager instance.
+func (m *Manager) Run(ctx context.Context) error {
+	defer func() {
+		if m.stopAnonymousReports != nil {
+			m.stopAnonymousReports()
+		}
+	}()
+	return m.m.Start(ctx)
+}
+
+// IsReady checks if the controller manager is ready to manage resources.
+// It's only valid to call this method after the controller manager has been started
+// with method Run(ctx).
+func (m *Manager) IsReady() error {
+	select {
+	// If we're elected as leader then report readiness based on the readiness
+	// of dataplane synchronizer.
+	case <-m.m.Elected():
+		if !m.synchronizer.IsReady() {
+			return errors.New("synchronizer not yet configured")
+		}
+	// If we're not the leader then just report as ready.
+	default:
+	}
+	return nil
 }

--- a/internal/util/test/controller_manager.go
+++ b/internal/util/test/controller_manager.go
@@ -136,8 +136,13 @@ func DeployControllerManagerForCluster(
 	go func() {
 		defer os.Remove(kubeconfig.Name())
 		fmt.Fprintf(os.Stderr, "INFO: Starting Controller Manager for Cluster %s with Configuration: %+v\n", cluster.Name(), clicfg)
-		if err := manager.Run(ctx, *clicfg.Config, logger); err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: Problems with Controller Manager: %s\n", err)
+		m, err := manager.New(ctx, *clicfg.Config, logger)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Problems with set up of Controller Manager: %s\n", err)
+			os.Exit(1)
+		}
+		if err := m.Run(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Problems with running Controller Manager: %s\n", err)
 			os.Exit(1)
 		}
 	}()

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -18,6 +18,26 @@ type Manager struct {
 	manager *managerinternal.Manager
 }
 
+// NewManager creates a new instance of the Kong Ingress Controller. It does not start the controller.
+func NewManager(ctx context.Context, id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
+	cfg, err := NewConfig(configOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager config: %w", err)
+	}
+
+	m, err := managerinternal.New(ctx, cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	return &Manager{
+		id:      id,
+		config:  cfg,
+		logger:  logger.WithValues("managerID", id.String()),
+		manager: m,
+	}, nil
+}
+
 // Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
 // It should be called only once per Manager instance.
 func (m *Manager) Run(ctx context.Context) error {
@@ -39,24 +59,4 @@ func (m *Manager) ID() ID {
 // Config returns the configuration of the manager.
 func (m *Manager) Config() managercfg.Config {
 	return m.config
-}
-
-// NewManager creates a new instance of the Kong Ingress Controller. It does not start the controller.
-func NewManager(ctx context.Context, id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
-	cfg, err := NewConfig(configOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create manager config: %w", err)
-	}
-
-	m, err := managerinternal.New(ctx, cfg, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create manager: %w", err)
-	}
-
-	return &Manager{
-		id:      id,
-		config:  cfg,
-		logger:  logger.WithValues("managerID", id.String()),
-		manager: m,
-	}, nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -10,31 +10,54 @@ import (
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
-// Manager is an object representing an instance of the Kong Ingress Controller.
-type Manager struct {
-	id     ID
-	config managercfg.Config
-	logger logr.Logger
-}
-
 // NewManager creates a new instance of the Kong Ingress Controller. It does not start the controller.
-func NewManager(id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
+func NewManager(ctx context.Context, id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
 	cfg, err := NewConfig(configOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager config: %w", err)
 	}
 
+	m, err := managerinternal.New(ctx, cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager: %w", err)
+	}
+
 	return &Manager{
-		id:     id,
-		config: cfg,
-		logger: logger.WithValues("managerID", id.String()),
+		id:      id,
+		config:  cfg,
+		logger:  logger.WithValues("managerID", id.String()),
+		manager: m,
 	}, nil
+}
+
+// Manager is an object representing an instance of the Kong Ingress Controller.
+type Manager struct {
+	id      ID
+	config  managercfg.Config
+	logger  logr.Logger
+	manager *managerinternal.Manager
 }
 
 // Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
 // It should be called only once per Manager instance.
 func (m *Manager) Run(ctx context.Context) error {
-	return managerinternal.Run(ctx, m.config, m.logger)
+	defer m.manager.StopAnonymousReports()
+	return m.manager.Run(ctx)
 }
 
-// TODO(czeslavo): expose healthcheck/readiness check methods from the manager
+// IsReady checks if the controller manager is ready to manage resources.
+// It's only valid to call this method after the controller manager has been started
+// with method Run(ctx).
+func (m *Manager) IsReady() error {
+	return m.manager.IsReady()
+}
+
+// ID returns the unique identifier of the manager.
+func (m *Manager) ID() ID {
+	return m.id
+}
+
+// Config returns the configuration of the manager.
+func (m *Manager) Config() managercfg.Config {
+	return m.config
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -10,26 +10,6 @@ import (
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
-// NewManager creates a new instance of the Kong Ingress Controller. It does not start the controller.
-func NewManager(ctx context.Context, id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
-	cfg, err := NewConfig(configOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create manager config: %w", err)
-	}
-
-	m, err := managerinternal.New(ctx, cfg, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create manager: %w", err)
-	}
-
-	return &Manager{
-		id:      id,
-		config:  cfg,
-		logger:  logger.WithValues("managerID", id.String()),
-		manager: m,
-	}, nil
-}
-
 // Manager is an object representing an instance of the Kong Ingress Controller.
 type Manager struct {
 	id      ID
@@ -41,7 +21,6 @@ type Manager struct {
 // Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
 // It should be called only once per Manager instance.
 func (m *Manager) Run(ctx context.Context) error {
-	defer m.manager.StopAnonymousReports()
 	return m.manager.Run(ctx)
 }
 
@@ -60,4 +39,24 @@ func (m *Manager) ID() ID {
 // Config returns the configuration of the manager.
 func (m *Manager) Config() managercfg.Config {
 	return m.config
+}
+
+// NewManager creates a new instance of the Kong Ingress Controller. It does not start the controller.
+func NewManager(ctx context.Context, id ID, logger logr.Logger, configOpts ...managercfg.Opt) (*Manager, error) {
+	cfg, err := NewConfig(configOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager config: %w", err)
+	}
+
+	m, err := managerinternal.New(ctx, cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	return &Manager{
+		id:      id,
+		config:  cfg,
+		logger:  logger.WithValues("managerID", id.String()),
+		manager: m,
+	}, nil
 }

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -111,8 +111,10 @@ func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = managerinternal.Run(ctx, cfg, logger)
-	require.ErrorContains(t, err, "timed out waiting for cache to be synced")
+	m, err := managerinternal.New(ctx, cfg, logger)
+	require.NoError(t, err)
+
+	require.ErrorContains(t, m.Run(ctx), "timed out waiting for cache to be synced")
 }
 
 func TestCRDValidations(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7044

**Special notes for your reviewer:**

The only run everywhere called should be [this one](https://github.com/Kong/kubernetes-ingress-controller/blob/95639d67f8d62992cfad3a51d38004f19306935f/pkg/manager/manager.go) the internal package should be only used in this import. I'm happy to address it in a separate PR. I think that in such a case ID can be hard coded to e.g. `KIC-classic`.

Further telemetry adjustments should be addressed in https://github.com/Kong/kubernetes-ingress-controller/issues/7038?issue=Kong%7Ckubernetes-ingress-controller%7C7048

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

