### PR TITLE
feat: allow dynamically exposing diagnostics for multiple instances

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -114,10 +114,11 @@ type Config struct {
 	AdmissionServer AdmissionServerConfig
 
 	// Diagnostics and performance
-	EnableProfiling      bool
-	EnableConfigDumps    bool
-	DumpSensitiveConfig  bool
-	DiagnosticServerPort int
+	EnableProfiling                 bool
+	EnableConfigDumps               bool
+	DumpSensitiveConfig             bool
+	DiagnosticServerPort            int
+	DisableRunningDiagnosticsServer bool // TODO(czeslavo): instead of this toggle, move the server out of the internal.Manager
 
 	// Feature Gates
 	FeatureGates FeatureGates

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/go-logr/logr"
 
@@ -54,4 +55,9 @@ func (m *Manager) ID() ID {
 // Config returns the configuration of the manager.
 func (m *Manager) Config() managercfg.Config {
 	return m.config
+}
+
+// DiagnosticsHandler returns the diagnostics handler of the manager if available. Otherwise, it returns nil.
+func (m *Manager) DiagnosticsHandler() http.Handler {
+	return m.manager.DiagnosticsHandler()
 }

--- a/pkg/manager/multiinstance/diagnostics.go
+++ b/pkg/manager/multiinstance/diagnostics.go
@@ -1,0 +1,91 @@
+package multiinstance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+)
+
+const (
+	// diagnosticsServerReadHeaderTimeout is the amount of time allowed to read request headers in the diagnostics server.
+	diagnosticsServerReadHeaderTimeout = 5 * time.Second
+)
+
+// DiagnosticsServer is a server that provides diagnostics information for multiple instances managed by the manager.
+// Each instance exposes its own diagnostics endpoints on `/{instanceID}/debug/config/` prefix. On every call to
+// RegisterInstance or UnregisterInstance, the server rebuilds its mux to include the latest set of handlers.
+type DiagnosticsServer struct {
+	listenerPort int
+	handlers     map[manager.ID]http.Handler
+
+	mux     *http.ServeMux
+	muxLock sync.Mutex
+}
+
+func NewDiagnosticsServer(listenerPort int) *DiagnosticsServer {
+	return &DiagnosticsServer{
+		listenerPort: listenerPort,
+		handlers:     make(map[manager.ID]http.Handler),
+		mux:          http.NewServeMux(),
+	}
+}
+
+// Start starts the diagnostics server.
+func (s *DiagnosticsServer) Start(ctx context.Context) error {
+	errg, _ := errgroup.WithContext(ctx)
+	errg.Go(func() error {
+		server := http.Server{
+			Addr:              fmt.Sprintf(":%d", s.listenerPort),
+			Handler:           s,
+			ReadHeaderTimeout: diagnosticsServerReadHeaderTimeout,
+		}
+		return server.ListenAndServe()
+	})
+	return errg.Wait()
+}
+
+// ServeHTTP serves the diagnostics server.
+func (s *DiagnosticsServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.muxLock.Lock()
+	defer s.muxLock.Unlock()
+
+	s.mux.ServeHTTP(w, r)
+}
+
+// RegisterInstance registers a new instance to the diagnostics server.
+func (s *DiagnosticsServer) RegisterInstance(instanceID manager.ID, instanceDiagnosticsHandler http.Handler) {
+	s.muxLock.Lock()
+	defer s.muxLock.Unlock()
+
+	s.handlers[instanceID] = instanceDiagnosticsHandler
+	s.rebuildMux()
+}
+
+// UnregisterInstance unregisters an instance from the diagnostics server.
+func (s *DiagnosticsServer) UnregisterInstance(instanceID manager.ID) {
+	s.muxLock.Lock()
+	defer s.muxLock.Unlock()
+
+	delete(s.handlers, instanceID)
+	s.rebuildMux()
+}
+
+// rebuildMux rebuilds the mux with the current handlers. It should be called with the muxLock held.
+func (s *DiagnosticsServer) rebuildMux() {
+	s.mux = http.NewServeMux()
+	for instanceID, handler := range s.handlers {
+		// It's possible an instance doesn't have a diagnostics handler. Handle that gracefully.
+		if handler == nil {
+			continue
+		}
+
+		prefix := fmt.Sprintf("/%s/debug/config", instanceID)
+		s.mux.Handle(fmt.Sprintf("%s/", prefix), http.StripPrefix(prefix, handler))
+	}
+}

--- a/pkg/manager/multiinstance/diagnostics.go
+++ b/pkg/manager/multiinstance/diagnostics.go
@@ -24,8 +24,8 @@ type DiagnosticsServer struct {
 	listenerPort int
 	handlers     map[manager.ID]http.Handler
 
-	mux     *http.ServeMux
 	muxLock sync.Mutex
+	mux     *http.ServeMux
 }
 
 func NewDiagnosticsServer(listenerPort int) *DiagnosticsServer {

--- a/pkg/manager/multiinstance/instance.go
+++ b/pkg/manager/multiinstance/instance.go
@@ -2,6 +2,7 @@ package multiinstance
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,13 @@ func (i *instance) Run(ctx context.Context) {
 	}
 }
 
+// DiagnosticsHandler returns an HTTP handler that exposes diagnostics information for this instance. It can return
+// nil if the instance does not expose diagnostics information.
+func (i *instance) DiagnosticsHandler() http.Handler {
+	return i.in.DiagnosticsHandler()
+}
+
+// IsReady returns an error if the instance is not ready.
 func (i *instance) IsReady() error {
 	return i.in.IsReady()
 }

--- a/pkg/manager/multiinstance/manager_test.go
+++ b/pkg/manager/multiinstance/manager_test.go
@@ -2,7 +2,6 @@ package multiinstance_test
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,41 +19,8 @@ const (
 	tickTime = time.Millisecond * 10
 )
 
-type MockInstance struct {
-	id                 manager.ID
-	returnErrOnRun     error
-	wasStarted         atomic.Bool
-	wasContextCanceled atomic.Bool
-}
-
-func newMockInstance(id manager.ID) *MockInstance {
-	return &MockInstance{
-		id: id,
-	}
-}
-
-func (m *MockInstance) ID() manager.ID {
-	return m.id
-}
-
-func (m *MockInstance) Run(ctx context.Context) error {
-	m.wasStarted.Store(true)
-
-	go func() {
-		<-ctx.Done()
-		m.wasContextCanceled.Store(true)
-	}()
-
-	return m.returnErrOnRun
-}
-
-func (m *MockInstance) IsReady() error {
-	return nil
-}
-
-func TestManager(t *testing.T) {
-	// At the end of the test, assert that there are no goroutines leaked.
-	t.Cleanup(func() { goleak.VerifyNone(t) })
+func TestManager_Scheduling(t *testing.T) {
+	onCleanupVerifyThereAreNoLeakedGoroutines(t)
 
 	// Create a context that will be canceled when the test ends so we can ensure all goroutines are cleaned up.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -75,7 +41,7 @@ func TestManager(t *testing.T) {
 		require.False(t, mockInstance1.wasStarted.Load(), "instance should not have been started yet as the manager is not running")
 	})
 
-	t.Run("schedling an instance with the same ID should fail", func(t *testing.T) {
+	t.Run("scheduling an instance with the same ID should fail", func(t *testing.T) {
 		err := multiManager.ScheduleInstance(mockInstance1)
 		require.Error(t, err)
 		require.IsType(t, multiinstance.InstanceWithIDAlreadyScheduledError{}, err)
@@ -118,4 +84,70 @@ func TestManager(t *testing.T) {
 		require.Error(t, err)
 		require.IsType(t, multiinstance.InstanceNotFoundError{}, err)
 	})
+}
+
+func TestManager_WithDiagnosticsExposer(t *testing.T) {
+	onCleanupVerifyThereAreNoLeakedGoroutines(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Log("Configuring a manager with a diagnostics exposer")
+	diagnosticsExposer := newMockDiagnosticsExposer()
+	multiManager := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagnosticsExposer))
+
+	managerRunning := make(chan struct{})
+	go func() {
+		close(managerRunning)
+		require.NoError(t, multiManager.Run(ctx))
+	}()
+	<-managerRunning // Wait for the manager to start.
+
+	instanceID1 := manager.NewRandomID()
+	instanceID2 := manager.NewRandomID()
+
+	t.Log("Scheduling first instance")
+	err := multiManager.ScheduleInstance(newMockInstance(instanceID1))
+	require.NoError(t, err)
+
+	t.Log("Expecting the diagnostics exposer to have the first instance registered")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.Contains(t, diagnosticsExposer.RegisteredInstances(), instanceID1)
+		require.NotContains(t, diagnosticsExposer.RegisteredInstances(), instanceID2)
+	}, waitTime, tickTime)
+
+	t.Log("Scheduling second instance")
+	err = multiManager.ScheduleInstance(newMockInstance(instanceID2))
+	require.NoError(t, err)
+
+	t.Log("Expecting the diagnostics exposer to have both instances registered")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.ElementsMatch(t, diagnosticsExposer.RegisteredInstances(), []manager.ID{instanceID1, instanceID2})
+	}, waitTime, tickTime)
+
+	t.Log("Stopping first instance")
+	err = multiManager.StopInstance(instanceID1)
+	require.NoError(t, err)
+
+	t.Log("Expecting the diagnostics exposer to have only the second instance registered")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.Contains(t, diagnosticsExposer.RegisteredInstances(), instanceID2)
+		require.NotContains(t, diagnosticsExposer.RegisteredInstances(), instanceID1)
+	}, waitTime, tickTime)
+
+	t.Log("Stopping second instance")
+	err = multiManager.StopInstance(instanceID2)
+	require.NoError(t, err)
+
+	t.Log("Expecting the diagnostics exposer to have no instances registered")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.Empty(t, diagnosticsExposer.RegisteredInstances())
+	}, waitTime, tickTime)
+}
+
+// onCleanupVerifyThereAreNoLeakedGoroutines is a helper function that sets up a cleanup function to verify there are no
+// leaked goroutines at the end of the test.
+func onCleanupVerifyThereAreNoLeakedGoroutines(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 }

