### PR TITLE
feat: implement multi-instance manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0
 	github.com/tonglil/buflogr v1.1.1
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/api v0.218.0
 	k8s.io/api v0.32.1

--- a/pkg/manager/multiinstance/errors.go
+++ b/pkg/manager/multiinstance/errors.go
@@ -1,0 +1,30 @@
+package multiinstance
+
+import "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+
+// InstanceWithIDAlreadyScheduledError is an error indicating that an instance with the same ID is already scheduled.
+type InstanceWithIDAlreadyScheduledError struct {
+	id manager.ID
+}
+
+func NewInstanceWithIDAlreadyScheduledError(id manager.ID) InstanceWithIDAlreadyScheduledError {
+	return InstanceWithIDAlreadyScheduledError{id: id}
+}
+
+func (e InstanceWithIDAlreadyScheduledError) Error() string {
+	return "instance with ID " + e.id.String() + " already exists"
+}
+
+// InstanceNotFoundError is an error indicating that an instance with the given ID was not found in the manager.
+// It can indicate that the instance was never scheduled or was stopped.
+type InstanceNotFoundError struct {
+	id manager.ID
+}
+
+func NewInstanceNotFoundError(id manager.ID) InstanceNotFoundError {
+	return InstanceNotFoundError{id: id}
+}
+
+func (e InstanceNotFoundError) Error() string {
+	return "instance with ID " + e.id.String() + " not found"
+}

