### PR TITLE
fix(manager): Run `AddToScheme` only once in `scheme.Get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@ Adding a new version? You'll need three changes:
   collected properly when the Konnect integration was enabled (only Konnect-related
   metrics were collected, omitting regular DP metrics). This has been fixed.
   [#6881](https://github.com/Kong/kubernetes-ingress-controller/pull/6881)
+- `AddToScheme` is only run in the initialization of scheme of the manager but
+  not called in `scheme.Get` to reduce the CPU usage.
+  [#7105](https://github.com/Kong/kubernetes-ingress-controller/pull/7105) 
 
 ## [3.4.1]
 

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -956,7 +956,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 		t.Run(tt.msg, func(t *testing.T) {
 			fakeClient := fakeclient.
 				NewClientBuilder().
-				WithScheme(lo.Must(scheme.Get())).
+				WithScheme(scheme.Get()).
 				WithObjects(tt.cachedObjects...).
 				Build()
 

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -1249,7 +1249,7 @@ func TestValidator_ValidateIngress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			storer := lo.Must(store.NewFakeStore(tc.storerObjects))
 			validator := KongHTTPValidator{
-				ManagerClient: fake.NewClientBuilder().WithScheme(lo.Must(managerscheme.Get())).WithObjects(tc.clientObjects...).Build(),
+				ManagerClient: fake.NewClientBuilder().WithScheme(managerscheme.Get()).WithObjects(tc.clientObjects...).Build(),
 				Storer:        storer,
 				AdminAPIServicesProvider: fakeServicesProvider{
 					routeSvc: &fakeRouteSvc{

--- a/internal/controllers/configuration/kongupstreampolicy_utils_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils_test.go
@@ -727,7 +727,7 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 			tc.inputObjects = append(tc.inputObjects, &tc.kongUpstreamPolicy)
 			fakeClient := fakectrlruntimeclient.
 				NewClientBuilder().
-				WithScheme(lo.Must(scheme.Get())).
+				WithScheme(scheme.Get()).
 				WithObjects(tc.inputObjects...).
 				WithStatusSubresource(tc.inputObjects...).
 				WithIndex(&corev1.Service{}, upstreamPolicyIndexKey, indexServicesOnUpstreamPolicyAnnotation).

--- a/internal/controllers/gateway/route_predicate_test.go
+++ b/internal/controllers/gateway/route_predicate_test.go
@@ -201,7 +201,7 @@ func TestIsRouteAttachedToReconciledGateway(t *testing.T) {
 	}
 
 	for _, tc := range httpRouteTestCases {
-		cl := fakeclient.NewClientBuilder().WithScheme(lo.Must(scheme.Get())).WithObjects(tc.objects...).Build()
+		cl := fakeclient.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(tc.objects...).Build()
 		t.Run(tc.name, func(t *testing.T) {
 			logger := logr.Discard()
 			result := IsRouteAttachedToReconciledGateway[*gatewayapi.HTTPRoute](cl, logger, tc.gatewayNN, tc.route)

--- a/internal/controllers/reference/indexer.go
+++ b/internal/controllers/reference/indexer.go
@@ -40,11 +40,7 @@ func objectKeyFunc(obj client.Object) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("could not convert %s/%s back to client Object", obj.GetNamespace(), obj.GetName())
 	}
-	s, err := scheme.Get()
-	if err != nil {
-		return "", fmt.Errorf("could not get scheme for %s/%s metadata: %w", obj.GetNamespace(), obj.GetName(), err)
-	}
-	err = util.PopulateTypeMeta(o, s)
+	err := util.PopulateTypeMeta(o, scheme.Get())
 	if err != nil {
 		return "", fmt.Errorf("could not populate %s/%s metadata: %w", obj.GetNamespace(), obj.GetName(), err)
 	}

--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -1096,9 +1096,7 @@ func TestServiceClientCertificate(t *testing.T) {
 			},
 		}
 		for _, service := range services {
-			scheme, err := scheme.Get()
-			require.NoError(t, err)
-			err = util.PopulateTypeMeta(service, scheme)
+			err := util.PopulateTypeMeta(service, scheme.Get())
 			require.NoError(t, err)
 		}
 		store, err := store.NewFakeStore(store.FakeObjects{

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -132,10 +132,7 @@ func Run(
 	}
 
 	setupLog.Info("Configuring and building the controller manager")
-	managerOpts, err := setupManagerOptions(ctx, setupLog, c, dbMode)
-	if err != nil {
-		return fmt.Errorf("unable to setup manager options: %w", err)
-	}
+	managerOpts := setupManagerOptions(ctx, setupLog, c, dbMode)
 
 	mgr, err := ctrl.NewManager(kubeconfig, managerOpts)
 	if err != nil {

--- a/internal/manager/scheme/scheme.go
+++ b/internal/manager/scheme/scheme.go
@@ -1,10 +1,9 @@
 package scheme
 
 import (
-	"sync/atomic"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -17,53 +16,27 @@ import (
 	incubatorv1alpha1 "github.com/kong/kubernetes-configuration/api/incubator/v1alpha1"
 )
 
-var (
-	kicScheme       = runtime.NewScheme()
-	addToSchemeDone atomic.Bool
-)
+var kicScheme *runtime.Scheme = initScheme()
 
-// REVIEW: Is it better to move initialization of scheme elsewhere,
-// and change the `Get` to only return the scheme (or directly use the scheme)?
+func initScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+
+	utilruntime.Must(kongv1.AddToScheme(s))
+	utilruntime.Must(kongv1alpha1.AddToScheme(s))
+	utilruntime.Must(kongv1beta1.AddToScheme(s))
+	utilruntime.Must(incubatorv1alpha1.AddToScheme(s))
+
+	utilruntime.Must(gatewayv1.Install(s))
+	utilruntime.Must(gatewayv1beta1.Install(s))
+	utilruntime.Must(gatewayv1alpha2.Install(s))
+	utilruntime.Must(gatewayv1alpha3.Install(s))
+
+	return s
+}
 
 // Get returns a scheme aware of all types the manager can interact with.
-func Get() (*runtime.Scheme, error) {
-	// Only add schemes to the runtime scheme when adding is not done.
-	if !addToSchemeDone.Load() {
-		if err := apiextensionsv1.AddToScheme(kicScheme); err != nil {
-			return nil, err
-		}
-
-		if err := clientgoscheme.AddToScheme(kicScheme); err != nil {
-			return nil, err
-		}
-
-		if err := kongv1.AddToScheme(kicScheme); err != nil {
-			return nil, err
-		}
-		if err := kongv1alpha1.AddToScheme(kicScheme); err != nil {
-			return nil, err
-		}
-		if err := kongv1beta1.AddToScheme(kicScheme); err != nil {
-			return nil, err
-		}
-		if err := incubatorv1alpha1.AddToScheme(kicScheme); err != nil {
-			return nil, err
-		}
-
-		if err := gatewayv1alpha2.Install(kicScheme); err != nil {
-			return nil, err
-		}
-		if err := gatewayv1alpha3.Install(kicScheme); err != nil {
-			return nil, err
-		}
-		if err := gatewayv1beta1.Install(kicScheme); err != nil {
-			return nil, err
-		}
-		if err := gatewayv1.Install(kicScheme); err != nil {
-			return nil, err
-		}
-	}
-	addToSchemeDone.Store(true)
-	// REVIEW: is it safe to return the same scheme everywhere it is used?
-	return kicScheme, nil
+func Get() *runtime.Scheme {
+	return kicScheme
 }

--- a/internal/manager/scheme/scheme.go
+++ b/internal/manager/scheme/scheme.go
@@ -1,6 +1,8 @@
 package scheme
 
 import (
+	"sync/atomic"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -15,46 +17,53 @@ import (
 	incubatorv1alpha1 "github.com/kong/kubernetes-configuration/api/incubator/v1alpha1"
 )
 
+var (
+	kicScheme       = runtime.NewScheme()
+	addToSchemeDone atomic.Bool
+)
+
+// REVIEW: Is it better to move initialization of scheme elsewhere,
+// and change the `Get` to only return the scheme (or directly use the scheme)?
+
 // Get returns a scheme aware of all types the manager can interact with.
 func Get() (*runtime.Scheme, error) {
-	scheme := runtime.NewScheme()
+	// Only add schemes to the runtime scheme when adding is not done.
+	if !addToSchemeDone.Load() {
+		if err := apiextensionsv1.AddToScheme(kicScheme); err != nil {
+			return nil, err
+		}
 
-	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
+		if err := clientgoscheme.AddToScheme(kicScheme); err != nil {
+			return nil, err
+		}
 
-	if err := clientgoscheme.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
+		if err := kongv1.AddToScheme(kicScheme); err != nil {
+			return nil, err
+		}
+		if err := kongv1alpha1.AddToScheme(kicScheme); err != nil {
+			return nil, err
+		}
+		if err := kongv1beta1.AddToScheme(kicScheme); err != nil {
+			return nil, err
+		}
+		if err := incubatorv1alpha1.AddToScheme(kicScheme); err != nil {
+			return nil, err
+		}
 
-	if err := kongv1.AddToScheme(scheme); err != nil {
-		return nil, err
+		if err := gatewayv1alpha2.Install(kicScheme); err != nil {
+			return nil, err
+		}
+		if err := gatewayv1alpha3.Install(kicScheme); err != nil {
+			return nil, err
+		}
+		if err := gatewayv1beta1.Install(kicScheme); err != nil {
+			return nil, err
+		}
+		if err := gatewayv1.Install(kicScheme); err != nil {
+			return nil, err
+		}
 	}
-	if err := kongv1alpha1.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := kongv1beta1.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := incubatorv1alpha1.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-
-	if err := gatewayv1alpha2.Install(scheme); err != nil {
-		return nil, err
-	}
-
-	if err := gatewayv1alpha3.Install(scheme); err != nil {
-		return nil, err
-	}
-
-	if err := gatewayv1beta1.Install(scheme); err != nil {
-		return nil, err
-	}
-
-	if err := gatewayv1.Install(scheme); err != nil {
-		return nil, err
-	}
-
-	return scheme, nil
+	addToSchemeDone.Store(true)
+	// REVIEW: is it safe to return the same scheme everywhere it is used?
+	return kicScheme, nil
 }

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -73,12 +73,8 @@ func SetupLoggers(c *Config, output io.Writer) (logr.Logger, error) {
 	return logger, nil
 }
 
-func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbmode dpconf.DBMode) (ctrl.Options, error) {
+func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbmode dpconf.DBMode) ctrl.Options {
 	logger.Info("Building the manager runtime scheme and loading apis into the scheme")
-	scheme, err := scheme.Get()
-	if err != nil {
-		return ctrl.Options{}, err
-	}
 
 	// configure the general manager options
 	managerOpts := ctrl.Options{
@@ -90,7 +86,7 @@ func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbm
 			SkipNameValidation: lo.ToPtr(true),
 		},
 		GracefulShutdownTimeout: c.GracefulShutdownTimeout,
-		Scheme:                  scheme,
+		Scheme:                  scheme.Get(),
 		Metrics: metricsserver.Options{
 			BindAddress: c.MetricsAddr,
 			FilterProvider: func() func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
@@ -146,7 +142,7 @@ func setupManagerOptions(ctx context.Context, logger logr.Logger, c *Config, dbm
 		managerOpts.LeaderElectionNamespace = c.LeaderElectionNamespace
 	}
 
-	return managerOpts, nil
+	return managerOpts
 }
 
 const (

--- a/internal/store/cache_stores.go
+++ b/internal/store/cache_stores.go
@@ -15,10 +15,6 @@ import (
 // NewCacheStoresFromObjYAML provides a new CacheStores object given any number of byte arrays containing
 // YAML Kubernetes objects. An error is returned if any provided YAML was not a valid Kubernetes object.
 func NewCacheStoresFromObjYAML(objs ...[]byte) (c CacheStores, err error) {
-	s, err := scheme.Get()
-	if err != nil {
-		return c, err
-	}
 	kobjs := make([]runtime.Object, 0, len(objs))
 	sr := serializer.NewYAMLSerializer(
 		yamlserializer.DefaultMetaFactory,
@@ -30,7 +26,7 @@ func NewCacheStoresFromObjYAML(objs ...[]byte) (c CacheStores, err error) {
 		if err = decodeErr; err != nil {
 			return
 		}
-		if err := util.PopulateTypeMeta(kobj, s); err != nil {
+		if err := util.PopulateTypeMeta(kobj, scheme.Get()); err != nil {
 			return c, err
 		}
 		kobjs = append(kobjs, kobj)

--- a/internal/util/types_test.go
+++ b/internal/util/types_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ func TestPopulateTypeMeta(t *testing.T) {
 
 	require.Empty(t, credential.GetObjectKind().GroupVersionKind().Kind)
 
-	err := PopulateTypeMeta(credential, lo.Must(scheme.Get()))
+	err := PopulateTypeMeta(credential, scheme.Get())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, credential.GetObjectKind().GroupVersionKind().Kind)

--- a/test/helpers/k8s_meta.go
+++ b/test/helpers/k8s_meta.go
@@ -12,9 +12,7 @@ import (
 
 // WithTypeMeta adds type meta to the given object based on its Go type.
 func WithTypeMeta[T runtime.Object](t *testing.T, obj T) T {
-	s, err := scheme.Get()
-	require.NoError(t, err)
-	err = util.PopulateTypeMeta(obj, s)
+	err := util.PopulateTypeMeta(obj, scheme.Get())
 	require.NoError(t, err)
 	return obj
 }

--- a/test/mocks/events_recorder.go
+++ b/test/mocks/events_recorder.go
@@ -44,8 +44,7 @@ func (r *EventRecorder) writeEvent(o runtime.Object, eventtype, reason, messageF
 	r.l.Lock()
 	defer r.l.Unlock()
 
-	s, _ := scheme.Get()
-	_ = util.PopulateTypeMeta(o, s)
+	_ = util.PopulateTypeMeta(o, scheme.Get())
 	fmtString := fmt.Sprintf("%s: %s %s %s", o.GetObjectKind().GroupVersionKind().Kind, eventtype, reason, messageFmt)
 	r.events = append(r.events, fmt.Sprintf(fmtString, args...))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Run `AddToScheme` in `scheme.Get` only once since `scheme.Get` is called very frequently and `AddToScheme` creates temporary objects. It causes large amount of creation and gc on these objects.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7104 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
