### PR TITLE
feat: report not only version but project name too to konnect

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -419,7 +419,7 @@ func setupKonnectNodeAgentWithMgr(
 	}
 	agent := konnect.NewNodeAgent(
 		resolveControllerHostnameForKonnect(logger),
-		metadata.Release,
+		metadata.UserAgent(),
 		c.Konnect.RefreshNodePeriod,
 		logger,
 		konnectNodesAPIClient,

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -33,6 +33,7 @@ var (
 	// Commit returns the SHA from the current branch HEAD.
 	Commit = NotSet
 
+	// ProjectName is the name of repository, the last part of the URL. Thus it's basically name of the application.
 	ProjectName = projectNameFromRepo(Repo)
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Report `kong-ingress-controller/v3.4.0` instead of `v3.4.0` by `nodeAgent` to make indistinguishable `KIC` from `KO`. This PR implements the outcome of the discussion - https://github.com/Kong/kubernetes-ingress-controller/issues/7051#issuecomment-2653311277

Furthermore, verify that `User-Agent` is set in `konnect` clients.

Implementation

https://github.com/Kong/kubernetes-ingress-controller/blob/e61ca89eb0f4500b272a275805c277e185821c19/internal/konnect/useragent/user_agent_round_tripper.go#L1-L25

tests that verify

- https://github.com/Kong/kubernetes-ingress-controller/blob/88f5c51275cbe213a8859a4fc7c9e157d6addc69/internal/konnect/controlplanes/client_test.go#L28-L38

- https://github.com/Kong/kubernetes-ingress-controller/blob/88f5c51275cbe213a8859a4fc7c9e157d6addc69/internal/konnect/license/client_test.go#L30-L34

- https://github.com/Kong/kubernetes-ingress-controller/blob/88f5c51275cbe213a8859a4fc7c9e157d6addc69/internal/konnect/nodes/client_test.go#L26-L28


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

closes #7051 

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

