### PR TITLE
test(integration): accept "connection reset by peer" error in error check where no routes matches in case TestTLSPassThrough

### DIFF
--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -499,9 +499,8 @@ func TestTLSRoutePassthrough(t *testing.T) {
 		if errors.As(err, &opErr) {
 			// From kong/kong-gateway-dev:20250129, the returned error changed in the scenario where no routes matched.
 			return strings.Contains(opErr.Error(), "connection reset by peer")
-		} else {
-			return errors.Is(err, io.EOF)
 		}
+		return errors.Is(err, io.EOF)
 	}, ingressWait, waitTick)
 
 	t.Log("putting the parentRefs back")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Accept both `connection reset by peer` and `io.EOF` errors in the case of no route matched in `TestTLSPassThrough` integration test case, since the returned errors changed after `kong/kong-gateway-dev:20250129`/

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7082
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
