### PR TITLE
feat: associate KIC instance with Kubernetes event via annotation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -187,6 +187,7 @@ linters-settings:
         - "!**/internal/cmd/rootcmd/config/cli.go"
         - "!**/test/internal/helpers/kong.go"
         - "!**/test/envtest/telemetry_test.go"
+        - "!**/test/envtest/configerrorevent_envtest_test.go"
         deny:
         - pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/manager
           desc: github.com/kong/kubernetes-ingress-controller/v3/internal/manager should not be used outside of its package. Use github.com/kong/kubernetes-ingress-controller/v3/pkg/manager instead.

--- a/internal/manager/consts/consts.go
+++ b/internal/manager/consts/consts.go
@@ -30,4 +30,8 @@ const (
 
 	// DefaultConfigMapSelector is the default label selector used to ingest ConfigMaps in the DataPlane sync.
 	DefaultConfigMapSelector = "konghq.com/configmap"
+
+	// InstanceIDAnnotationKey is the annotation key used to store the instance ID of particular manager,
+	// to corelate events with it.
+	InstanceIDAnnotationKey = "konghq.com/instance-id"
 )

--- a/internal/manager/record.go
+++ b/internal/manager/record.go
@@ -1,0 +1,41 @@
+package manager
+
+import (
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
+)
+
+// newEventRecorderForInstance creates a new event recorder that will annotate all events with the given instance ID.
+// It implements standard the record.EventRecorder interface.
+func newEventRecorderForInstance(instanceID InstanceID, eventRecorder record.EventRecorder) *eventRecorderWithID {
+	return &eventRecorderWithID{
+		idAnnotation: map[string]string{
+			consts.InstanceIDAnnotationKey: instanceID.String(),
+		},
+		eventRecorder: eventRecorder,
+	}
+}
+
+var _ record.EventRecorder = &eventRecorderWithID{}
+
+type eventRecorderWithID struct {
+	idAnnotation  map[string]string
+	eventRecorder record.EventRecorder
+}
+
+func (e *eventRecorderWithID) AnnotatedEventf(
+	object runtime.Object, annotations map[string]string, eventtype string, reason string, messageFmt string, args ...interface{},
+) {
+	e.eventRecorder.AnnotatedEventf(object, lo.Assign(e.idAnnotation, annotations), eventtype, reason, messageFmt, args...)
+}
+
+func (e *eventRecorderWithID) Event(object runtime.Object, eventtype string, reason string, message string) {
+	e.eventRecorder.AnnotatedEventf(object, e.idAnnotation, eventtype, reason, message)
+}
+
+func (e *eventRecorderWithID) Eventf(object runtime.Object, eventtype string, reason string, messageFmt string, args ...interface{}) {
+	e.eventRecorder.AnnotatedEventf(object, e.idAnnotation, eventtype, reason, messageFmt, args...)
+}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -176,7 +176,7 @@ func New(
 	var eventRecorder record.EventRecorder
 	if c.EmitKubernetesEvents {
 		setupLog.Info("Emitting Kubernetes events enabled, creating an event recorder for " + consts.KongClientEventRecorderComponentName)
-		eventRecorder = mgr.GetEventRecorderFor(consts.KongClientEventRecorderComponentName)
+		eventRecorder = newEventRecorderForInstance(instanceID, mgr.GetEventRecorderFor(consts.KongClientEventRecorderComponentName))
 	} else {
 		setupLog.Info("Emitting Kubernetes events disabled, discarding all events")
 		// Create an empty record.FakeRecorder with no Events channel to discard all events.

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/mocks"
 )
@@ -103,9 +104,12 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		t.Logf("got %d events", len(events.Items))
 
 		const numberOfExpectedEvents = 8
+		// InstanceID of manager run for the test is the same as the test name.
+		expectedInstanceID := t.Name()
 		matches := make([]bool, numberOfExpectedEvents)
 		matches[0] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationApplyFailedEventReason &&
 				e.InvolvedObject.Kind == "Ingress" &&
 				e.InvolvedObject.Name == ingress.Name &&
@@ -113,6 +117,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		})
 		matches[1] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationApplyFailedEventReason &&
 				e.InvolvedObject.Kind == "Service" &&
 				e.InvolvedObject.Name == service.Name &&
@@ -120,6 +125,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		})
 		matches[2] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationApplyFailedEventReason &&
 				e.InvolvedObject.Kind == "Service" &&
 				e.InvolvedObject.Name == service.Name &&
@@ -128,6 +134,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		matches[3] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			ok, err := regexp.MatchString(`failed to apply Kong configuration to http://[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+: HTTP status 400 \(message: "failed posting new config to /config"\)`, e.Message)
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationApplyFailedEventReason &&
 				e.InvolvedObject.Kind == "Pod" &&
 				e.InvolvedObject.Name == podName &&
@@ -135,6 +142,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		})
 		matches[4] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationTranslationFailedEventReason &&
 				e.InvolvedObject.Kind == "Service" &&
 				e.InvolvedObject.Name == service.Name &&
@@ -142,6 +150,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		})
 		matches[5] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationTranslationFailedEventReason &&
 				e.InvolvedObject.Kind == "Service" &&
 				e.InvolvedObject.Name == service.Name &&
@@ -149,6 +158,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		})
 		matches[6] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationTranslationFailedEventReason &&
 				e.InvolvedObject.Kind == "Ingress" &&
 				e.InvolvedObject.Name == ingress.Name &&
@@ -156,6 +166,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		})
 		matches[7] = lo.ContainsBy(events.Items, func(e corev1.Event) bool {
 			return e.Type == corev1.EventTypeWarning &&
+				e.ObjectMeta.Annotations[consts.InstanceIDAnnotationKey] == expectedInstanceID &&
 				e.Reason == dataplane.KongConfigurationTranslationFailedEventReason &&
 				e.InvolvedObject.Kind == "Service" &&
 				e.InvolvedObject.Name == service.Name &&


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Each event generated by a controller has an annotation `konghq.com/instance-id` with the ID of a particular KIC instance making it identifiable. The actual format of ID (what this string contains) is not in the scope of this issue/PR. 
The interface of the standard K8s emitter is preserved but ensures that every event generated will have that annotation. 


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7046

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

