### PR TITLE
[Backport release/3.4.x] chore(ci): harden GITHUB_TOKEN permissions (#6961)

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -9,6 +9,9 @@ on:
         default: ""
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   dependencies-versions:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_docker_build.yaml
+++ b/.github/workflows/_docker_build.yaml
@@ -20,6 +20,9 @@ on:
         description: The image name and tag.
         value: ${{ jobs.build.outputs.image }}
 
+permissions:
+  contents: read
+
 jobs:
   prepare-tags:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -32,6 +32,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   setup-e2e-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -3,6 +3,9 @@ name: envtest tests
 on:
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   envtest-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -39,6 +39,9 @@ on:
         default: ""
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   dependencies-versions:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -3,6 +3,9 @@ name: kong integration tests
 on:
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   kongintegration-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}

--- a/.github/workflows/_linters.yaml
+++ b/.github/workflows/_linters.yaml
@@ -3,6 +3,9 @@ name: linters
 on:
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -23,6 +23,9 @@ on:
         description: The number of resource for performance tests
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   performance-matrix:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}

--- a/.github/workflows/_permission_check.yaml
+++ b/.github/workflows/_permission_check.yaml
@@ -6,6 +6,9 @@ name: permission check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-permission:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_test_reports.yaml
+++ b/.github/workflows/_test_reports.yaml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/_unit_tests.yaml
+++ b/.github/workflows/_unit_tests.yaml
@@ -3,6 +3,9 @@ name: unit tests
 on:
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,11 +5,17 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Backport
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
-  deployments: write
+  contents: read
+  deployments: read
 
 jobs:
   benchmark:
@@ -23,6 +23,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 

--- a/.github/workflows/check_fixed_issues_references.yaml
+++ b/.github/workflows/check_fixed_issues_references.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '30 4 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
     check_issues_state:
       timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   label:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,6 +19,9 @@ on:
       - '**'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   check-permission:
     uses: ./.github/workflows/_permission_check.yaml
@@ -142,6 +145,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
     needs:
+      - ensure-actions-sha-pin
       - up-to-date
       - tools
       - ensure-actions-sha-pin

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '*/30 * * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   gcloud:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,6 +17,9 @@ on:
     - cron: '27 0 * * 4'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -9,6 +9,9 @@ on:
         required: false
         default: main
 
+permissions:
+  contents: read
+
 jobs:
   dependencies-versions:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '30 4 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   ensure-nightly-image-was-built:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -31,6 +31,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   post-comment-in-pr:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