--- a/pkg/manager/multiinstance/manager_test.go
+++ b/pkg/manager/multiinstance/manager_test.go
@@ -96,12 +96,9 @@ func TestManager_WithDiagnosticsExposer(t *testing.T) {
 	diagnosticsExposer := newMockDiagnosticsExposer()
 	multiManager := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagnosticsExposer))
 
-	managerRunning := make(chan struct{})
 	go func() {
-		close(managerRunning)
 		require.NoError(t, multiManager.Run(ctx))
 	}()
-	<-managerRunning // Wait for the manager to start.
 
 	instanceID1 := manager.NewRandomID()
 	instanceID2 := manager.NewRandomID()
@@ -112,8 +109,8 @@ func TestManager_WithDiagnosticsExposer(t *testing.T) {
 
 	t.Log("Expecting the diagnostics exposer to have the first instance registered")
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		require.Contains(t, diagnosticsExposer.RegisteredInstances(), instanceID1)
-		require.NotContains(t, diagnosticsExposer.RegisteredInstances(), instanceID2)
+		assert.Contains(t, diagnosticsExposer.RegisteredInstances(), instanceID1)
+		assert.NotContains(t, diagnosticsExposer.RegisteredInstances(), instanceID2)
 	}, waitTime, tickTime)
 
 	t.Log("Scheduling second instance")
