### PR TITLE
chore: ensure no gouroutines leak after cancelling manager

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -180,14 +180,17 @@ linters-settings:
         - "!**/pkg/manager/*.go"
         # TODO: Remove those exclusion once the needed parts of manager are moved to pkg/manager.
         # Imported stuff: consts, flags, kongconfig, utils.GetKubeconfig(...).
-        - "!**/pkg/telemetry/reports.go"
+        - "!**/internal/admission/server.go"
+        - "!**/internal/cmd/rootcmd/config/cli.go"
         - "!**/internal/dataplane/kong_client_golden_test.go"
         - "!**/internal/dataplane/translator/translator_test.go"
-        - "!**/test/integration/isolated/backendtlspolicy_test.go"
-        - "!**/internal/cmd/rootcmd/config/cli.go"
-        - "!**/test/internal/helpers/kong.go"
-        - "!**/test/envtest/telemetry_test.go"
+        - "!**/internal/diagnostics/server.go"
+        - "!**/pkg/telemetry/reports.go"
         - "!**/test/envtest/configerrorevent_envtest_test.go"
+        - "!**/test/envtest/manager_envtest_test.go"
+        - "!**/test/envtest/telemetry_test.go"
+        - "!**/test/integration/isolated/backendtlspolicy_test.go"
+        - "!**/test/internal/helpers/kong.go"
         deny:
         - pkg: github.com/kong/kubernetes-ingress-controller/v3/internal/manager
           desc: github.com/kong/kubernetes-ingress-controller/v3/internal/manager should not be used outside of its package. Use github.com/kong/kubernetes-ingress-controller/v3/pkg/manager instead.

--- a/internal/admission/server.go
+++ b/internal/admission/server.go
@@ -3,15 +3,18 @@ package admission
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/go-logr/logr"
+	"github.com/samber/mo"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 )
 
@@ -25,26 +28,54 @@ const (
 	DefaultAdmissionWebhookKeyPath  = "/admission-webhook/tls.key"
 )
 