@@ -43,6 +46,9 @@ jobs:
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.inputs.pr-number }}
       RUN_GKE: ${{ inputs.run-gke }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: |

--- a/.github/workflows/e2e_trigger_via_label.yaml
+++ b/.github/workflows/e2e_trigger_via_label.yaml
@@ -5,6 +5,9 @@ on:
     types:
     - labeled
 
+permissions:
+  contents: read
+
 jobs:
   check-permission:
     uses: ./.github/workflows/_permission_check.yaml
@@ -20,7 +23,9 @@ jobs:
       WORKFLOW: .github/workflows/e2e_targeted.yaml
       BRANCH: ${{ github.event.pull_request.head.ref }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '30 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   fossa-scan:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '30 3 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build-push-images:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}

--- a/.github/workflows/performance_nightly.yaml
+++ b/.github/workflows/performance_nightly.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '30 5 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   ensure-nightly-image-was-built:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/.github/workflows/performance_targeted.yaml
+++ b/.github/workflows/performance_targeted.yaml
@@ -23,11 +23,17 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   post-comment-in-pr:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: ${{ github.event.inputs.pr-number != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
       # URL is the current workflow's run URL.

--- a/.github/workflows/performance_trigger_via_label.yaml
+++ b/.github/workflows/performance_trigger_via_label.yaml
@@ -5,11 +5,17 @@ on:
     types:
     - labeled
 
+permissions:
+  contents: read
+
 jobs:
   trigger-performance-tests-targeted:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     if: contains(github.event.*.labels.*.name, 'ci/run-performance')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
       WORKFLOW: .github/workflows/performance_targeted.yaml

--- a/.github/workflows/regenerate_on_deps_bump.yaml
+++ b/.github/workflows/regenerate_on_deps_bump.yaml
@@ -8,15 +8,22 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   regenerate:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     if: contains(github.event.*.labels.*.name, 'renovate/auto-regenerate')
     runs-on: ubuntu-latest
+    env:
+      REF: ${{ github.event.pull_request.head.ref }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ env.ref }}
           token: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
 
       - name: setup golang
@@ -39,4 +46,4 @@ jobs:
           git status
           git diff-index --quiet HEAD || \
           git commit -m "chore: regenerate" && \
-          git push origin ${{ github.event.pull_request.head.ref }}
+          git push origin ${{ env.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   verify-manifest-tag:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
@@ -155,6 +158,8 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: [build-push-images, test-e2e]
+    permissions:
+      contents: write
     steps:
     - name: Parse semver string
       id: semver_parser
@@ -186,6 +191,8 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: github.event.inputs.latest == 'true'
+    permissions:
+      contents: write
     needs:
     - publish-release
     steps:

--- a/.github/workflows/release_docs.yaml
+++ b/.github/workflows/release_docs.yaml
@@ -7,10 +7,16 @@ on:
         description: 'The version to release (e.g. v1.2.3)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   create_docs_pr:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Parse semver string
         id: semver_parser

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -23,6 +23,9 @@ env:
   kong-gateway-oss-tag: latest-ubuntu
   kong-gateway-oss-effective-version: "3.4.1"
 
+permissions:
+  contents: read
+
 jobs:
   post-comment-in-pr:
     if: (contains(github.event.*.labels.*.name, 'ci/run-nightly') || github.event_name == 'workflow_dispatch') && github.event.pull_request.number != ''
@@ -33,6 +36,9 @@ jobs:
       # Sadly this is not readily available in github's context.
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: |

--- a/.github/workflows/validate_kong_image.yaml
+++ b/.github/workflows/validate_kong_image.yaml
@@ -33,6 +33,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   startup-issue-comment:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
@@ -90,6 +93,9 @@ jobs:
     - run-integration-tests
     if: ${{ always() && github.event.inputs.issue-number != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
       URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/validate_kong_image_trigger_via_label.yaml
+++ b/.github/workflows/validate_kong_image_trigger_via_label.yaml
@@ -4,12 +4,18 @@ on:
     types:
     - labeled
 
+permissions:
+  contents: read
+
 jobs:
   # Firstly remove the issue label to avoid duplicate triggers.
   check-and-remove-issue-label:
     name: Check label "ci/run-validate-kong-image" and remove the label
     if: contains(github.event.*.labels.*.name, 'ci/run-validate-kong-image')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
@@ -100,7 +106,7 @@ jobs:
             echo "KIC_IMAGE_TAG=2.12" >> $GITHUB_OUTPUT
           elif [ $TEST_KONG_IMAGE_MAJOR_VERSION -eq 3 ] && [ $TEST_KONG_IMAGE_MINOR_VERSION -le 3 ]; then
             echo "KIC_BRANCH=release/2.12.x" >> $GITHUB_OUTPUT
-            echo "KIC_IMAGE_TAG=2.12" >> $GITHUB_OUTPUT          
+            echo "KIC_IMAGE_TAG=2.12" >> $GITHUB_OUTPUT
           else
             echo "KIC_BRANCH=main" >> $GITHUB_OUTPUT
             echo "KIC_IMAGE_TAG=latest" >> $GITHUB_OUTPUT
@@ -113,6 +119,9 @@ jobs:
     - extract-and-parse-container-image
     - decide-kic-branch-and-image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     env:
       GH_TOKEN: ${{ secrets.K8S_TEAM_BOT_GH_PAT }}
       WORKFLOW: .github/workflows/validate_kong_image.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Backport #6961

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
