### PR TITLE
fix: GatewayReconciler will fall into a loop and cannot converge to stable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ Adding a new version? You'll need three changes:
   [#6881](https://github.com/Kong/kubernetes-ingress-controller/pull/6881)
 - Fix mapping `KongConsumer` to respective `KongConsumerGroup` in Konnect.
   [#7144](https://github.com/Kong/kubernetes-ingress-controller/pull/7144)
+- GatewayReconciler will fall into a loop and cannot converge to stable state.
+  [#7111](https://github.com/Kong/kubernetes-ingress-controller/pull/7111)
 
 ## [3.4.2]
 

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -876,7 +876,7 @@ func (r *GatewayReconciler) updateAddressesAndListenersStatus(
 		err := r.Status().Update(ctx, pruneGatewayStatusConds(gateway))
 		return handleUpdateError(err, r.Log, gateway)
 	}
-	if !reflect.DeepEqual(gateway.Status.Listeners, listenerStatuses) {
+	if !isEqualListenersStatus(gateway.Status.Listeners, listenerStatuses) {
 		gateway.Status.Listeners = listenerStatuses
 
 		err := r.Status().Update(ctx, gateway)

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
@@ -737,4 +738,44 @@ func getAttachedRoutesForListener(ctx context.Context, mgrc client.Client, gatew
 		}
 	}
 	return attachedRoutes, nil
+}
+
+// GatewayReconciler will determine the change of ListenerStatus to decide whether to update Gateway.status.
+// When Gateway.spec.listeners has many entries (greater than 10 and has a certain relationship with the number of HTTPRoutes),
+// GatewayReconciler will fall into a loop and cannot converge to a stable state (updating status
+// will trigger a new gateway reconciler event, and the new round of reconcile will always find differences).
+// The reason here is that when using reflect.DeepEqual to compare two slice structs,
+// the order of elements will affect the result, and Gateway.status.listeners[].conditions[].lastTransitionTime
+// will always be assigned the current time in each round of reconcile, which should be excluded.
+func isEqualListenersStatus(a, b []gatewayapi.ListenerStatus) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	t := metav1.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ax := prepareListenersStatusForDeepEqual(a, t)
+	bx := prepareListenersStatusForDeepEqual(b, t)
+
+	return reflect.DeepEqual(ax, bx)
+}
+
+func prepareListenersStatusForDeepEqual(ls []gatewayapi.ListenerStatus, t metav1.Time) []gatewayapi.ListenerStatus {
+	ret := make([]gatewayapi.ListenerStatus, len(ls))
+
+	for k, v := range ls {
+		co := v.DeepCopy()
+
+		sort.Slice(co.Conditions, func(i, j int) bool {
+			return co.Conditions[i].Type < co.Conditions[j].Type
+		})
+		for kc, _ := range co.Conditions {
+			co.Conditions[kc].LastTransitionTime = t
+		}
+		ret[k] = *co
+	}
+
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Name < ret[j].Name
+	})
+	return ret
 }

--- a/internal/controllers/gateway/gateway_utils_test.go
+++ b/internal/controllers/gateway/gateway_utils_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -522,6 +523,131 @@ func TestRouteAcceptedByGateways(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gateways := routeAcceptedByGateways(tc.route)
 			assert.Equal(t, tc.expectedGatewayNNs, gateways)
+		})
+	}
+}
+
+func Test_isEqualListenersStatus(t *testing.T) {
+	type args struct {
+		a []gatewayapi.ListenerStatus
+		b []gatewayapi.ListenerStatus
+	}
+
+	lastTransitionTime := metav1.Now()
+	lastTransitionTime2 := metav1.NewTime(lastTransitionTime.Add(time.Second))
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "",
+			args: args{
+				a: []gatewayapi.ListenerStatus{
+					{
+						Name: "http",
+						SupportedKinds: []gatewayapi.RouteGroupKind{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  gatewayapi.Kind("HTTPRoute"),
+							},
+						},
+					},
+					{
+						Name: "https",
+						SupportedKinds: []gatewayapi.RouteGroupKind{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  gatewayapi.Kind("HTTPRoute"),
+							},
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Accepted",
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: lastTransitionTime,
+							},
+						},
+					},
+				},
+				b: []gatewayapi.ListenerStatus{
+					{
+						Name: "https",
+						SupportedKinds: []gatewayapi.RouteGroupKind{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  gatewayapi.Kind("HTTPRoute"),
+							},
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:               "Accepted",
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: lastTransitionTime2,
+							},
+						},
+					},
+					{
+						Name: "http",
+						SupportedKinds: []gatewayapi.RouteGroupKind{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  gatewayapi.Kind("HTTPRoute"),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "",
+			args: args{
+				a: []gatewayapi.ListenerStatus{
+					{
+						Name: "http",
+						SupportedKinds: []gatewayapi.RouteGroupKind{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  gatewayapi.Kind("HTTPRoute"),
+							},
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Programmed",
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+				b: []gatewayapi.ListenerStatus{
+					{
+						Name: "http",
+						SupportedKinds: []gatewayapi.RouteGroupKind{
+							{
+								Group: lo.ToPtr(gatewayapi.V1Group),
+								Kind:  gatewayapi.Kind("HTTPRoute"),
+							},
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Accepted",
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEqualListenersStatus(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("isEqualListenersStatus() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

GatewayReconciler will determine the change of ListenerStatus to decide whether to update Gateway.status. When Gateway.spec.listeners has many entries (greater than 10 and has a certain relationship with the number of HTTPRoutes), GatewayReconciler will fall into a loop and cannot converge to a stable state (updating status will trigger a new gateway reconciler event, and the new round of reconcile will always find differences). The reason here is that when using reflect.DeepEqual to compare two slice structs, the order of elements will affect the result, and Gateway.status.listeners[].conditions[].lastTransitionTime will always be assigned the current time in each round of reconcile, which should be excluded.

**Which issue this PR fixes**:

fixes #7031 

**Special notes for your reviewer**:



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