@@ -122,7 +119,7 @@ func TestManager_WithDiagnosticsExposer(t *testing.T) {
 
 	t.Log("Expecting the diagnostics exposer to have both instances registered")
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		require.ElementsMatch(t, diagnosticsExposer.RegisteredInstances(), []manager.ID{instanceID1, instanceID2})
+		assert.ElementsMatch(t, diagnosticsExposer.RegisteredInstances(), []manager.ID{instanceID1, instanceID2})
 	}, waitTime, tickTime)
 
 	t.Log("Stopping first instance")
@@ -131,8 +128,8 @@ func TestManager_WithDiagnosticsExposer(t *testing.T) {
 
 	t.Log("Expecting the diagnostics exposer to have only the second instance registered")
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		require.Contains(t, diagnosticsExposer.RegisteredInstances(), instanceID2)
-		require.NotContains(t, diagnosticsExposer.RegisteredInstances(), instanceID1)
+		assert.Contains(t, diagnosticsExposer.RegisteredInstances(), instanceID2)
+		assert.NotContains(t, diagnosticsExposer.RegisteredInstances(), instanceID1)
 	}, waitTime, tickTime)
 
 	t.Log("Stopping second instance")

--- a/pkg/manager/multiinstance/mocks_test.go
+++ b/pkg/manager/multiinstance/mocks_test.go
@@ -1,0 +1,82 @@
+package multiinstance_test
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/samber/lo"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+)
+
+// mockInstance is a mock implementation of multiinstance.ManagerInstance.
+type mockInstance struct {
+	id                 manager.ID
+	returnErrOnRun     error
+	wasStarted         atomic.Bool
+	wasContextCanceled atomic.Bool
+}
+
+func newMockInstance(id manager.ID) *mockInstance {
+	return &mockInstance{
+		id: id,
+	}
+}
+
+func (m *mockInstance) ID() manager.ID {
+	return m.id
+}
+
+func (m *mockInstance) Run(ctx context.Context) error {
+	m.wasStarted.Store(true)
+
+	go func() {
+		<-ctx.Done()
+		m.wasContextCanceled.Store(true)
+	}()
+
+	return m.returnErrOnRun
+}
+
+func (m *mockInstance) IsReady() error {
+	return nil
+}
+
+func (m *mockInstance) DiagnosticsHandler() http.Handler {
+	return nil
+}
+
+// mockDiagnosticsExposer is a mock implementation of multiinstance.DiagnosticsExposer.
+type mockDiagnosticsExposer struct {
+	registeredInstances map[manager.ID]struct{}
+	lock                sync.Mutex
+}
+
+func newMockDiagnosticsExposer() *mockDiagnosticsExposer {
+	return &mockDiagnosticsExposer{
+		registeredInstances: make(map[manager.ID]struct{}),
+	}
+}
+
+func (m *mockDiagnosticsExposer) RegisterInstance(id manager.ID, _ http.Handler) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.registeredInstances[id] = struct{}{}
+}
+
+func (m *mockDiagnosticsExposer) UnregisterInstance(id manager.ID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	delete(m.registeredInstances, id)
+}
+
+func (m *mockDiagnosticsExposer) RegisteredInstances() []manager.ID {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	return lo.Keys(m.registeredInstances)
+}