--- a/pkg/manager/multiinstance/instance.go
+++ b/pkg/manager/multiinstance/instance.go
@@ -41,8 +41,7 @@ func (i *instance) StopChannel() <-chan struct{} {
 func (i *instance) Run(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
-		err := i.in.Run(ctx)
-		if err != nil {
+		if err := i.in.Run(ctx); err != nil {
 			i.logger.Error(err, "Instance exited with an error")
 		}
 	}()

--- a/pkg/manager/multiinstance/instance.go
+++ b/pkg/manager/multiinstance/instance.go
@@ -1,0 +1,59 @@
+package multiinstance
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+// instance represents a single manager.Manager instance in the multi-instance manager.
+type instance struct {
+	logger logr.Logger
+	in     ManagerInstance
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+func newInstance(in ManagerInstance, logger logr.Logger) *instance {
+	return &instance{
+		logger: logger.WithValues("instanceID", in.ID()),
+		in:     in,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// Stop stops the instance. Only its first call has an effect.
+func (i *instance) Stop() {
+	// Close stopCh only once as otherwise it would panic.
+	i.stopOnce.Do(func() {
+		close(i.stopCh)
+	})
+}
+
+// StopChannel returns a channel one can use to wait for the instance to stop.
+func (i *instance) StopChannel() <-chan struct{} {
+	return i.stopCh
+}
+
+// Run runs the instance in a goroutine and blocks until the instance is stopped or the context is done.
+func (i *instance) Run(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		err := i.in.Run(ctx)
+		if err != nil {
+			i.logger.Error(err, "Instance exited with an error")
+		}
+	}()
+
+	defer cancel() // Cancel the context once the parent context is done or the instance is stopped.
+	select {
+	case <-ctx.Done():
+	case <-i.stopCh:
+	}
+}
+
+func (i *instance) IsReady() error {
+	return i.in.IsReady()
+}

--- a/pkg/manager/multiinstance/manager.go
+++ b/pkg/manager/multiinstance/manager.go
@@ -1,0 +1,137 @@
+package multiinstance
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+)
+
+const (
+	// SchedulingQueueSize is the size of the scheduling queue for manager.Manager instances. It should be large enough
+	// to handle all reasonable cases of manager.Manager instances being scheduled at the same time.
+	SchedulingQueueSize = 100
+)
+
+// ManagerInstance is an interface that represents a single instance of a manager.Manager, exposing only the methods
+// needed by the multi-instance manager.
+type ManagerInstance interface {
+	ID() manager.ID
+	Run(context.Context) error
+	IsReady() error
+
+	// TODO(czeslavo): expose a getter for the diagnostics server and handle its lifecycle.
+}
+
+// Manager is able to dynamically run multiple instances of manager.Manager and manage their lifecycle.
+// It is responsible for things like:
+// - Making sure there's only one instance of a manager.Manager with a given ID.
+// - Starting and stopping manager.Manager instances as needed.
+// - Exposing a common diagnostics server for all manager.Manager instances.
+type Manager struct {
+	logger logr.Logger
+
+	instances       map[manager.ID]*instance
+	instancesLock   sync.RWMutex
+	schedulingQueue chan manager.ID
+}
+
+// NewManager creates a new multi-instance manager.
+func NewManager(logger logr.Logger) *Manager {
+	return &Manager{
+		logger:          logger,
+		instances:       make(map[manager.ID]*instance),
+		schedulingQueue: make(chan manager.ID, SchedulingQueueSize),
+	}
+}
+
+// Run starts the multi-instance manager and blocks until the context is canceled. It should only be called once.
+func (m *Manager) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case instanceID := <-m.schedulingQueue:
+			go m.runInstance(ctx, instanceID)
+		}
+	}
+}
+
+// ScheduleInstance adds a new manager.Manager instance to the multi-instance manager and starts it immediately in a
+// separate goroutine. If an instance with the same ID already exists, it returns a InstanceWithIDAlreadyScheduledError error.
+func (m *Manager) ScheduleInstance(in ManagerInstance) error {
+	m.logger.Info("Scheduling instance", "instanceID", in.ID())
+
+	m.instancesLock.Lock()
+	defer m.instancesLock.Unlock()
+
+	if _, exists := m.instances[in.ID()]; exists {
+		return NewInstanceWithIDAlreadyScheduledError(in.ID())
+	}
+
+	// Keep track of the instance, but do not start it from here.
+	m.instances[in.ID()] = newInstance(in, m.logger)
+
+	// Send a signal to the scheduling channel to start the instance.
+	m.schedulingQueue <- in.ID()
+
+	return nil
+}
+
+// StopInstance stops a manager.Manager instance with the given ID. If no instance with the given ID exists, it returns
+// a InstanceNotFoundError error.
+func (m *Manager) StopInstance(instanceID manager.ID) error {
+	m.logger.Info("Stopping instance", "instanceID", instanceID)
+
+	m.instancesLock.Lock()
+	defer m.instancesLock.Unlock()
+
+	in, exists := m.instances[instanceID]
+	if !exists {
+		return NewInstanceNotFoundError(instanceID)
+	}
+
+	// Send a signal to the instance to stop and let the running goroutine handle the cleanup.
+	in.Stop()
+
+	return nil
+}
+
+// IsInstanceReady checks if a manager.Manager instance with the given ID is ready. If no instance with the given ID
+// exists, it returns a InstanceNotFoundError error.
+func (m *Manager) IsInstanceReady(id manager.ID) error {
+	m.instancesLock.RLock()
+	defer m.instancesLock.RUnlock()
+	in, ok := m.instances[id]
+	if !ok {
+		return NewInstanceNotFoundError(id)
+	}
+	return in.IsReady()
+}
+
+func (m *Manager) runInstance(ctx context.Context, instanceID manager.ID) {
+	m.instancesLock.RLock()
+	in, exists := m.instances[instanceID]
+	m.instancesLock.RUnlock()
+
+	if !exists {
+		// Instance was removed while waiting for the lock.
+		m.logger.WithValues("instanceID", instanceID).Info("Instance was removed while waiting for the lock")
+		return
+	}
+
+	m.logger.Info("Starting instance", "instanceID", instanceID)
+	go in.Run(ctx)
+
+	// Wait for the instance to stop or the parent context be done.
+	select {
+	case <-in.StopChannel():
+		m.logger.Info("Instance stopped, removing it from managed instances", "instanceID", instanceID)
+		m.instancesLock.Lock()
+		delete(m.instances, instanceID)
+		m.instancesLock.Unlock()
+	case <-ctx.Done():
+	}
+}

