### PR TITLE
feat: expose pprof endpoints from multiinstance diagnostics server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/goccy/go-json v0.10.5
 	github.com/google/go-cmp v0.6.0
+	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.16.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Add ability of running a pprof handler to the `multiinstance.DiagnosticsServer`. When running instances, wrap them in `pprof.Do` so their CPU profiling data is labeled with their ID. 

This allows to see where each instance spent most of its CPU time:

```text
go tool pprof cpu.pprof                                                 
File: ___TestMultiInstanceManager_Profiling_in_github_com_kong_kubernetes_ingress_controller_v3_test_envtest.test
Type: cpu
Time: Feb 7, 2025 at 4:32pm (CET)
Duration: 30.01s, Total samples = 870ms ( 2.90%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) tags
 instanceID: Total 330.0ms
             180.0ms (54.55%): cp-2
             150.0ms (45.45%): cp-1

(pprof) tagfocus=instanceID:cp-2
(pprof) top10 -cum
Active filters:
   tagfocus=instanceID:cp-2
Showing nodes accounting for 60ms, 6.90% of 870ms total
Showing top 10 nodes out of 116
      flat  flat%   sum%        cum   cum%
      60ms  6.90%  6.90%       60ms  6.90%  syscall.syscall
         0     0%  6.90%       50ms  5.75%  internal/poll.ignoringEINTRIO (inline)
         0     0%  6.90%       40ms  4.60%  bufio.(*Writer).Flush
         0     0%  6.90%       40ms  4.60%  github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane.(*KongClient).sendOutToGatewayClients.func2
         0     0%  6.90%       40ms  4.60%  github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane.(*KongClient).sendToClient
         0     0%  6.90%       40ms  4.60%  github.com/sourcegraph/conc.(*WaitGroup).Go.func1
         0     0%  6.90%       40ms  4.60%  github.com/sourcegraph/conc/iter.Iterator[go.shape.*uint8].ForEachIdx.func1
         0     0%  6.90%       40ms  4.60%  github.com/sourcegraph/conc/iter.Mapper[go.shape.*uint8,go.shape.string].MapErr.func1
         0     0%  6.90%       40ms  4.60%  github.com/sourcegraph/conc/panics.(*Catcher).Try
         0     0%  6.90%       40ms  4.60%  internal/poll.(*FD).Write

```

<img width="1675" alt="image" src="https://github.com/user-attachments/assets/bd790e65-bc39-4779-a664-a5bceff3ad47" />

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7042.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