--- a/test/envtest/multiinstance_manager_diagnostics_test.go
+++ b/test/envtest/multiinstance_manager_diagnostics_test.go
@@ -1,0 +1,72 @@
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-configuration/pkg/clientset/scheme"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/multiinstance"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
+)
+
+func TestMultiInstanceManagerDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	const (
+		waitTime = 10 * time.Second
+		tickTime = 10 * time.Millisecond
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	envcfg := Setup(t, scheme.Scheme)
+	diagPort := helpers.GetFreePort(t)
+
+	t.Log("Starting the diagnostics server and the multi-instance manager")
+	diagServer := multiinstance.NewDiagnosticsServer(diagPort)
+	go func() {
+		require.ErrorIs(t, diagServer.Start(ctx), http.ErrServerClosed)
+	}()
+	multimgr := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagServer))
+	go func() {
+		require.NoError(t, multimgr.Run(ctx))
+	}()
+
+	t.Log("Setting up two instances of the manager and scheduling them in the multi-instance manager")
+	mgrInstance1 := SetupManager(ctx, t, manager.NewRandomID(), envcfg, AdminAPIOptFns(), WithDiagnosticsWithoutServer())
+	mgrInstance2 := SetupManager(ctx, t, manager.NewRandomID(), envcfg, AdminAPIOptFns(), WithDiagnosticsWithoutServer())
+	require.NoError(t, multimgr.ScheduleInstance(mgrInstance1))
+	require.NoError(t, multimgr.ScheduleInstance(mgrInstance2))
+
+	t.Log("Waiting for the diagnostics server to expose instances' diagnostics endpoints")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/%s/debug/config/successful", diagPort, mgrInstance1.ID()))
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		resp, err = http.Get(fmt.Sprintf("http://localhost:%d/%s/debug/config/successful", diagPort, mgrInstance2.ID()))
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}, waitTime, tickTime, "diagnostics should be exposed under /{instanceID}/debug/config prefix for both instances")
+
+	t.Log("Stopping the first instance and waiting for its diagnostics endpoints to be removed from the server")
+	require.NoError(t, multimgr.StopInstance(mgrInstance1.ID()))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/%s/debug/config/successful", diagPort, mgrInstance1.ID()))
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}, waitTime, tickTime, "diagnostics should no longer be available after stopping the instance")
+}

--- a/test/envtest/multiinstance_manager_diagnostics_test.go
+++ b/test/envtest/multiinstance_manager_diagnostics_test.go
@@ -51,14 +51,16 @@ func TestMultiInstanceManagerDiagnostics(t *testing.T) {
 	t.Log("Waiting for the diagnostics server to expose instances' diagnostics endpoints")
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/%s/debug/config/successful", diagPort, mgrInstance1.ID()))
-		require.NoError(t, err)
-		resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		if assert.NoError(t, err) {
+			resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		}
 
 		resp, err = http.Get(fmt.Sprintf("http://localhost:%d/%s/debug/config/successful", diagPort, mgrInstance2.ID()))
-		require.NoError(t, err)
-		resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		if assert.NoError(t, err) {
+			resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		}
 	}, waitTime, tickTime, "diagnostics should be exposed under /{instanceID}/debug/config prefix for both instances")
 
 	t.Log("Stopping the first instance and waiting for its diagnostics endpoints to be removed from the server")

--- a/test/envtest/multiinstance_manager_diagnostics_test.go
+++ b/test/envtest/multiinstance_manager_diagnostics_test.go
@@ -69,6 +69,6 @@ func TestMultiInstanceManagerDiagnostics(t *testing.T) {
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/%s/debug/config/successful", diagPort, mgrInstance1.ID()))
 		require.NoError(t, err)
 		resp.Body.Close()
-		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}, waitTime, tickTime, "diagnostics should no longer be available after stopping the instance")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `multiinstace.DiagnosticsServer` and integrates it with `multiinstace.Manager` to register/unregister currently running instances and expose their config diagnostics data on `/{instanceID}/debug/config` endpoints.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/7042.