--- a/pkg/manager/multiinstance/manager_test.go
+++ b/pkg/manager/multiinstance/manager_test.go
@@ -1,0 +1,124 @@
+package multiinstance_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/multiinstance"
+)
+
+const (
+	waitTime = time.Second
+	tickTime = time.Millisecond * 10
+)
+
+type MockInstance struct {
+	id                 manager.ID
+	returnErrOnRun     error
+	wasStarted         atomic.Bool
+	wasContextCanceled atomic.Bool
+}
+
+func newMockInstance(id manager.ID) *MockInstance {
+	return &MockInstance{
+		id: id,
+	}
+}
+
+func (m *MockInstance) ID() manager.ID {
+	return m.id
+}
+
+func (m *MockInstance) Run(ctx context.Context) error {
+	m.wasStarted.Store(true)
+
+	go func() {
+		<-ctx.Done()
+		m.wasContextCanceled.Store(true)
+	}()
+
+	if m.returnErrOnRun != nil {
+		return m.returnErrOnRun
+	}
+	return nil
+}
+
+func (m *MockInstance) IsReady() error {
+	return nil
+}
+
+func TestManager(t *testing.T) {
+	// At the end of the test, assert that there are no goroutines leaked.
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	// Create a context that will be canceled when the test ends so we can ensure all goroutines are cleaned up.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	multiManager := multiinstance.NewManager(testr.New(t))
+
+	mockInstance1 := newMockInstance(manager.NewRandomID())
+	mockInstance2 := newMockInstance(manager.NewRandomID())
+
+	t.Run("can schedule instances before starting the manager", func(t *testing.T) {
+		err := multiManager.ScheduleInstance(mockInstance1)
+		require.NoError(t, err)
+
+		err = multiManager.ScheduleInstance(mockInstance2)
+		require.NoError(t, err)
+
+		require.False(t, mockInstance1.wasStarted.Load(), "instance should not have been started yet as the manager is not running")
+	})
+
+	t.Run("schedling an instance with the same ID should fail", func(t *testing.T) {
+		err := multiManager.ScheduleInstance(mockInstance1)
+		require.Error(t, err)
+		require.IsType(t, multiinstance.InstanceWithIDAlreadyScheduledError{}, err)
+	})
+
+	managerRunning := make(chan struct{})
+	t.Run("can run the manager", func(t *testing.T) {
+		go func() {
+			close(managerRunning)
+			require.NoError(t, multiManager.Run(ctx))
+		}()
+	})
+
+	t.Run("can schedule instances after starting the manager", func(t *testing.T) {
+		<-managerRunning // Wait for the manager to start.
+
+		mockInstance3 := newMockInstance(manager.NewRandomID())
+		err := multiManager.ScheduleInstance(mockInstance3)
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.True(t, mockInstance1.wasStarted.Load())
+		}, waitTime, tickTime)
+	})
+
+	t.Run("can stop an instance", func(t *testing.T) {
+		err := multiManager.StopInstance(mockInstance1.ID())
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.True(t, mockInstance1.wasContextCanceled.Load())
+		}, waitTime, tickTime)
+	})
+
+	t.Run("can inspect instance readiness", func(t *testing.T) {
+		err := multiManager.IsInstanceReady(mockInstance2.ID())
+		require.NoError(t, err)
+
+		err = multiManager.IsInstanceReady(mockInstance1.ID())
+		require.Error(t, err)
+		require.IsType(t, multiinstance.InstanceNotFoundError{}, err)
+	})
+}

--- a/pkg/manager/multiinstance/manager_test.go
+++ b/pkg/manager/multiinstance/manager_test.go
@@ -45,10 +45,7 @@ func (m *MockInstance) Run(ctx context.Context) error {
 		m.wasContextCanceled.Store(true)
 	}()
 
-	if m.returnErrOnRun != nil {
-		return m.returnErrOnRun
-	}
-	return nil
+	return m.returnErrOnRun
 }
 
 func (m *MockInstance) IsReady() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

It implements a multi-instance manager that will be responsible for running multiple `manager.Manager` instances and managing their lifecycle. It will also run servers that need to be shared between the running instances (i.e. diagnostics).

I try to design its API to match what most likely will be required on KO's reconcilers side (i.e. scheduling, stopping, checking readiness).

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/7042.