-func MakeTLSServer(
-	ctx context.Context,
-	config config.AdmissionServerConfig,
-	handler http.Handler,
-	logger logr.Logger,
-) (*http.Server, error) {
+type Server struct {
+	s           *http.Server
+	certWatcher mo.Option[*certwatcher.CertWatcher]
+}
+
+func MakeTLSServer(config config.AdmissionServerConfig, handler http.Handler) (*Server, error) {
 	const defaultHTTPReadHeaderTimeout = 10 * time.Second
-	tlsConfig, err := serverConfigToTLSConfig(ctx, config, logger)
+
+	s := &Server{}
+	tlsConfig, err := s.setupTLSConfig(config)
 	if err != nil {
 		return nil, err
 	}
-	return &http.Server{
+
+	s.s = &http.Server{
 		Addr:              config.ListenAddr,
 		TLSConfig:         tlsConfig,
 		Handler:           handler,
 		ReadHeaderTimeout: defaultHTTPReadHeaderTimeout,
-	}, nil
+	}
+	return s, nil
 }
 
-func serverConfigToTLSConfig(ctx context.Context, sc config.AdmissionServerConfig, logger logr.Logger) (*tls.Config, error) {
+// Start starts the admission server and blocks until the context is done.
+func (s *Server) Start(ctx context.Context) error {
+	logger := ctrllog.FromContext(ctx)
+	go func() {
+		if err := s.s.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error(err, "Failed to start admission server")
+		}
+	}()
+
+	if cw, ok := s.certWatcher.Get(); ok {
+		go func() {
+			if err := cw.Start(ctx); err != nil {
+				logger.Error(err, "Failed to start CertWatcher")
+			}
+		}()
+	}
+
+	<-ctx.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), consts.DefaultGracefulShutdownTimeout) //nolint:contextcheck
+	defer cancel()
+	return s.s.Shutdown(ctx)
+}
+
+func (s *Server) setupTLSConfig(sc config.AdmissionServerConfig) (*tls.Config, error) {
 	var watcher *certwatcher.CertWatcher
 	var cert, key []byte
 	switch {
@@ -81,11 +112,11 @@ func serverConfigToTLSConfig(ctx context.Context, sc config.AdmissionServerConfi
 		return nil, fmt.Errorf("either cert/key files OR cert/key values must be provided, or none")
 	}
 
-	go func() {
-		if err := watcher.Start(ctx); err != nil {
-			logger.Error(err, "Certificate watcher error")
-		}
-	}()
+	// If we have a watcher, we need to keep it to run it later in Start() method.
+	if watcher != nil {
+		s.certWatcher = mo.Some(watcher)
+	}
+
 	return &tls.Config{
 		MinVersion:     tls.VersionTLS12,
 		MaxVersion:     tls.VersionTLS13,

--- a/internal/manager/consts/consts.go
+++ b/internal/manager/consts/consts.go
@@ -1,5 +1,7 @@
 package consts
 
+import "time"
+
 // -----------------------------------------------------------------------------
 // Controller Manager - Constants & Vars
 // -----------------------------------------------------------------------------
@@ -34,4 +36,8 @@ const (
 	// InstanceIDAnnotationKey is the annotation key used to store the instance ID of particular manager,
 	// to corelate events with it.
 	InstanceIDAnnotationKey = "konghq.com/instance-id"
+
+	// DefaultGracefulShutdownTimeout is the default timeout for graceful shutdown. It is used by the manager
+	// subcomponents to wait for the resources to be cleaned up before shutting down.
+	DefaultGracefulShutdownTimeout = time.Second * 5
 )

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/admission"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/clients"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/gateway"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
@@ -63,7 +64,7 @@ type Manager struct {
 	diagnosticsServer    mo.Option[diagnostics.Server]
 	diagnosticsCollector mo.Option[*diagnostics.Collector]
 	diagnosticsHandler   mo.Option[*diagnostics.HTTPHandler]
-	admissionServer      mo.Option[*http.Server]
+	admissionServer      mo.Option[*admission.Server]
 	kubeconfig           *rest.Config
 	clientsManager       *clients.AdminAPIClientsManager
 }
@@ -521,7 +522,7 @@ func (m *Manager) Run(ctx context.Context) error {
 	if s, ok := m.admissionServer.Get(); ok {
 		go func() {
 			logger.Info("Starting admission server")
-			if err := s.ListenAndServeTLS("", ""); err != nil {
+			if err := s.Start(ctx); err != nil {
 				logger.Error(err, "Admission server exited")
 			}
 		}()

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -199,7 +199,7 @@ func (m *Manager) setupAdmissionServer(
 	}
 
 	adminAPIServicesProvider := admission.NewDefaultAdminAPIServicesProvider(m.clientsManager)
-	srv, err := admission.MakeTLSServer(ctx, m.cfg.AdmissionServer, &admission.RequestHandler{
+	srv, err := admission.MakeTLSServer(m.cfg.AdmissionServer, &admission.RequestHandler{
 		Validator: admission.NewKongHTTPValidator(
 			admissionLogger,
 			m.m.GetClient(),
@@ -210,7 +210,7 @@ func (m *Manager) setupAdmissionServer(
 		),
 		ReferenceIndexers: referenceIndexers,
 		Logger:            admissionLogger,
-	}, admissionLogger)
+	})
 	if err != nil {
 		return err
 	}

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -53,7 +53,7 @@ func TestAdmissionWebhook_KongVault(t *testing.T) {
 	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
-		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, admissionWebhookPort),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 		WithUpdateStatus(),
 	)
@@ -198,7 +198,7 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
-		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, admissionWebhookPort),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 	)
 	WaitForManagerStart(t, logs)
@@ -452,7 +452,7 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
-		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, admissionWebhookPort),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 	)
 	WaitForManagerStart(t, logs)
@@ -716,7 +716,7 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
-		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, admissionWebhookPort),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 	)
 	WaitForManagerStart(t, logs)
@@ -1057,7 +1057,7 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
-		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, admissionWebhookPort),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 	)
 	WaitForManagerStart(t, logs)
