### PR TITLE
chore: ensure logger is passed down

### DIFF
--- a/internal/clients/manager.go
+++ b/internal/clients/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
@@ -100,7 +101,6 @@ func (c *AdminAPIClientsManager) WithReconciliationInterval(d time.Duration) *Ad
 
 func NewAdminAPIClientsManager(
 	ctx context.Context,
-	logger logr.Logger,
 	initialClients []*adminapi.Client,
 	readinessChecker ReadinessChecker,
 	opts ...AdminAPIClientsManagerOption,
@@ -121,7 +121,7 @@ func NewAdminAPIClientsManager(
 		discoveredAdminAPIsNotifyChan:   make(chan []adminapi.DiscoveredAdminAPI),
 		ctx:                             ctx,
 		runningChan:                     make(chan struct{}),
-		logger:                          logger,
+		logger:                          ctrl.LoggerFrom(ctx),
 	}
 
 	for _, opt := range opts {

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -8,12 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
@@ -95,13 +93,11 @@ func TestAdminAPIClientsManager_OnNotifyClientsAreUpdatedAccordingly(t *testing.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := zapr.NewLogger(zap.NewNop())
 	readinessChecker := &mockReadinessChecker{}
 	initialClient, err := adminapi.NewTestClient("https://localhost:8083")
 	require.NoError(t, err)
 	manager, err := clients.NewAdminAPIClientsManager(
 		ctx,
-		logger,
 		[]*adminapi.Client{initialClient},
 		readinessChecker,
 	)
@@ -166,7 +162,6 @@ func TestAdminAPIClientsManager_OnNotifyClientsAreUpdatedAccordingly(t *testing.
 func TestNewAdminAPIClientsManager_NoInitialClientsDisallowed(t *testing.T) {
 	_, err := clients.NewAdminAPIClientsManager(
 		context.Background(),
-		zapr.NewLogger(zap.NewNop()),
 		nil,
 		&mockReadinessChecker{},
 	)
@@ -180,7 +175,6 @@ func TestAdminAPIClientsManager_NotRunningNotifyLoop(t *testing.T) {
 	require.NoError(t, err)
 	m, err := clients.NewAdminAPIClientsManager(
 		context.Background(),
-		zapr.NewLogger(zap.NewNop()),
 		[]*adminapi.Client{testClient},
 		&mockReadinessChecker{},
 	)
@@ -200,7 +194,6 @@ func TestAdminAPIClientsManager_Clients(t *testing.T) {
 	require.NoError(t, err)
 	m, err := clients.NewAdminAPIClientsManager(
 		context.Background(),
-		zapr.NewLogger(zap.NewNop()),
 		[]*adminapi.Client{testClient},
 		&mockReadinessChecker{},
 	)
@@ -220,7 +213,6 @@ func TestAdminAPIClientsManager_Clients_DBMode(t *testing.T) {
 
 	m, err := clients.NewAdminAPIClientsManager(
 		context.Background(),
-		zapr.NewLogger(zap.NewNop()),
 		initialClients,
 		&mockReadinessChecker{},
 	)
@@ -254,7 +246,6 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	m, err := clients.NewAdminAPIClientsManager(
 		ctx,
-		zapr.NewLogger(zap.NewNop()),
 		[]*adminapi.Client{testClient},
 		readinessChecker)
 
@@ -346,7 +337,7 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	m, err := clients.NewAdminAPIClientsManager(ctx, zapr.NewLogger(zap.NewNop()), []*adminapi.Client{testClient}, readinessChecker)
+	m, err := clients.NewAdminAPIClientsManager(ctx, []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
 	m.Run()
 
@@ -385,7 +376,7 @@ func TestAdminAPIClientsManager_GatewayClientsChanges(t *testing.T) {
 	readinessChecker := &mockReadinessChecker{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	m, err := clients.NewAdminAPIClientsManager(ctx, zapr.NewLogger(zap.NewNop()), []*adminapi.Client{testClient}, readinessChecker)
+	m, err := clients.NewAdminAPIClientsManager(ctx, []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
 
 	m.Run()
@@ -485,13 +476,7 @@ func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
 	readinessChecker := &mockReadinessChecker{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	m, err := clients.NewAdminAPIClientsManager(
-		ctx,
-		zapr.NewLogger(zap.NewNop()),
-		[]*adminapi.Client{testClient},
-		readinessChecker,
-		clients.WithReadinessReconciliationTicker(readinessTicker),
-	)
+	m, err := clients.NewAdminAPIClientsManager(ctx, []*adminapi.Client{testClient}, readinessChecker, clients.WithReadinessReconciliationTicker(readinessTicker))
 	require.NoError(t, err)
 	m.Run()
 	<-m.Running()

--- a/internal/cmd/rootcmd/run.go
+++ b/internal/cmd/rootcmd/run.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"os/signal"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
@@ -18,7 +16,6 @@ func Run(ctx context.Context, c managercfg.Config, output io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
-	ctx = ctrl.LoggerInto(ctx, logger)
 
 	ctx, err = SetupSignalHandler(ctx, c, logger)
 	if err != nil {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -58,12 +58,16 @@ func Run(
 	c managercfg.Config,
 	logger logr.Logger,
 ) error {
+	// Inject logger into the context so it can be used by the controllers and other components without
+	// passing it explicitly when they accept a context.
+	ctx = ctrl.LoggerInto(ctx, logger)
+
 	if err := c.Validate(); err != nil {
 		return fmt.Errorf("config invalid: %w", err)
 	}
 
-	diagnosticsServer := startDiagnosticsServer(ctx, c.DiagnosticServerPort, c, logger)
-	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
+	diagnosticsServer := startDiagnosticsServer(ctx, c.DiagnosticServerPort, c)
+	setupLog := logger.WithName("setup")
 	setupLog.Info("Starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
 	setupLog.Info("The ingress class name has been set", "value", c.IngressClassName)
 
@@ -167,7 +171,6 @@ func Run(
 	readinessChecker := clients.NewDefaultReadinessChecker(adminAPIClientsFactory, c.GatewayDiscoveryReadinessCheckTimeout, setupLog.WithName("readiness-checker"))
 	clientsManager, err := clients.NewAdminAPIClientsManager(
 		ctx,
-		logger,
 		initialKongClients,
 		readinessChecker,
 	)
@@ -201,7 +204,7 @@ func Run(
 	}
 
 	setupLog.Info("Starting Admission Server")
-	if err := setupAdmissionServer(ctx, c, clientsManager, referenceIndexers, mgr.GetClient(), logger, translatorFeatureFlags, storer); err != nil {
+	if err := setupAdmissionServer(ctx, c, clientsManager, referenceIndexers, mgr.GetClient(), translatorFeatureFlags, storer); err != nil {
 		return err
 	}
 
@@ -339,7 +342,6 @@ func Run(
 	if c.AnonymousReports {
 		stopAnonymousReports, err := telemetry.SetupAnonymousReports(
 			ctx,
-			logger.WithName("telemetry"),
 			kubeconfig,
 			clientsManager,
 			telemetry.ReportConfig{
@@ -464,8 +466,8 @@ func startDiagnosticsServer(
 	ctx context.Context,
 	port int,
 	c managercfg.Config,
-	logger logr.Logger,
 ) diagnostics.Server {
+	logger := ctrl.LoggerFrom(ctx)
 	if !c.EnableProfiling && !c.EnableConfigDumps {
 		logger.Info("Diagnostics server disabled")
 		return diagnostics.Server{}

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -217,14 +217,13 @@ func setupAdmissionServer(
 	clientsManager *clients.AdminAPIClientsManager,
 	referenceIndexers ctrlref.CacheIndexers,
 	managerClient client.Client,
-	logger logr.Logger,
 	translatorFeatures translator.FeatureFlags,
 	storer store.Storer,
 ) error {
-	admissionLogger := logger.WithName("admission-server")
+	admissionLogger := ctrl.LoggerFrom(ctx).WithName("admission-server")
 
 	if managerConfig.AdmissionServer.ListenAddr == "off" {
-		logger.Info("Admission webhook server disabled")
+		admissionLogger.Info("Admission webhook server disabled")
 		return nil
 	}
 
@@ -246,7 +245,7 @@ func setupAdmissionServer(
 	}
 	go func() {
 		err := srv.ListenAndServeTLS("", "")
-		logger.Error(err, "Admission webhook server stopped")
+		admissionLogger.Error(err, "Admission webhook server stopped")
 	}()
 	return nil
 }

--- a/internal/manager/telemetry/reports.go
+++ b/internal/manager/telemetry/reports.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/kong/go-kong/kong"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/metadata"
@@ -44,12 +44,13 @@ type ReportConfig struct {
 // error is not nil - to stop the reports sending.
 func SetupAnonymousReports(
 	ctx context.Context,
-	logger logr.Logger,
 	kubeCfg *rest.Config,
 	clientsProvider GatewayClientsProvider,
 	reportCfg ReportConfig,
 	instanceIDProvider InstanceIDProvider,
 ) (func(), error) {
+	logger := ctrl.LoggerFrom(ctx).WithName("telemetry")
+
 	// if anonymous reports are enabled this helps provide Kong with insights about usage of the ingress controller
 	// which is non-sensitive and predominantly informs us of the controller and cluster versions in use.
 	// This data helps inform us what versions, features, e.t.c. end-users are actively using which helps to inform


### PR DESCRIPTION
**What this PR does / why we need it**:

Where possible, it leverages `ctrl.LoggerFrom(ctx)` instead of passing the logger explicitly. Besides that, there was no further improvement needed to pass the parent logger down.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7045.
