### PR TITLE
chore: do not run goroutines in manager.New

### DIFF
--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -27,7 +27,7 @@ const (
 
 func MakeTLSServer(
 	ctx context.Context,
-	config *config.AdmissionServerConfig,
+	config config.AdmissionServerConfig,
 	handler http.Handler,
 	logger logr.Logger,
 ) (*http.Server, error) {
@@ -44,7 +44,7 @@ func MakeTLSServer(
 	}, nil
 }
 
-func serverConfigToTLSConfig(ctx context.Context, sc *config.AdmissionServerConfig, logger logr.Logger) (*tls.Config, error) {
+func serverConfigToTLSConfig(ctx context.Context, sc config.AdmissionServerConfig, logger logr.Logger) (*tls.Config, error) {
 	var watcher *certwatcher.CertWatcher
 	var cert, key []byte
 	switch {

--- a/internal/konnect/node_agent.go
+++ b/internal/konnect/node_agent.go
@@ -35,7 +35,7 @@ type GatewayInstanceGetter interface {
 }
 
 type GatewayClientsChangesNotifier interface {
-	SubscribeToGatewayClientsChanges() (<-chan struct{}, bool)
+	SubscribeToGatewayClientsChanges(ctx context.Context) (<-chan struct{}, bool)
 }
 
 type ManagerInstanceID interface {
@@ -221,7 +221,7 @@ func (a *NodeAgent) maybeUpdateConfigStatus(ctx context.Context) {
 }
 
 func (a *NodeAgent) subscribeToGatewayClientsChanges(ctx context.Context) {
-	gatewayClientsChangedCh, changesAreExpected := a.gatewayClientsChangesNotifier.SubscribeToGatewayClientsChanges()
+	gatewayClientsChangedCh, changesAreExpected := a.gatewayClientsChangesNotifier.SubscribeToGatewayClientsChanges(ctx)
 	if !changesAreExpected {
 		// There are no changes of gateway clients going to happen, we don't have to watch them.
 		return

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -48,7 +48,7 @@ func newMockGatewayClientsNotifier() *mockGatewayClientsNotifier {
 	}
 }
 
-func (m *mockGatewayClientsNotifier) SubscribeToGatewayClientsChanges() (<-chan struct{}, bool) {
+func (m *mockGatewayClientsNotifier) SubscribeToGatewayClientsChanges(context.Context) (<-chan struct{}, bool) {
 	return m.ch, true
 }
 

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -185,28 +185,25 @@ func setupDataplaneSynchronizer(
 	return dataplaneSynchronizer, nil
 }
 
-func setupAdmissionServer(
+func (m *Manager) setupAdmissionServer(
 	ctx context.Context,
-	managerConfig managercfg.Config,
-	clientsManager *clients.AdminAPIClientsManager,
 	referenceIndexers ctrlref.CacheIndexers,
-	managerClient client.Client,
 	translatorFeatures translator.FeatureFlags,
 	storer store.Storer,
 ) error {
 	admissionLogger := ctrl.LoggerFrom(ctx).WithName("admission-server")
 
-	if managerConfig.AdmissionServer.ListenAddr == "off" {
+	if m.cfg.AdmissionServer.ListenAddr == "off" {
 		admissionLogger.Info("Admission webhook server disabled")
 		return nil
 	}
 
-	adminAPIServicesProvider := admission.NewDefaultAdminAPIServicesProvider(clientsManager)
-	srv, err := admission.MakeTLSServer(ctx, &managerConfig.AdmissionServer, &admission.RequestHandler{
+	adminAPIServicesProvider := admission.NewDefaultAdminAPIServicesProvider(m.clientsManager)
+	srv, err := admission.MakeTLSServer(ctx, m.cfg.AdmissionServer, &admission.RequestHandler{
 		Validator: admission.NewKongHTTPValidator(
 			admissionLogger,
-			managerClient,
-			managerConfig.IngressClassName,
+			m.m.GetClient(),
+			m.cfg.IngressClassName,
 			adminAPIServicesProvider,
 			translatorFeatures,
 			storer,
@@ -217,10 +214,8 @@ func setupAdmissionServer(
 	if err != nil {
 		return err
 	}
-	go func() {
-		err := srv.ListenAndServeTLS("", "")
-		admissionLogger.Error(err, "Admission webhook server stopped")
-	}()
+
+	m.admissionServer = mo.Some(srv)
 	return nil
 }
 

--- a/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/test/envtest/kongadminapi_controller_envtest_test.go
@@ -38,7 +38,7 @@ type notifier struct {
 	last []adminapi.DiscoveredAdminAPI
 }
 
-func (n *notifier) Notify(adminAPIs []adminapi.DiscoveredAdminAPI) {
+func (n *notifier) Notify(_ context.Context, adminAPIs []adminapi.DiscoveredAdminAPI) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	n.last = adminAPIs


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove spawning of long-running goroutines from the `internalmanager.New` constructor.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7099.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->


