### PR TITLE
chore: decouple diagnostics server from collector and handlers

### DIFF
--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/sendconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/translator"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
@@ -300,7 +299,6 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 	kongClient, err := NewKongClient(
 		logger,
 		timeout,
-		diagnostics.ClientDiagnostic{},
 		cfg,
 		mocks.NewEventRecorder(),
 		dpconf.DBModeOff, // Test will run in DB-less mode only for now. In the future, we may want to test DB mode as well.

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -1033,7 +1033,7 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 				&originalCache,
 				fallbackConfigGenerator,
 				mocks.MetricsRecorder{},
-				WithDiagnosticClient(diagnostics.Client{
+				WithDiagnosticsClient(diagnostics.Client{
 					Configs: diagnosticsCh,
 				}),
 			)
@@ -1167,7 +1167,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 		&originalCache,
 		fallbackConfigGenerator,
 		mocks.MetricsRecorder{},
-		WithDiagnosticClient(diagnostics.Client{
+		WithDiagnosticsClient(diagnostics.Client{
 			Configs: diagnosticsCh,
 		}),
 	)
@@ -1312,7 +1312,7 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 		&originalCache,
 		fallbackConfigGenerator,
 		mocks.MetricsRecorder{},
-		WithDiagnosticClient(diagnostics.Client{
+		WithDiagnosticsClient(diagnostics.Client{
 			Configs: diagnosticsCh,
 		}),
 	)

--- a/internal/dataplane/sendconfig/dbmode.go
+++ b/internal/dataplane/sendconfig/dbmode.go
@@ -31,7 +31,7 @@ type UpdateStrategyDBMode struct {
 	dumpConfig        dump.Config
 	version           semver.Version
 	concurrency       int
-	diagnostic        *diagnostics.ClientDiagnostic
+	diagnostic        *diagnostics.Client
 	isKonnect         bool
 	logger            logr.Logger
 	resourceErrors    []ResourceError
@@ -42,7 +42,7 @@ type UpdateStrategyDBMode struct {
 type UpdateStrategyDBModeOpt func(*UpdateStrategyDBMode)
 
 // WithDiagnostic sets the diagnostic server to send diffs to.
-func WithDiagnostic(diagnostic *diagnostics.ClientDiagnostic) UpdateStrategyDBModeOpt {
+func WithDiagnostic(diagnostic *diagnostics.Client) UpdateStrategyDBModeOpt {
 	return func(s *UpdateStrategyDBMode) {
 		s.diagnostic = diagnostic
 	}
@@ -137,7 +137,7 @@ func (s *UpdateStrategyDBMode) Update(ctx context.Context, targetContent Content
 func (s *UpdateStrategyDBMode) HandleEvents(
 	ctx context.Context,
 	events chan diff.EntityAction,
-	diagnostic *diagnostics.ClientDiagnostic,
+	diagnostic *diagnostics.Client,
 	hash string,
 ) {
 	s.resourceErrorLock.Lock()

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -23,7 +23,7 @@ import (
 // -----------------------------------------------------------------------------
 
 type UpdateStrategyResolver interface {
-	ResolveUpdateStrategy(client UpdateClient, diagnostic *diagnostics.ClientDiagnostic) UpdateStrategy
+	ResolveUpdateStrategy(client UpdateClient, diagnostic *diagnostics.Client) UpdateStrategy
 }
 
 type AdminAPIClient interface {
@@ -49,7 +49,7 @@ func PerformUpdate(
 	promMetrics metrics.Recorder,
 	updateStrategyResolver UpdateStrategyResolver,
 	configChangeDetector ConfigurationChangeDetector,
-	diagnostic *diagnostics.ClientDiagnostic,
+	diagnostic *diagnostics.Client,
 	isFallback bool,
 ) ([]byte, error) {
 	oldSHA := client.LastConfigSHA()

--- a/internal/dataplane/sendconfig/strategy.go
+++ b/internal/dataplane/sendconfig/strategy.go
@@ -81,7 +81,7 @@ func NewDefaultUpdateStrategyResolver(config Config, logger logr.Logger) Default
 // with the backoff strategy it provides.
 func (r DefaultUpdateStrategyResolver) ResolveUpdateStrategy(
 	client UpdateClient,
-	diagnostic *diagnostics.ClientDiagnostic,
+	diagnostic *diagnostics.Client,
 ) UpdateStrategy {
 	updateStrategy := r.resolveUpdateStrategy(client, diagnostic)
 
@@ -94,7 +94,7 @@ func (r DefaultUpdateStrategyResolver) ResolveUpdateStrategy(
 
 func (r DefaultUpdateStrategyResolver) resolveUpdateStrategy(
 	client UpdateClient,
-	diagnostic *diagnostics.ClientDiagnostic,
+	diagnostic *diagnostics.Client,
 ) UpdateStrategy {
 	adminAPIClient := client.AdminAPIClient()
 

--- a/internal/diagnostics/collector.go
+++ b/internal/diagnostics/collector.go
@@ -1,0 +1,201 @@
+package diagnostics
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/samber/mo"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
+	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+)
+
+const (
+	// diagnosticConfigBufferDepth is the size of the channel buffer for receiving diagnostic
+	// config dumps from the proxy sync loop. The chosen size is essentially arbitrary: we don't
+	// expect that the receive end will get backlogged (it only assigns the value to a local
+	// variable) but do want a small amount of leeway to account for goroutine scheduling, so it
+	// is not zero.
+	diagnosticConfigBufferDepth = 3
+
+	// diffHistorySize is the number of diffs to keep in history.
+	diffHistorySize = 5
+
+	// diffHashQuery is the query string key for requesting a specific hash's diff.
+	diffHashQuery = "hash"
+)
+
+// Collector collects diagnostic information from the proxy sync loop via Client it returns from Client()
+// method. It can be queried for everything it collects as it implements the ConfigDiagnosticsProvider interface.
+type Collector struct {
+	logger logr.Logger
+
+	clientDiagnostic Client
+
+	lastSuccessfulConfigDump file.Content
+	lastSuccessHash          string
+
+	lastFailedConfigDump file.Content
+	lastFailedHash       string
+	lastRawErrBody       []byte
+
+	currentFallbackCacheMetadata mo.Option[fallback.GeneratedCacheMetadata]
+
+	diffs diffMap
+
+	configLock   sync.RWMutex
+	fallbackLock sync.RWMutex
+	diffLock     sync.RWMutex
+}
+
+func NewCollector(logger logr.Logger, cfg managercfg.Config) *Collector {
+	return &Collector{
+		logger: logger,
+		diffs:  newDiffMap(diffHistorySize),
+		clientDiagnostic: Client{
+			DumpsIncludeSensitive: cfg.DumpSensitiveConfig,
+			Configs:               make(chan ConfigDump, diagnosticConfigBufferDepth),
+			FallbackCacheMetadata: make(chan fallback.GeneratedCacheMetadata, diagnosticConfigBufferDepth),
+			Diffs:                 make(chan ConfigDiff, diagnosticConfigBufferDepth),
+		},
+	}
+}
+
+// Start starts the diagnostic collection loop. It will block until the context is done.
+func (s *Collector) Start(ctx context.Context) error {
+	return s.receiveDiagnostics(ctx)
+}
+
+// Client returns an object allowing dumping succeeded and failed configuration updates.
+func (s *Collector) Client() Client {
+	return s.clientDiagnostic
+}
+
+// LastSuccessfulConfigDump returns the last successful configuration dump.
+func (s *Collector) LastSuccessfulConfigDump() (file.Content, string, bool) {
+	s.configLock.RLock()
+	defer s.configLock.RUnlock()
+
+	if s.lastSuccessHash != "" {
+		return *s.lastSuccessfulConfigDump.DeepCopy(), s.lastSuccessHash, true
+	}
+	return file.Content{}, "", false
+}
+
+// LastFailedConfigDump returns the last failed configuration dump.
+func (s *Collector) LastFailedConfigDump() (file.Content, string, bool) {
+	s.configLock.RLock()
+	defer s.configLock.RUnlock()
+
+	if s.lastFailedHash != "" {
+		return *s.lastFailedConfigDump.DeepCopy(), s.lastFailedHash, true
+	}
+	return file.Content{}, "", false
+}
+
+// LastErrorBody returns the raw error body of the last failed configuration push.
+func (s *Collector) LastErrorBody() ([]byte, bool) {
+	s.configLock.RLock()
+	defer s.configLock.RUnlock()
+
+	if s.lastRawErrBody != nil {
+		return s.lastRawErrBody, true
+	}
+	return nil, false
+}
+
+// CurrentFallbackCacheMetadata returns the current fallback cache metadata.
+func (s *Collector) CurrentFallbackCacheMetadata() mo.Option[fallback.GeneratedCacheMetadata] {
+	s.fallbackLock.RLock()
+	defer s.fallbackLock.RUnlock()
+
+	return s.currentFallbackCacheMetadata
+}
+
+// LastConfigDiffHash returns the hash of the last config diff.
+func (s *Collector) LastConfigDiffHash() string {
+	s.diffLock.RLock()
+	defer s.diffLock.RUnlock()
+
+	return s.diffs.Latest()
+}
+
+// ConfigDiffByHash returns the config diff by hash.
+func (s *Collector) ConfigDiffByHash(hash string) (ConfigDiff, bool) {
+	s.diffLock.RLock()
+	defer s.diffLock.RUnlock()
+
+	return s.diffs.ByHash(hash)
+}
+
+// AvailableConfigDiffsHashes returns the hashes of available config diffs.
+func (s *Collector) AvailableConfigDiffsHashes() []DiffIndex {
+	s.diffLock.RLock()
+	defer s.diffLock.RUnlock()
+
+	return s.diffs.Available()
+}
+
+// receiveDiagnostics watches the diagnostic update channels.
+func (s *Collector) receiveDiagnostics(ctx context.Context) error {
+	for {
+		select {
+		case dump := <-s.clientDiagnostic.Configs:
+			s.onConfigDump(dump)
+		case meta := <-s.clientDiagnostic.FallbackCacheMetadata:
+			s.onFallbackCacheMetadata(meta)
+		case diff := <-s.clientDiagnostic.Diffs:
+			s.onDiff(diff)
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+				s.logger.Error(err, "Shutting down diagnostic collection: context completed with error")
+				return err
+			}
+			s.logger.V(logging.InfoLevel).Info("Shutting down diagnostic collection: context completed")
+			return nil
+		}
+	}
+}
+
+// onConfigDump handles a new configuration dump.
+func (s *Collector) onConfigDump(dump ConfigDump) {
+	s.configLock.Lock()
+	defer s.configLock.Unlock()
+
+	if dump.Meta.Failed {
+		// If the config push failed, we need to keep the failed config dump and the raw error body.
+		s.lastFailedConfigDump = dump.Config
+		s.lastFailedHash = dump.Meta.Hash
+		s.lastRawErrBody = dump.RawResponseBody
+	} else {
+		// If the config push was successful, we need to keep successful config dump and the hash.
+		s.lastSuccessfulConfigDump = dump.Config
+		s.lastSuccessHash = dump.Meta.Hash
+
+		// If the regular config push was successful, we can drop the fallback cache metadata as it is
+		// no longer relevant.
+		if !dump.Meta.Fallback {
+			s.fallbackLock.Lock()
+			s.currentFallbackCacheMetadata = mo.None[fallback.GeneratedCacheMetadata]()
+			s.fallbackLock.Unlock()
+		}
+	}
+}
+
+// onFallbackCacheMetadata handles a new fallback cache metadata.
+func (s *Collector) onFallbackCacheMetadata(meta fallback.GeneratedCacheMetadata) {
+	s.fallbackLock.Lock()
+	defer s.fallbackLock.Unlock()
+	s.currentFallbackCacheMetadata = mo.Some(meta)
+}
+
+// onDiff handles a new configuration diff.
+func (s *Collector) onDiff(diff ConfigDiff) {
+	s.diffLock.Lock()
+	defer s.diffLock.Unlock()
+	s.diffs.Update(diff)
+}

--- a/internal/diagnostics/collector_test.go
+++ b/internal/diagnostics/collector_test.go
@@ -1,0 +1,71 @@
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+)
+
+func TestCollector_EventsHandling(t *testing.T) {
+	successfulDump := ConfigDump{
+		Meta: DumpMeta{
+			Failed:   false,
+			Fallback: false,
+			Hash:     "success-hash",
+		},
+		Config: file.Content{
+			FormatVersion: "success", // Just for the sake of distinguishing between success and failure.
+		},
+	}
+	failedDump := ConfigDump{
+		Config: file.Content{
+			FormatVersion: "failed", // Just for the sake of distinguishing between success and failure.
+		},
+		Meta: DumpMeta{
+			Failed:   true,
+			Fallback: false,
+		},
+		RawResponseBody: []byte("error body"),
+	}
+	fallbackMeta := fallback.GeneratedCacheMetadata{
+		BrokenObjects: []fallback.ObjectHash{
+			{
+				Name: "object",
+			},
+		},
+	}
+
+	c := NewCollector(logr.Discard(), managercfg.Config{
+		DumpSensitiveConfig: true,
+	})
+	t.Run("on successful config dump", func(t *testing.T) {
+		c.onConfigDump(successfulDump)
+		require.Equal(t, successfulDump.Config, c.lastSuccessfulConfigDump)
+		require.Equal(t, successfulDump.Meta.Hash, c.lastSuccessHash)
+	})
+	t.Run("on failed config dump", func(t *testing.T) {
+		c.onConfigDump(failedDump)
+		require.Equal(t, failedDump.Config, c.lastFailedConfigDump)
+		require.Equal(t, failedDump.Meta.Hash, c.lastFailedHash)
+		require.Equal(t, failedDump.RawResponseBody, c.lastRawErrBody)
+	})
+	t.Run("on fallback cache metadata", func(t *testing.T) {
+		c.onFallbackCacheMetadata(fallbackMeta)
+		require.NotNilf(t, c.currentFallbackCacheMetadata, "expected fallback cache metadata to be set")
+		meta, ok := c.currentFallbackCacheMetadata.Get()
+		require.True(t, ok)
+		require.Equal(t, fallbackMeta, meta)
+	})
+	t.Run("on successful config dump after fallback", func(t *testing.T) {
+		c.onConfigDump(successfulDump)
+		require.Equal(t, successfulDump.Config, c.lastSuccessfulConfigDump)
+		require.Equal(t, successfulDump.Meta.Hash, c.lastSuccessHash)
+		require.Equal(t, mo.None[fallback.GeneratedCacheMetadata](), c.currentFallbackCacheMetadata, "expected fallback cache metadata to be dropped as it'c no more relevant")
+	})
+}

--- a/internal/diagnostics/collector_test.go
+++ b/internal/diagnostics/collector_test.go
@@ -46,12 +46,12 @@ func TestCollector_EventsHandling(t *testing.T) {
 	})
 	t.Run("on successful config dump", func(t *testing.T) {
 		c.onConfigDump(successfulDump)
-		require.Equal(t, successfulDump.Config, c.lastSuccessfulConfigDump)
+		require.Equal(t, mo.Some(successfulDump.Config), c.lastSuccessfulConfigDump)
 		require.Equal(t, successfulDump.Meta.Hash, c.lastSuccessHash)
 	})
 	t.Run("on failed config dump", func(t *testing.T) {
 		c.onConfigDump(failedDump)
-		require.Equal(t, failedDump.Config, c.lastFailedConfigDump)
+		require.Equal(t, mo.Some(failedDump.Config), c.lastFailedConfigDump)
 		require.Equal(t, failedDump.Meta.Hash, c.lastFailedHash)
 		require.Equal(t, failedDump.RawResponseBody, c.lastRawErrBody)
 	})
@@ -64,7 +64,7 @@ func TestCollector_EventsHandling(t *testing.T) {
 	})
 	t.Run("on successful config dump after fallback", func(t *testing.T) {
 		c.onConfigDump(successfulDump)
-		require.Equal(t, successfulDump.Config, c.lastSuccessfulConfigDump)
+		require.Equal(t, mo.Some(successfulDump.Config), c.lastSuccessfulConfigDump)
 		require.Equal(t, successfulDump.Meta.Hash, c.lastSuccessHash)
 		require.Equal(t, mo.None[fallback.GeneratedCacheMetadata](), c.currentFallbackCacheMetadata, "expected fallback cache metadata to be dropped as it'c no more relevant")
 	})

--- a/internal/diagnostics/diff.go
+++ b/internal/diagnostics/diff.go
@@ -2,13 +2,12 @@ package diagnostics
 
 import (
 	"container/list"
-	"fmt"
 
 	"github.com/kong/go-database-reconciler/pkg/diff"
 )
 
-// generatedEntity is basic name and type metadata about a Kong gateway entity.
-type generatedEntity struct {
+// GeneratedEntity is basic name and type metadata about a Kong gateway entity.
+type GeneratedEntity struct {
 	// Name is the name of the entity.
 	Name string `json:"name"`
 	// Kind is the type of entity.
@@ -26,7 +25,7 @@ type ConfigDiff struct {
 // EntityDiff is an individual entity change. It includes the entity metadata, the action performed during
 // reconciliation, and the diff string for update actions.
 type EntityDiff struct {
-	Generated generatedEntity `json:"kongEntity"`
+	Generated GeneratedEntity `json:"kongEntity"`
 	Action    string          `json:"action"`
 	Diff      string          `json:"diff,omitempty"`
 }
@@ -34,7 +33,7 @@ type EntityDiff struct {
 // NewEntityDiff creates a diagnostic entity diff.
 func NewEntityDiff(diff string, action string, entity diff.Entity) EntityDiff {
 	return EntityDiff{
-		Generated: generatedEntity{
+		Generated: GeneratedEntity{
 			Name: entity.Name,
 			Kind: entity.Kind,
 		},
@@ -89,11 +88,11 @@ func (d *diffMap) Latest() string {
 }
 
 // ByHash returns the diff array matching the given hash.
-func (d *diffMap) ByHash(hash string) ([]EntityDiff, error) {
+func (d *diffMap) ByHash(hash string) (ConfigDiff, bool) {
 	if diff, ok := d.diffs[hash]; ok {
-		return diff.Entities, nil
+		return diff, true
 	}
-	return []EntityDiff{}, fmt.Errorf("no diff found for hash %s", hash)
+	return ConfigDiff{}, false
 }
 
 // TimeByHash returns the diff timestamp matching the given hash.

--- a/internal/diagnostics/diff_test.go
+++ b/internal/diagnostics/diff_test.go
@@ -351,7 +351,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 		name       string
 		initial    diffMap
 		hash       string
-		expected   []EntityDiff
+		expected   ConfigDiff
 		shouldFail bool
 	}{
 		{
@@ -363,7 +363,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 				hashQueue: list.New(),
 			},
 			hash:       "hash1",
-			expected:   []EntityDiff{},
+			expected:   ConfigDiff{},
 			shouldFail: true,
 		},
 		{
@@ -380,7 +380,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 					Timestamp: now.Format(time.RFC3339),
 					Entities: []EntityDiff{
 						{
-							Generated: generatedEntity{Name: "entity1", Kind: "kind1"},
+							Generated: GeneratedEntity{Name: "entity1", Kind: "kind1"},
 							Action:    "create",
 							Diff:      "diff1",
 						},
@@ -389,11 +389,15 @@ func TestDiffMap_ByHash(t *testing.T) {
 				return dm
 			}(),
 			hash: "hash1",
-			expected: []EntityDiff{
-				{
-					Generated: generatedEntity{Name: "entity1", Kind: "kind1"},
-					Action:    "create",
-					Diff:      "diff1",
+			expected: ConfigDiff{
+				Hash:      "hash1",
+				Timestamp: now.Format(time.RFC3339),
+				Entities: []EntityDiff{
+					{
+						Generated: GeneratedEntity{Name: "entity1", Kind: "kind1"},
+						Action:    "create",
+						Diff:      "diff1",
+					},
 				},
 			},
 			shouldFail: false,
@@ -412,7 +416,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 					Timestamp: now.Format(time.RFC3339),
 					Entities: []EntityDiff{
 						{
-							Generated: generatedEntity{Name: "entity1", Kind: "kind1"},
+							Generated: GeneratedEntity{Name: "entity1", Kind: "kind1"},
 							Action:    "create",
 							Diff:      "diff1",
 						},
@@ -423,7 +427,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 					Timestamp: now.Format(time.RFC3339),
 					Entities: []EntityDiff{
 						{
-							Generated: generatedEntity{Name: "entity2", Kind: "kind2"},
+							Generated: GeneratedEntity{Name: "entity2", Kind: "kind2"},
 							Action:    "update",
 							Diff:      "diff2",
 						},
@@ -432,11 +436,15 @@ func TestDiffMap_ByHash(t *testing.T) {
 				return dm
 			}(),
 			hash: "hash2",
-			expected: []EntityDiff{
-				{
-					Generated: generatedEntity{Name: "entity2", Kind: "kind2"},
-					Action:    "update",
-					Diff:      "diff2",
+			expected: ConfigDiff{
+				Hash:      "hash2",
+				Timestamp: now.Format(time.RFC3339),
+				Entities: []EntityDiff{
+					{
+						Generated: GeneratedEntity{Name: "entity2", Kind: "kind2"},
+						Action:    "update",
+						Diff:      "diff2",
+					},
 				},
 			},
 			shouldFail: false,
@@ -455,7 +463,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 					Timestamp: now.Format(time.RFC3339),
 					Entities: []EntityDiff{
 						{
-							Generated: generatedEntity{Name: "entity1", Kind: "kind1"},
+							Generated: GeneratedEntity{Name: "entity1", Kind: "kind1"},
 							Action:    "create",
 							Diff:      "diff1",
 						},
@@ -466,7 +474,7 @@ func TestDiffMap_ByHash(t *testing.T) {
 					Timestamp: now.Format(time.RFC3339),
 					Entities: []EntityDiff{
 						{
-							Generated: generatedEntity{Name: "entity2", Kind: "kind2"},
+							Generated: GeneratedEntity{Name: "entity2", Kind: "kind2"},
 							Action:    "update",
 							Diff:      "diff2",
 						},
@@ -475,19 +483,19 @@ func TestDiffMap_ByHash(t *testing.T) {
 				return dm
 			}(),
 			hash:       "hash3",
-			expected:   []EntityDiff{},
+			expected:   ConfigDiff{},
 			shouldFail: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.initial.ByHash(tt.hash)
+			result, ok := tt.initial.ByHash(tt.hash)
 			if tt.shouldFail {
-				assert.Error(t, err)
+				assert.False(t, ok)
 				return
 			}
-			assert.NoError(t, err)
+			assert.True(t, ok)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/diagnostics/http_handler.go
+++ b/internal/diagnostics/http_handler.go
@@ -1,0 +1,168 @@
+package diagnostics
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/samber/mo"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+)
+
+// ConfigDiagnosticsProvider is an interface representing a provider of diagnostic information.
+type ConfigDiagnosticsProvider interface {
+	LastSuccessfulConfigDump() (file.Content, string, bool)
+	LastFailedConfigDump() (file.Content, string, bool)
+	LastErrorBody() ([]byte, bool)
+	CurrentFallbackCacheMetadata() mo.Option[fallback.GeneratedCacheMetadata]
+	LastConfigDiffHash() string
+	ConfigDiffByHash(string) (ConfigDiff, bool)
+	AvailableConfigDiffsHashes() []DiffIndex
+}
+
+// ConfigDiagnosticsHTTPHandler is a handler for the diagnostic HTTP endpoints.
+type ConfigDiagnosticsHTTPHandler struct {
+	diagnosticsProvider   ConfigDiagnosticsProvider
+	dumpsIncludeSensitive bool
+	mux                   *http.ServeMux
+}
+
+func NewConfigDiagnosticsHTTPHandler(diagnosticsProvider ConfigDiagnosticsProvider, dumpsIncludeSensitive bool) *ConfigDiagnosticsHTTPHandler {
+	h := &ConfigDiagnosticsHTTPHandler{
+		diagnosticsProvider:   diagnosticsProvider,
+		dumpsIncludeSensitive: dumpsIncludeSensitive,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/successful", h.handleLastValidConfig)
+	mux.HandleFunc("/failed", h.handleLastFailedConfig)
+	mux.HandleFunc("/fallback", h.handleCurrentFallback)
+	mux.HandleFunc("/raw-error", h.handleLastErrBody)
+	mux.HandleFunc("/diff-report", h.handleDiffReport)
+
+	h.mux = mux
+	return h
+}
+
+func (h *ConfigDiagnosticsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mux.ServeHTTP(w, r)
+}
+
+func (h *ConfigDiagnosticsHTTPHandler) handleLastValidConfig(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	config, configHash, ok := h.diagnosticsProvider.LastSuccessfulConfigDump()
+	if !ok {
+		rw.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err := json.NewEncoder(rw).Encode(
+		ConfigDumpResponse{
+			Config:     config,
+			ConfigHash: configHash,
+		}.Config); err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (h *ConfigDiagnosticsHTTPHandler) handleLastFailedConfig(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	config, configHash, ok := h.diagnosticsProvider.LastFailedConfigDump()
+	if !ok {
+		rw.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if err := json.NewEncoder(rw).Encode(
+		ConfigDumpResponse{
+			Config:     config,
+			ConfigHash: configHash,
+		}); err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (h *ConfigDiagnosticsHTTPHandler) handleCurrentFallback(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	fallbackCacheMeta := h.diagnosticsProvider.CurrentFallbackCacheMetadata()
+	resp := mapFallbackCacheMetadataIntoFallbackResponse(fallbackCacheMeta)
+	if err := json.NewEncoder(rw).Encode(resp); err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (h *ConfigDiagnosticsHTTPHandler) handleLastErrBody(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "text/plain")
+
+	errBody, ok := h.diagnosticsProvider.LastErrorBody()
+	if !ok || len(errBody) == 0 {
+		rw.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if _, err := rw.Write(errBody); err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (h *ConfigDiagnosticsHTTPHandler) handleDiffReport(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	// GDR has no notion of sensitive data, so its raw diffs will include credentials and certificates when they
+	// change. We could make this fancier by walking through the entity types to exclude them if sensitive is not
+	// enabled, but would need to maintain a list of such types. Filter would probably happen on the producer (DB
+	// update strategy) side, since that'h where we currently filter for the dump.
+	if !h.dumpsIncludeSensitive {
+		if err := json.NewEncoder(rw).Encode(DiffResponse{
+			Message: "diffs include sensitive data: set CONTROLLER_DUMP_SENSITIVE_CONFIG=true in environment to enable",
+		}); err == nil {
+			rw.WriteHeader(http.StatusNotFound)
+		} else {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+
+	availableDiffs := h.diagnosticsProvider.AvailableConfigDiffsHashes()
+
+	if len(availableDiffs) == 0 {
+		if err := json.NewEncoder(rw).Encode(DiffResponse{
+			Message: "no diffs available",
+		}); err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+
+	var requestedHash string
+	var message string
+	requestedHashQuery := r.URL.Query()[diffHashQuery]
+	if len(requestedHashQuery) == 0 {
+		requestedHash = h.diagnosticsProvider.LastConfigDiffHash()
+	} else {
+		if len(requestedHashQuery) > 1 {
+			message = "this endpoint does not support requesting multiple diffs, using the first hash provided"
+		}
+		requestedHash = requestedHashQuery[0]
+	}
+
+	requestedConfigDiff, ok := h.diagnosticsProvider.ConfigDiffByHash(requestedHash)
+	if !ok {
+		message = fmt.Sprintf("diff with hash %q not found", requestedHash)
+		rw.WriteHeader(http.StatusNotFound)
+	}
+
+	response := DiffResponse{
+		Message:    message,
+		ConfigHash: requestedHash,
+		Timestamp:  requestedConfigDiff.Timestamp,
+		Diffs:      requestedConfigDiff.Entities,
+		Available:  availableDiffs,
+	}
+
+	if err := json.NewEncoder(rw).Encode(response); err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/internal/diagnostics/http_handler_test.go
+++ b/internal/diagnostics/http_handler_test.go
@@ -1,0 +1,226 @@
+package diagnostics_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
+)
+
+type MockDiagnosticsProvider struct {
+	lastSuccessfulConfigDump mo.Option[file.Content]
+
+	lastFailedConfigDump mo.Option[file.Content]
+	lastErrorBody        mo.Option[[]byte]
+
+	currentFallbackCacheMeta mo.Option[fallback.GeneratedCacheMetadata]
+
+	lastConfigDiffHash mo.Option[string]
+	configDiffsByHash  map[string]diagnostics.ConfigDiff
+}
+
+func (m MockDiagnosticsProvider) LastSuccessfulConfigDump() (file.Content, string, bool) {
+	if d, ok := m.lastSuccessfulConfigDump.Get(); ok {
+		return d, "success-hash", true
+	}
+	return file.Content{}, "", false
+}
+
+func (m MockDiagnosticsProvider) LastFailedConfigDump() (file.Content, string, bool) {
+	if d, ok := m.lastFailedConfigDump.Get(); ok {
+		return d, "failed-hash", true
+	}
+	return file.Content{}, "", false
+}
+
+func (m MockDiagnosticsProvider) LastErrorBody() ([]byte, bool) {
+	if errBody, ok := m.lastErrorBody.Get(); ok {
+		return errBody, true
+	}
+	return nil, false
+}
+
+func (m MockDiagnosticsProvider) CurrentFallbackCacheMetadata() mo.Option[fallback.GeneratedCacheMetadata] {
+	return m.currentFallbackCacheMeta
+}
+
+func (m MockDiagnosticsProvider) LastConfigDiffHash() string {
+	if h, ok := m.lastConfigDiffHash.Get(); ok {
+		return h
+	}
+	return ""
+}
+
+func (m MockDiagnosticsProvider) ConfigDiffByHash(s string) (diagnostics.ConfigDiff, bool) {
+	c, ok := m.configDiffsByHash[s]
+	return c, ok
+}
+
+func (m MockDiagnosticsProvider) AvailableConfigDiffsHashes() []diagnostics.DiffIndex {
+	var result []diagnostics.DiffIndex
+	for k := range m.configDiffsByHash {
+		result = append(result, diagnostics.DiffIndex{ConfigHash: k})
+	}
+	return result
+}
+
+func TestConfigDiagnosticsHTTPHandler(t *testing.T) {
+	testCases := []struct {
+		name               string
+		provider           MockDiagnosticsProvider
+		endpoint           string
+		expectedStatusCode int
+		expectedResponse   string
+	}{
+		{
+			name:               "no successful config dump",
+			provider:           MockDiagnosticsProvider{},
+			endpoint:           "/successful",
+			expectedStatusCode: http.StatusNoContent,
+		},
+		{
+			name: "successful config dump",
+			provider: MockDiagnosticsProvider{
+				lastSuccessfulConfigDump: mo.Some(file.Content{
+					FormatVersion: "2.0",
+				}),
+			},
+			endpoint:           "/successful",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   `{"_format_version":"2.0"}`,
+		},
+		{
+			name:               "no failed config dump",
+			provider:           MockDiagnosticsProvider{},
+			endpoint:           "/failed",
+			expectedStatusCode: http.StatusNoContent,
+		},
+		{
+			name: "failed config dump",
+			provider: MockDiagnosticsProvider{
+				lastFailedConfigDump: mo.Some(file.Content{
+					FormatVersion: "2.0",
+				}),
+			},
+			endpoint:           "/failed",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   `{"config": {"_format_version":"2.0"}, "hash": "failed-hash"}`,
+		},
+		{
+			name:               "no error body",
+			provider:           MockDiagnosticsProvider{},
+			endpoint:           "/raw-error",
+			expectedStatusCode: http.StatusNoContent,
+		},
+		{
+			name: "error body",
+			provider: MockDiagnosticsProvider{
+				lastErrorBody: mo.Some([]byte("error body")),
+			},
+			endpoint:           "/raw-error",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   "error body",
+		},
+		{
+			name:               "no fallback cache metadata",
+			provider:           MockDiagnosticsProvider{},
+			endpoint:           "/fallback",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name: "fallback cache metadata",
+			provider: MockDiagnosticsProvider{
+				currentFallbackCacheMeta: mo.Some(fallback.GeneratedCacheMetadata{}),
+			},
+			endpoint:           "/fallback",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "no config diff by hash",
+			provider:           MockDiagnosticsProvider{},
+			endpoint:           "/diff-report?hash=missing",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   `{"available": null, "diffs": null, "hash": "", "message": "no diffs available", "timestamp": ""}`,
+		},
+		{
+			name: "config diff by hash",
+			provider: MockDiagnosticsProvider{
+				configDiffsByHash: map[string]diagnostics.ConfigDiff{
+					"existing": {
+						Hash: "existing",
+						Entities: []diagnostics.EntityDiff{
+							{
+								Generated: diagnostics.GeneratedEntity{
+									Name: "name",
+									Kind: "kind",
+								},
+								Action: "action",
+								Diff:   "+diff",
+							},
+						},
+						Timestamp: "2025-01-05T00:00:00Z",
+					},
+				},
+			},
+			endpoint:           "/diff-report?hash=existing",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse: `{
+  "hash": "existing",
+  "timestamp": "2025-01-05T00:00:00Z",
+  "diffs": [
+    {
+      "kongEntity": {
+        "name": "name",
+        "kind": "kind"
+      },
+      "action": "action",
+      "diff": "+diff"
+    }
+  ],
+  "available": [
+    {
+      "hash": "existing",
+      "timestamp": ""
+    }
+  ]
+}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := diagnostics.NewConfigDiagnosticsHTTPHandler(tc.provider, true)
+			s := httptest.NewServer(h)
+			defer s.Close()
+			client := s.Client()
+
+			resp, err := client.Get(fmt.Sprintf("%s%s", s.URL, tc.endpoint))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+
+			if tc.expectedResponse != "" {
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+
+				dummy := map[string]interface{}{}
+				if err := json.Unmarshal(body, &dummy); err == nil {
+					// If the expected response is JSON, we can use JSONEq to compare.
+					require.JSONEq(t, tc.expectedResponse, string(body))
+				} else {
+					// Otherwise, we should compare the raw string.
+					require.Equal(t, tc.expectedResponse, string(body))
+				}
+			}
+		})
+	}
+}

--- a/internal/diagnostics/http_handler_test.go
+++ b/internal/diagnostics/http_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 )
 
+// MockDiagnosticsProvider is a mock implementation of diagnostics.Provider.
 type MockDiagnosticsProvider struct {
 	lastSuccessfulConfigDump mo.Option[file.Content]
 
@@ -73,7 +74,7 @@ func (m MockDiagnosticsProvider) AvailableConfigDiffsHashes() []diagnostics.Diff
 	return result
 }
 
-func TestConfigDiagnosticsHTTPHandler(t *testing.T) {
+func TestHTTPHandler(t *testing.T) {
 	testCases := []struct {
 		name               string
 		provider           MockDiagnosticsProvider
@@ -96,7 +97,7 @@ func TestConfigDiagnosticsHTTPHandler(t *testing.T) {
 			},
 			endpoint:           "/successful",
 			expectedStatusCode: http.StatusOK,
-			expectedResponse:   `{"_format_version":"2.0"}`,
+			expectedResponse:   `{"config": {"_format_version":"2.0"}, "hash": "success-hash"}`,
 		},
 		{
 			name:               "no failed config dump",

--- a/internal/diagnostics/mapping.go
+++ b/internal/diagnostics/mapping.go
@@ -2,13 +2,15 @@ package diagnostics
 
 import (
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
 )
 
 // mapFallbackCacheMetadataIntoFallbackResponse maps the generated cache metadata into a FallbackResponse.
-func mapFallbackCacheMetadataIntoFallbackResponse(meta *fallback.GeneratedCacheMetadata) FallbackResponse {
-	if meta == nil {
+func mapFallbackCacheMetadataIntoFallbackResponse(m mo.Option[fallback.GeneratedCacheMetadata]) FallbackResponse {
+	meta, ok := m.Get()
+	if !ok {
 		return FallbackResponse{
 			Status: FallbackStatusNotTriggered,
 		}

--- a/internal/diagnostics/server.go
+++ b/internal/diagnostics/server.go
@@ -2,119 +2,83 @@ package diagnostics
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/kong/go-database-reconciler/pkg/file"
-
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 )
 
 const (
 	defaultHTTPReadHeaderTimeout = 10 * time.Second
-
-	// diagnosticConfigBufferDepth is the size of the channel buffer for receiving diagnostic
-	// config dumps from the proxy sync loop. The chosen size is essentially arbitrary: we don't
-	// expect that the receive end will get backlogged (it only assigns the value to a local
-	// variable) but do want a small amount of leeway to account for goroutine scheduling, so it
-	// is not zero.
-	diagnosticConfigBufferDepth = 3
-
-	// diffHistorySize is the number of diffs to keep in history.
-	diffHistorySize = 5
-
-	// diffHashQuery is the query string key for requesting a specific hash's diff.
-	diffHashQuery = "hash"
 )
 
 // Server is an HTTP server running exposing the pprof profiling tool, and processing diagnostic dumps of Kong configurations.
 type Server struct {
-	logger           logr.Logger
-	profilingEnabled bool
-	clientDiagnostic ClientDiagnostic
-
-	lastSuccessfulConfigDump file.Content
-	lastSuccessHash          string
-
-	lastFailedConfigDump file.Content
-	lastFailedHash       string
-	lastRawErrBody       []byte
-
-	currentFallbackCacheMetadata *fallback.GeneratedCacheMetadata
-
-	diffs diffMap
-
-	configLock   *sync.RWMutex
-	fallbackLock *sync.RWMutex
-	diffLock     *sync.RWMutex
+	logger                   logr.Logger
+	cfg                      ServerConfig
+	configDiagnosticsHandler http.Handler
 }
 
 // ServerConfig contains configuration for the diagnostics server.
 type ServerConfig struct {
-	// ProfilingEnabled enables profiling endpoints.
+	// ProfilingEnabled enables Golang profiling endpoints under /debug/pprof/ prefix.
 	ProfilingEnabled bool
-
-	// ConfigDumpsEnabled enables config dumps endpoints.
-	ConfigDumpsEnabled bool
 
 	// DumpSensitiveConfig makes config dumps to include sensitive information.
 	DumpSensitiveConfig bool
+
+	// ListenerPort is the port the diagnostics server will listen on.
+	ListenerPort int
 }
 
-// NewServer creates a diagnostics server ready to start listening.
-func NewServer(logger logr.Logger, cfg ServerConfig) Server {
+// ServerOption is a functional option for configuring the server.
+type ServerOption func(*Server)
+
+// WithConfigDiagnostics enables the config diagnostics handler (with /debug/config/ prefix).
+func WithConfigDiagnostics(handler http.Handler) ServerOption {
+	return func(s *Server) {
+		s.configDiagnosticsHandler = handler
+	}
+}
+
+// NewServer creates a diagnostics server. Listen() must be called to start the server.
+func NewServer(logger logr.Logger, cfg ServerConfig, opts ...ServerOption) Server {
 	s := Server{
-		logger:           logger,
-		profilingEnabled: cfg.ProfilingEnabled,
-		configLock:       &sync.RWMutex{},
-		fallbackLock:     &sync.RWMutex{},
-		diffLock:         &sync.RWMutex{},
-		diffs:            newDiffMap(diffHistorySize),
+		logger: logger,
+		cfg:    cfg,
 	}
 
-	if cfg.ConfigDumpsEnabled {
-		s.clientDiagnostic = ClientDiagnostic{
-			DumpsIncludeSensitive: cfg.DumpSensitiveConfig,
-			Configs:               make(chan ConfigDump, diagnosticConfigBufferDepth),
-			FallbackCacheMetadata: make(chan fallback.GeneratedCacheMetadata, diagnosticConfigBufferDepth),
-			Diffs:                 make(chan ConfigDiff, diagnosticConfigBufferDepth),
-		}
+	for _, opt := range opts {
+		opt(&s)
 	}
 
 	return s
 }
 
-// ConfigDumps returns an object allowing dumping succeeded and failed configuration updates.
-// It will return a zero value of the type in case the config dumps are not enabled.
-func (s *Server) ConfigDumps() ClientDiagnostic {
-	return s.clientDiagnostic
-}
-
 // Listen starts up the HTTP server and blocks until ctx expires.
-func (s *Server) Listen(ctx context.Context, port int) error {
+func (s *Server) Listen(ctx context.Context) error {
+	const (
+		configPrefix = "/debug/config"
+		pprofPrefix  = "/debug/pprof"
+	)
+
 	mux := http.NewServeMux()
-	if s.clientDiagnostic != (ClientDiagnostic{}) {
-		s.installConfigDebugHandlers(mux)
+	if h := s.configDiagnosticsHandler; h != nil {
+		mux.Handle(fmt.Sprintf("%s/", configPrefix), http.StripPrefix(configPrefix, h))
 	}
-	if s.profilingEnabled {
-		installProfilingHandlers(mux)
+	if s.cfg.ProfilingEnabled {
+		mux.Handle(fmt.Sprintf("%s/", pprofPrefix), http.StripPrefix(pprofPrefix, profilingHandler()))
 	}
 
 	httpServer := &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
+		Addr:              fmt.Sprintf(":%d", s.cfg.ListenerPort),
 		Handler:           mux,
 		ReadHeaderTimeout: defaultHTTPReadHeaderTimeout,
 	}
 	errChan := make(chan error)
-
-	go s.receiveDiagnostics(ctx)
 
 	go func() {
 		err := httpServer.ListenAndServe()
@@ -126,7 +90,7 @@ func (s *Server) Listen(ctx context.Context, port int) error {
 		}
 	}()
 
-	s.logger.Info("Diagnostics server is starting to listen", "addr", port)
+	s.logger.Info("Diagnostics server is starting to listen", "addr", s.cfg.ListenerPort)
 
 	select {
 	case <-ctx.Done():
@@ -137,201 +101,18 @@ func (s *Server) Listen(ctx context.Context, port int) error {
 	}
 }
 
-// receiveDiagnostics watches the diagnostic update channels.
-func (s *Server) receiveDiagnostics(ctx context.Context) {
-	for {
-		select {
-		case dump := <-s.clientDiagnostic.Configs:
-			s.onConfigDump(dump)
-		case meta := <-s.clientDiagnostic.FallbackCacheMetadata:
-			s.onFallbackCacheMetadata(meta)
-		case diff := <-s.clientDiagnostic.Diffs:
-			s.onDiff(diff)
-		case <-ctx.Done():
-			if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
-				s.logger.Error(err, "Shutting down diagnostic collection: context completed with error")
-				return
-			}
-			s.logger.V(logging.InfoLevel).Info("Shutting down diagnostic collection: context completed")
-			return
-		}
-	}
-}
-
-func (s *Server) onConfigDump(dump ConfigDump) {
-	s.configLock.Lock()
-	defer s.configLock.Unlock()
-
-	if dump.Meta.Failed {
-		// If the config push failed, we need to keep the failed config dump and the raw error body.
-		s.lastFailedConfigDump = dump.Config
-		s.lastFailedHash = dump.Meta.Hash
-		s.lastRawErrBody = dump.RawResponseBody
-	} else {
-		// If the config push was successful, we need to keep successful config dump and the hash.
-		s.lastSuccessfulConfigDump = dump.Config
-		s.lastSuccessHash = dump.Meta.Hash
-
-		// If the regular config push was successful, we can drop the fallback cache metadata as it is
-		// no longer relevant.
-		if !dump.Meta.Fallback {
-			s.fallbackLock.Lock()
-			s.currentFallbackCacheMetadata = nil
-			s.fallbackLock.Unlock()
-		}
-	}
-}
-
-func (s *Server) onFallbackCacheMetadata(meta fallback.GeneratedCacheMetadata) {
-	s.fallbackLock.Lock()
-	defer s.fallbackLock.Unlock()
-	s.currentFallbackCacheMetadata = &meta
-}
-
-func (s *Server) onDiff(diff ConfigDiff) {
-	s.diffLock.Lock()
-	defer s.diffLock.Unlock()
-	s.diffs.Update(diff)
-}
-
 // installProfilingHandlers adds the Profiling webservice to the given mux.
-func installProfilingHandlers(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/pprof", redirectTo("/debug/pprof/"))
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/heap", pprof.Index)
-	mux.HandleFunc("/debug/pprof/mutex", pprof.Index)
-	mux.HandleFunc("/debug/pprof/goroutine", pprof.Index)
-	mux.HandleFunc("/debug/pprof/threadcreate", pprof.Index)
-	mux.HandleFunc("/debug/pprof/block", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-}
-
-// installConfigDebugHandlers adds the config dump webservice to the given mux.
-func (s *Server) installConfigDebugHandlers(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/config/successful", s.handleLastValidConfig)
-	mux.HandleFunc("/debug/config/failed", s.handleLastFailedConfig)
-	mux.HandleFunc("/debug/config/fallback", s.handleCurrentFallback)
-	mux.HandleFunc("/debug/config/raw-error", s.handleLastErrBody)
-	mux.HandleFunc("/debug/config/diff-report", s.handleDiffReport)
-}
-
-// redirectTo redirects request to a certain destination.
-func redirectTo(to string) func(http.ResponseWriter, *http.Request) {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		http.Redirect(rw, req, to, http.StatusFound)
-	}
-}
-
-func (s *Server) handleLastValidConfig(rw http.ResponseWriter, _ *http.Request) {
-	rw.Header().Set("Content-Type", "application/json")
-	s.configLock.RLock()
-	defer s.configLock.RUnlock()
-	if err := json.NewEncoder(rw).Encode(
-		ConfigDumpResponse{
-			Config:     s.lastSuccessfulConfigDump,
-			ConfigHash: s.lastSuccessHash,
-		}); err != nil {
-		rw.WriteHeader(http.StatusInternalServerError)
-	}
-}
-
-func (s *Server) handleLastFailedConfig(rw http.ResponseWriter, _ *http.Request) {
-	rw.Header().Set("Content-Type", "application/json")
-	s.configLock.RLock()
-	defer s.configLock.RUnlock()
-	if err := json.NewEncoder(rw).Encode(
-		ConfigDumpResponse{
-			Config:     s.lastFailedConfigDump,
-			ConfigHash: s.lastFailedHash,
-		}); err != nil {
-		rw.WriteHeader(http.StatusInternalServerError)
-	}
-}
-
-func (s *Server) handleCurrentFallback(rw http.ResponseWriter, _ *http.Request) {
-	rw.Header().Set("Content-Type", "application/json")
-	s.configLock.RLock()
-	defer s.configLock.RUnlock()
-	resp := mapFallbackCacheMetadataIntoFallbackResponse(s.currentFallbackCacheMetadata)
-	if err := json.NewEncoder(rw).Encode(resp); err != nil {
-		rw.WriteHeader(http.StatusOK)
-	}
-}
-
-func (s *Server) handleLastErrBody(rw http.ResponseWriter, _ *http.Request) {
-	rw.Header().Set("Content-Type", "text/plain")
-	s.configLock.RLock()
-	defer s.configLock.RUnlock()
-	raw := s.lastRawErrBody
-	if len(raw) == 0 {
-		raw = []byte("No raw error body available.\n")
-	}
-	if _, err := rw.Write(raw); err != nil {
-		rw.WriteHeader(http.StatusInternalServerError)
-	}
-}
-
-func (s *Server) handleDiffReport(rw http.ResponseWriter, r *http.Request) {
-	rw.Header().Set("Content-Type", "application/json")
-	s.diffLock.RLock()
-	defer s.diffLock.RUnlock()
-
-	// GDR has no notion of sensitive data, so its raw diffs will include credentials and certificates when they
-	// change. We could make this fancier by walking through the entity types to exclude them if sensitive is not
-	// enabled, but would need to maintain a list of such types. Filter would probably happen on the producer (DB
-	// update strategy) side, since that's where we currently filter for the dump.
-	if !s.clientDiagnostic.DumpsIncludeSensitive {
-		if err := json.NewEncoder(rw).Encode(DiffResponse{
-			Message: "diffs include sensitive data: set CONTROLLER_DUMP_SENSITIVE_CONFIG=true in environment to enable",
-		}); err == nil {
-			rw.WriteHeader(http.StatusNotFound)
-		} else {
-			rw.WriteHeader(http.StatusInternalServerError)
-		}
-		return
-	}
-
-	if s.diffs.Len() == 0 {
-		if err := json.NewEncoder(rw).Encode(DiffResponse{
-			Message: "no diffs available",
-		}); err == nil {
-			rw.WriteHeader(http.StatusOK)
-		} else {
-			rw.WriteHeader(http.StatusInternalServerError)
-		}
-		return
-	}
-
-	var requestedHash string
-	var message string
-	requestedHashQuery := r.URL.Query()[diffHashQuery]
-	if len(requestedHashQuery) == 0 {
-		requestedHash = s.diffs.Latest()
-	} else {
-		if len(requestedHashQuery) > 1 {
-			message = "this endpoint does not support requesting multiple diffs, using the first hash provided"
-		}
-		requestedHash = requestedHashQuery[0]
-	}
-
-	requested, err := s.diffs.ByHash(requestedHash)
-	if err != nil {
-		message = err.Error()
-		rw.WriteHeader(http.StatusNotFound)
-	}
-
-	response := DiffResponse{
-		Message:    message,
-		ConfigHash: requestedHash,
-		Timestamp:  s.diffs.TimeByHash(requestedHash),
-		Diffs:      requested,
-		Available:  s.diffs.Available(),
-	}
-
-	if err := json.NewEncoder(rw).Encode(response); err != nil {
-		rw.WriteHeader(http.StatusInternalServerError)
-	}
+func profilingHandler() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", pprof.Index)
+	mux.HandleFunc("/heap", pprof.Index)
+	mux.HandleFunc("/mutex", pprof.Index)
+	mux.HandleFunc("/goroutine", pprof.Index)
+	mux.HandleFunc("/threadcreate", pprof.Index)
+	mux.HandleFunc("/block", pprof.Index)
+	mux.HandleFunc("/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/profile", pprof.Profile)
+	mux.HandleFunc("/symbol", pprof.Symbol)
+	mux.HandleFunc("/trace", pprof.Trace)
+	return mux
 }

--- a/internal/diagnostics/server_test.go
+++ b/internal/diagnostics/server_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/go-logr/logr/testr"
 	"github.com/google/uuid"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/stretchr/testify/assert"
@@ -53,17 +52,18 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 
 	readWriteWg.Done()
 	readWriteWg.Wait()
+
 	httpClient := &http.Client{}
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/successful", port))
 		require.NoError(t, err)
 		_ = resp.Body.Close()
-		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/failed", port))
 		require.NoError(t, err)
 		_ = resp.Body.Close()
-		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/raw-error", port))
 		require.NoError(t, err)
@@ -166,7 +166,7 @@ func testConfigDiff() ConfigDiff {
 
 // setupTestServer sets up a diagnostics server for testing. It returns a client attached to it and the port it's running on.
 func setupTestServer(ctx context.Context, t *testing.T) (Client, int) {
-	diagnosticsCollector := NewCollector(testr.New(t), managercfg.Config{
+	diagnosticsCollector := NewCollector(logr.Discard(), managercfg.Config{
 		DumpSensitiveConfig: true,
 	})
 	diagnosticsHandler := NewConfigDiagnosticsHTTPHandler(diagnosticsCollector, true)

--- a/internal/diagnostics/server_test.go
+++ b/internal/diagnostics/server_test.go
@@ -11,31 +11,23 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/google/uuid"
 	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/fallback"
+	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	testhelpers "github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
 )
 
 // TestDiagnosticsServer_ConfigDumps tests that the diagnostics server can receive and serve config dumps.
 // It's primarily to test that write and read operations run simultaneously do not fall into a race condition.
 func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
-	s := NewServer(logr.Discard(), ServerConfig{
-		ConfigDumpsEnabled: true,
-	})
-	configsCh := s.clientDiagnostic.Configs
-
-	port := testhelpers.GetFreePort(t)
-	t.Logf("Obtained a free port: %d", port)
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		err := s.Listen(ctx, port)
-		require.NoError(t, err)
-	}()
-	t.Log("Started diagnostics server")
+	t.Cleanup(cancel)
+	client, port := setupTestServer(ctx, t)
+	configsCh := client.Configs
 
 	// Use a WaitGroup to ensure that both the write and read operations are run simultaneously.
 	readWriteWg := sync.WaitGroup{}
@@ -47,9 +39,8 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 		readWriteWg.Done()
 		readWriteWg.Wait()
 
-		defer cancel()
 		failed := false
-		for i := 0; i < configDumpsToWrite; i++ {
+		for range configDumpsToWrite {
 			failed = !failed // Toggle failed flag.
 			configsCh <- ConfigDump{
 				Config:          file.Content{},
@@ -60,112 +51,33 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 	}()
 	t.Log("Started writing config dumps")
 
-	// Continuously read config dumps from the Server until context is cancelled.
-	go func() {
-		readWriteWg.Done()
-		readWriteWg.Wait()
+	readWriteWg.Done()
+	readWriteWg.Wait()
+	httpClient := &http.Client{}
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/successful", port))
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-		httpClient := &http.Client{}
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/successful", port))
-				if err == nil {
-					_ = resp.Body.Close()
-				}
-				resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/failed", port))
-				if err == nil {
-					_ = resp.Body.Close()
-				}
-				resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/raw-error", port))
-				if err == nil {
-					_ = resp.Body.Close()
-				}
-			}
-		}
-	}()
-	t.Log("Started reading config dumps")
+		resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/failed", port))
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-	<-ctx.Done()
-}
-
-func TestServer_EventsHandling(t *testing.T) {
-	successfulDump := ConfigDump{
-		Meta: DumpMeta{
-			Failed:   false,
-			Fallback: false,
-			Hash:     "success-hash",
-		},
-		Config: file.Content{
-			FormatVersion: "success", // Just for the sake of distinguishing between success and failure.
-		},
-	}
-	failedDump := ConfigDump{
-		Config: file.Content{
-			FormatVersion: "failed", // Just for the sake of distinguishing between success and failure.
-		},
-		Meta: DumpMeta{
-			Failed:   true,
-			Fallback: false,
-		},
-		RawResponseBody: []byte("error body"),
-	}
-	fallbackMeta := fallback.GeneratedCacheMetadata{
-		BrokenObjects: []fallback.ObjectHash{
-			{
-				Name: "object",
-			},
-		},
-	}
-
-	s := NewServer(logr.Discard(), ServerConfig{
-		ConfigDumpsEnabled: true,
-	})
-
-	t.Run("on successful config dump", func(t *testing.T) {
-		s.onConfigDump(successfulDump)
-		require.Equal(t, successfulDump.Config, s.lastSuccessfulConfigDump)
-		require.Equal(t, successfulDump.Meta.Hash, s.lastSuccessHash)
-	})
-	t.Run("on failed config dump", func(t *testing.T) {
-		s.onConfigDump(failedDump)
-		require.Equal(t, failedDump.Config, s.lastFailedConfigDump)
-		require.Equal(t, failedDump.Meta.Hash, s.lastFailedHash)
-		require.Equal(t, failedDump.RawResponseBody, s.lastRawErrBody)
-	})
-	t.Run("on fallback cache metadata", func(t *testing.T) {
-		s.onFallbackCacheMetadata(fallbackMeta)
-		require.NotNilf(t, s.currentFallbackCacheMetadata, "expected fallback cache metadata to be set")
-		require.Equal(t, fallbackMeta, *s.currentFallbackCacheMetadata)
-	})
-	t.Run("on successful config dump after fallback", func(t *testing.T) {
-		s.onConfigDump(successfulDump)
-		require.Equal(t, successfulDump.Config, s.lastSuccessfulConfigDump)
-		require.Equal(t, successfulDump.Meta.Hash, s.lastSuccessHash)
-		require.Nil(t, s.currentFallbackCacheMetadata, "expected fallback cache metadata to be dropped as it's no more relevant")
-	})
+		resp, err = httpClient.Get(fmt.Sprintf("http://localhost:%d/debug/config/raw-error", port))
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}, time.Second*5, time.Millisecond*10)
 }
 
 // TestDiagnosticsServer_Diffs tests the diff endpoint using fake data.
 func TestDiagnosticsServer_Diffs(t *testing.T) {
-	s := NewServer(logr.Discard(), ServerConfig{
-		ConfigDumpsEnabled:  true,
-		DumpSensitiveConfig: true,
-	})
-	diffCh := s.clientDiagnostic.Diffs
-
-	port := testhelpers.GetFreePort(t)
-	t.Logf("Obtained a free port: %d", port)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go func() {
-		err := s.Listen(ctx, port)
-		require.NoError(t, err)
-	}()
-	t.Log("Started diagnostics server")
+	client, port := setupTestServer(ctx, t)
+	diffCh := client.Diffs
 
 	// initially write the max number of cached diffs
 	configDumpsToWrite := diffHistorySize
@@ -250,4 +162,34 @@ func testConfigDiff() ConfigDiff {
 			},
 		},
 	}
+}
+
+// setupTestServer sets up a diagnostics server for testing. It returns a client attached to it and the port it's running on.
+func setupTestServer(ctx context.Context, t *testing.T) (Client, int) {
+	diagnosticsCollector := NewCollector(testr.New(t), managercfg.Config{
+		DumpSensitiveConfig: true,
+	})
+	diagnosticsHandler := NewConfigDiagnosticsHTTPHandler(diagnosticsCollector, true)
+
+	port := testhelpers.GetFreePort(t)
+	t.Logf("Obtained a free port: %d", port)
+
+	s := NewServer(logr.Discard(), ServerConfig{
+		ListenerPort: port,
+	}, WithConfigDiagnostics(diagnosticsHandler))
+	client := diagnosticsCollector.Client()
+
+	go func() {
+		err := s.Listen(ctx)
+		require.NoError(t, err)
+	}()
+	t.Log("Started diagnostics server")
+
+	go func() {
+		err := diagnosticsCollector.Start(ctx)
+		require.NoError(t, err)
+	}()
+	t.Log("Started diagnostics collector")
+
+	return client, port
 }

--- a/internal/diagnostics/types.go
+++ b/internal/diagnostics/types.go
@@ -27,8 +27,9 @@ type ConfigDump struct {
 	RawResponseBody []byte
 }
 
-// ClientDiagnostic contains settings and channels for receiving diagnostic data from the controller's Kong client.
-type ClientDiagnostic struct {
+// Client contains settings and channels for receiving diagnostic data from the controller's Kong client.
+// TODO(czeslavo): we could consider refactoring this to use private channels and expose methods for sending data.
+type Client struct {
 	// DumpsIncludeSensitive is true if the configuration dump includes sensitive values, such as certificate private
 	// keys and credential secrets.
 	DumpsIncludeSensitive bool

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -227,7 +227,7 @@ func New(
 
 	var dataplaneClientOpts []dataplane.KongClientOption
 	if dc, ok := diagnosticsClient.Get(); ok {
-		dataplaneClientOpts = append(dataplaneClientOpts, dataplane.WithDiagnosticClient(dc))
+		dataplaneClientOpts = append(dataplaneClientOpts, dataplane.WithDiagnosticsClient(dc))
 	}
 	dataplaneClient, err := dataplane.NewKongClient(
 		logger,
@@ -479,7 +479,7 @@ func resolveControllerHostnameForKonnect(logger logr.Logger) string {
 }
 
 // setupDiagnostics creates diagnostics components (collector, server) if enabled in the configuration and prepares
-// them to be run by the manager. It returns a non-empty diagnostics.ConfigDiagnosticsProvider if config dumps are enabled.
+// them to be run by the manager. It returns a non-empty diagnostics.Provider if config dumps are enabled.
 func (m *Manager) setupDiagnostics(
 	ctx context.Context,
 	c managercfg.Config,
@@ -521,7 +521,7 @@ func (m *Manager) setupDiagnostics(
 func (m *Manager) Run(ctx context.Context) error {
 	logger := ctrl.LoggerFrom(ctx)
 
-	logger.Info("Starting controller manager")
+	logger.Info("Starting manager")
 
 	defer func() {
 		if m.stopAnonymousReports != nil {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/samber/mo"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,9 +53,13 @@ import (
 // -----------------------------------------------------------------------------
 
 type Manager struct {
+	cfg managercfg.Config
+
 	m                    manager.Manager
 	synchronizer         *dataplane.Synchronizer
+	diagnosticsServer    mo.Option[diagnostics.Server]
 	stopAnonymousReports func()
+	diagnosticsCollector mo.Option[*diagnostics.Collector]
 }
 
 // New configures the controller manager call Start.
@@ -79,7 +84,11 @@ func New(
 		}
 	}
 
-	diagnosticsServer := startDiagnosticsServer(ctx, c.DiagnosticServerPort, c)
+	m := &Manager{
+		cfg: c,
+	}
+
+	diagnosticsClient := m.setupDiagnostics(ctx, c)
 	setupLog := logger.WithName("setup")
 	setupLog.Info("Starting controller manager", "release", metadata.Release, "repo", metadata.Repo, "commit", metadata.Commit)
 	setupLog.Info("The ingress class name has been set", "value", c.IngressClassName)
@@ -215,10 +224,14 @@ func New(
 	kongConfigFetcher := configfetcher.NewDefaultKongLastGoodConfigFetcher(translatorFeatureFlags.FillIDs, c.KongWorkspace)
 	fallbackConfigGenerator := fallback.NewGenerator(fallback.NewDefaultCacheGraphProvider(), logger)
 	metricsRecorder := metrics.NewGlobalCtrlRuntimeMetricsRecorder()
+
+	var dataplaneClientOpts []dataplane.KongClientOption
+	if dc, ok := diagnosticsClient.Get(); ok {
+		dataplaneClientOpts = append(dataplaneClientOpts, dataplane.WithDiagnosticClient(dc))
+	}
 	dataplaneClient, err := dataplane.NewKongClient(
 		logger,
 		time.Duration(c.ProxyTimeoutSeconds*float32(time.Second)),
-		diagnosticsServer.ConfigDumps(),
 		kongConfig,
 		eventRecorder,
 		dbMode,
@@ -230,6 +243,7 @@ func New(
 		&cache,
 		fallbackConfigGenerator,
 		metricsRecorder,
+		dataplaneClientOpts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize kong data-plane client: %w", err)
@@ -367,12 +381,12 @@ func New(
 		setupLog.Info("Anonymous reports disabled, skipping")
 	}
 
-	setupLog.Info("Starting manager")
-	return &Manager{
-		m:                    mgr,
-		stopAnonymousReports: stopAnonymousReports,
-		synchronizer:         synchronizer,
-	}, nil
+	m.m = mgr
+	m.stopAnonymousReports = stopAnonymousReports
+	m.synchronizer = synchronizer
+
+	setupLog.Info("Finished setting up the controller manager")
+	return m, nil
 }
 
 // waitForKubernetesAPIReadiness waits for the Kubernetes API to be ready. It's used as a prerequisite to run any
@@ -464,40 +478,75 @@ func resolveControllerHostnameForKonnect(logger logr.Logger) string {
 	return nn.String()
 }
 
-// startDiagnosticsServer starts a goroutine that handles requests for the diagnostics server.
-func startDiagnosticsServer(
+// setupDiagnostics creates diagnostics components (collector, server) if enabled in the configuration and prepares
+// them to be run by the manager. It returns a non-empty diagnostics.ConfigDiagnosticsProvider if config dumps are enabled.
+func (m *Manager) setupDiagnostics(
 	ctx context.Context,
-	port int,
 	c managercfg.Config,
-) diagnostics.Server {
+) mo.Option[diagnostics.Client] {
 	logger := ctrl.LoggerFrom(ctx)
-	if !c.EnableProfiling && !c.EnableConfigDumps {
-		logger.Info("Diagnostics server disabled")
-		return diagnostics.Server{}
-	}
-	logger.Info("Starting diagnostics server")
 
-	s := diagnostics.NewServer(logger, diagnostics.ServerConfig{
+	// If neither profiling nor config dumps are enabled, we don't need to setup diagnostics at all.
+	if !c.EnableProfiling && !c.EnableConfigDumps {
+		logger.Info("Diagnostics disabled")
+		return mo.None[diagnostics.Client]()
+	}
+
+	var serverOpts []diagnostics.ServerOption
+	// If config dumps are enabled, we need to create a diagnostics collector, setup an HTTP handler exposing its
+	// diagnostics, and pass it to the server options so it's plugged in.
+	if c.EnableConfigDumps {
+		diagnosticsCollector := diagnostics.NewCollector(logger, c)
+		m.diagnosticsCollector = mo.Some(diagnosticsCollector)
+		configDiagnosticsHandler := diagnostics.NewConfigDiagnosticsHTTPHandler(diagnosticsCollector, c.DumpSensitiveConfig)
+		serverOpts = append(serverOpts, diagnostics.WithConfigDiagnostics(configDiagnosticsHandler))
+	}
+
+	m.diagnosticsServer = mo.Some(diagnostics.NewServer(logger, diagnostics.ServerConfig{
 		ProfilingEnabled:    c.EnableProfiling,
-		ConfigDumpsEnabled:  c.EnableConfigDumps,
 		DumpSensitiveConfig: c.DumpSensitiveConfig,
-	})
-	go func() {
-		if err := s.Listen(ctx, port); err != nil {
-			logger.Error(err, "Unable to start diagnostics server")
-		}
-	}()
-	return s
+		ListenerPort:        c.DiagnosticServerPort,
+	}, serverOpts...))
+
+	// If diagnosticsCollector is set, it means that config dumps are enabled and we should return a diagnostics.Client.
+	if dc, ok := m.diagnosticsCollector.Get(); ok {
+		return mo.Some(dc.Client())
+	}
+
+	return mo.None[diagnostics.Client]()
 }
 
 // Run starts the Kong Ingress Controller. It blocks until the context is cancelled.
 // It should be called only once per Manager instance.
 func (m *Manager) Run(ctx context.Context) error {
+	logger := ctrl.LoggerFrom(ctx)
+
+	logger.Info("Starting controller manager")
+
 	defer func() {
 		if m.stopAnonymousReports != nil {
 			m.stopAnonymousReports()
 		}
 	}()
+
+	if ds, ok := m.diagnosticsServer.Get(); ok {
+		go func() {
+			logger.Info("Starting diagnostics server")
+			if err := ds.Listen(ctx); err != nil {
+				logger.Error(err, "Diagnostics server exited")
+			}
+		}()
+	}
+
+	if dc, ok := m.diagnosticsCollector.Get(); ok {
+		go func() {
+			logger.Info("Starting diagnostics collector")
+			if err := dc.Start(ctx); err != nil {
+				logger.Error(err, "Diagnostics collector exited")
+			}
+		}()
+	}
+
 	return m.m.Start(ctx)
 }
 

--- a/test/envtest/control_plane_reference_test.go
+++ b/test/envtest/control_plane_reference_test.go
@@ -6,13 +6,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/zapr"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
@@ -37,8 +34,6 @@ func TestControlPlaneReferenceHandling(t *testing.T) {
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	deployIngressClass(ctx, t, ingressClassName, ctrlClient)
-	logger := zapr.NewLogger(zap.NewNop())
-	ctrl.SetLogger(logger)
 	ns := CreateNamespace(ctx, t, ctrlClient)
 	RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -9,17 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/zapr"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kongv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
@@ -98,7 +95,6 @@ func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctrl.SetLogger(zapr.NewLogger(zap.NewNop()))
 	ctx, logger, _ := CreateTestLogger(ctx)
 	adminAPIServerURL := StartAdminAPIServerMock(t).URL
 

--- a/test/envtest/ingress_test.go
+++ b/test/envtest/ingress_test.go
@@ -22,19 +22,11 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
 )
-
-// configDumpResponse mirrors the diagnostics.configDumpResponse struct, which isn't published.
-// It's replicated here since some envtests use the config dump endpoints as a hack to extract the config for
-// inspection.
-
-type configDumpResponse struct {
-	ConfigHash string       `json:"hash"`
-	Config     file.Content `json:"config"`
-}
 
 func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 	t.Parallel()
@@ -165,7 +157,7 @@ func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 		defer resp.Body.Close()
 
 		var (
-			configDump configDumpResponse
+			configDump diagnostics.ConfigDumpResponse
 			config     file.Content
 			buff       bytes.Buffer
 		)

--- a/test/envtest/kongupstreampolicy_test.go
+++ b/test/envtest/kongupstreampolicy_test.go
@@ -3,32 +3,29 @@
 package envtest
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"testing"
 
-	"github.com/go-logr/zapr"
-	gojson "github.com/goccy/go-json"
 	"github.com/google/uuid"
-	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kongv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/builder"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
@@ -46,9 +43,6 @@ func TestKongUpstreamPolicyWithoutGatewayAPICRDs(t *testing.T) {
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	ingressClassName := "kongenvtest"
 	deployIngressClass(ctx, t, ingressClassName, ctrlClient)
-
-	logger := zapr.NewLogger(zap.NewNop())
-	ctrl.SetLogger(logger)
 
 	diagPort := helpers.GetFreePort(t)
 	ns := CreateNamespace(ctx, t, ctrlClient)
@@ -129,34 +123,26 @@ func TestKongUpstreamPolicyWithoutGatewayAPICRDs(t *testing.T) {
 	require.NoError(t, ctrlClient.Create(ctx, ingress))
 
 	t.Logf("verify that upstream policy is configured in Kong gateway correctly")
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/config/successful", diagPort))
-		if err != nil {
-			t.Logf("WARNING: error while getting config: %v", err)
-			return false
-		}
+		require.NoError(t, err, "failed to get successful config from debug endpoint")
 		defer resp.Body.Close()
 
-		var (
-			configDump configDumpResponse
-			config     file.Content
-			buff       bytes.Buffer
-		)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "failed to read response body")
 
-		if err := gojson.NewDecoder(io.TeeReader(resp.Body, &buff)).Decode(&configDump); err != nil {
-			t.Logf("WARNING: error while decoding config: %+v, response: %s", err, buff.String())
-			return false
-		}
+		var configDump diagnostics.ConfigDump
+		require.NoError(t, json.Unmarshal(body, &configDump), "failed to decode config dump")
 
-		config = configDump.Config
+		config := configDump.Config
+		require.Len(t, config.Upstreams, 1, "expected 1 upstream in config: %+v", config)
 
-		if len(config.Upstreams) != 1 {
-			t.Logf("WARNING: expected 1 upstream in config: %+v", config)
-			return false
-		}
 		upstream := config.Upstreams[0]
-		return upstream.Algorithm != nil && *upstream.Algorithm == "round-robin" && upstream.Slots != nil && *upstream.Slots == 32
-	}, waitTime, tickTime)
+		require.NotNil(t, upstream.Algorithm)
+		require.Equal(t, "round-robin", *upstream.Algorithm)
+		require.NotNil(t, upstream.Slots)
+		require.Equal(t, 32, *upstream.Slots)
+	}, waitTime*20, tickTime)
 
 	t.Logf("verify that ancestor status of KongUpstreamPolicy is updated correctly")
 	err := ctrlClient.Get(ctx, k8stypes.NamespacedName{
@@ -181,9 +167,6 @@ func TestKongUpstreamPolicyWithHTTPRoute(t *testing.T) {
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	ingressClassName := "kongenvtest"
 	deployIngressClass(ctx, t, ingressClassName, ctrlClient)
-
-	logger := zapr.NewLogger(zap.NewNop())
-	ctrl.SetLogger(logger)
 
 	diagPort := helpers.GetFreePort(t)
 	ns := CreateNamespace(ctx, t, ctrlClient)
@@ -371,9 +354,6 @@ func TestKongUpstreamPolicyNotReferencedInReconciledIngress(t *testing.T) {
 	deployIngressClass(ctx, t, ingressClassName, ctrlClient)
 	alterIngressClassName := "kongenvtest-alter"
 	deployIngressClass(ctx, t, alterIngressClassName, ctrlClient)
-
-	logger := zapr.NewLogger(zap.NewNop())
-	ctrl.SetLogger(logger)
 
 	ns := CreateNamespace(ctx, t, ctrlClient)
 	RunManager(ctx, t, envcfg,

--- a/test/mocks/update_strategy_resolver.go
+++ b/test/mocks/update_strategy_resolver.go
@@ -33,7 +33,7 @@ func NewUpdateStrategyResolver() *UpdateStrategyResolver {
 }
 
 // ResolveUpdateStrategy returns a mocked UpdateStrategy that will track which URLs were called.
-func (f *UpdateStrategyResolver) ResolveUpdateStrategy(c sendconfig.UpdateClient, _ *diagnostics.ClientDiagnostic) sendconfig.UpdateStrategy {
+func (f *UpdateStrategyResolver) ResolveUpdateStrategy(c sendconfig.UpdateClient, _ *diagnostics.Client) sendconfig.UpdateStrategy {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the `diagnostics.Server` by splitting it into a `Collector`, `Handler`, and a `Server`. That will be needed to enable plugging multiple instances of an `HTTPHandler` into one mux when we run multiple instances of the manager. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/7042.