@@ -1225,7 +1225,7 @@ func TestAdmissionWebhook_KongCustomEntities(t *testing.T) {
 	logs := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(ns.Name),
-		WithAdmissionWebhookEnabled(webhookKey, webhookCert, fmt.Sprintf(":%d", admissionWebhookPort)),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, admissionWebhookPort),
 		WithKongAdminURLs(kongContainer.AdminURL(ctx, t)),
 	)
 	WaitForManagerStart(t, logs)

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -10,11 +10,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"go.uber.org/zap/zaptest/observer"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
+	testhelpers "github.com/kong/kubernetes-ingress-controller/v3/test/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/helpers/certificate"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
@@ -68,4 +75,48 @@ func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
 		return hasLog(startingManagerLog) &&
 			hasLog(configurationSyncedToKongLog)
 	}, time.Minute, time.Millisecond)
+}
+
+func TestManager_NoLeakedGoroutinesAfterContextCancellation(t *testing.T) {
+	// Not using t.Parallel() because goleak.VerifyNone(t) does not work with parallel tests.
+	t.Cleanup(func() {
+		t.Logf("Checking for goroutine leaks")
+		goleak.VerifyNone(t)
+	})
+
+	scheme := Scheme(t, WithKong)
+	envcfg := Setup(t, scheme)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	diagnosticsServerPort := testhelpers.GetFreePort(t)
+	webhookServerPort := testhelpers.GetFreePort(t)
+	webhookCert, webhookKey := certificate.MustGenerateCertPEMFormat(
+		certificate.WithDNSNames("localhost"),
+	)
+	ctx = ctrllog.IntoContext(ctx, testr.New(t))
+	t.Log("Running the manager")
+	m := SetupManager(ctx, t, manager.NewRandomID(), envcfg, AdminAPIOptFns(),
+		WithDefaultEnvTestsConfig(envcfg),
+		WithDiagnosticsServer(diagnosticsServerPort),
+		WithAdmissionWebhookEnabled(webhookKey, webhookCert, webhookServerPort),
+	)
+	go func() {
+		err := m.Run(ctx)
+		require.NoError(t, err)
+	}()
+
+	t.Log("Waiting for the manager to become ready")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.NoError(t, m.IsReady())
+	}, time.Minute, time.Millisecond)
+
+	t.Log("Cancelling context")
+	cancel()
+
+	t.Logf("Waiting for the manager to stop gracefully, this should happen within %f seconds",
+		consts.DefaultGracefulShutdownTimeout.Seconds(),
+	)
+	<-time.After(consts.DefaultGracefulShutdownTimeout)
 }

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -166,9 +166,9 @@ func WithKongAdminURLs(urls ...string) func(cfg *managercfg.Config) {
 	}
 }
 
-func WithAdmissionWebhookEnabled(key, cert []byte, addr string) func(cfg *managercfg.Config) {
+func WithAdmissionWebhookEnabled(key, cert []byte, port int) func(cfg *managercfg.Config) {
 	return func(cfg *managercfg.Config) {
-		cfg.AdmissionServer.ListenAddr = addr
+		cfg.AdmissionServer.ListenAddr = fmt.Sprintf(":%d", port)
 		cfg.AdmissionServer.Key = string(key)
 		cfg.AdmissionServer.Cert = string(cert)
 	}
@@ -210,7 +210,12 @@ func AdminAPIOptFns(fns ...mocks.AdminAPIHandlerOpt) []mocks.AdminAPIHandlerOpt 
 }
 
 func SetupManager(
-	ctx context.Context, t *testing.T, mgrID manager.ID, envcfg *rest.Config, adminAPIOpts []mocks.AdminAPIHandlerOpt, modifyCfgFns ...managercfg.Opt,
+	ctx context.Context,
+	t *testing.T,
+	mgrID manager.ID,
+	envcfg *rest.Config,
+	adminAPIOpts []mocks.AdminAPIHandlerOpt,
+	modifyCfgFns ...managercfg.Opt,
 ) *manager.Manager {
 	adminAPIServerURL := StartAdminAPIServerMock(t, adminAPIOpts...).URL
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements graceful shutdown for admission and diagnostics servers. Ensures no goroutines leak after cancelling the context passed to `Manager.Run`.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/7041.
<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

