### PR TITLE
fix: map `KongConsumer` to respective `KongConsumerGroup` in Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,9 @@ Adding a new version? You'll need three changes:
   [#6881](https://github.com/Kong/kubernetes-ingress-controller/pull/6881)
 - `AddToScheme` is only run in the initialization of scheme of the manager but
   not called in `scheme.Get` to reduce the CPU usage.
-  [#7105](https://github.com/Kong/kubernetes-ingress-controller/pull/7105) 
+  [#7105](https://github.com/Kong/kubernetes-ingress-controller/pull/7105)
+- Fix mapping `KongConsumer` to respective `KongConsumerGroup` in Konnect
+  [#7144](https://github.com/Kong/kubernetes-ingress-controller/pull/7144)
 
 ## [3.4.1]
 

--- a/internal/dataplane/kongstate/consumer.go
+++ b/internal/dataplane/kongstate/consumer.go
@@ -32,8 +32,9 @@ type Consumer struct {
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
 func (c *Consumer) SanitizedCopy(uuidGenerator util.UUIDGenerator) Consumer {
 	return Consumer{
-		Consumer: c.Consumer,
-		Plugins:  c.Plugins,
+		Consumer:       c.Consumer,
+		Plugins:        c.Plugins,
+		ConsumerGroups: c.ConsumerGroups,
 		KeyAuths: func() []*KeyAuth {
 			if c.KeyAuths == nil {
 				return nil

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -29,6 +29,10 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 					CreatedAt: int64Ptr(4),
 					Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
 				},
+				ConsumerGroups: []kong.ConsumerGroup{
+					{ID: kong.String("group-1")},
+					{ID: kong.String("group-2")},
+				},
 				Plugins: []kong.Plugin{{ID: kong.String("1")}},
 				KeyAuths: []*KeyAuth{
 					{
@@ -74,6 +78,10 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 					Username:  kong.String("3"),
 					CreatedAt: int64Ptr(4),
 					Tags:      []*string{kong.String("5.1"), kong.String("5.2")},
+				},
+				ConsumerGroups: []kong.ConsumerGroup{
+					{ID: kong.String("group-1")},
+					{ID: kong.String("group-2")},
 				},
 				Plugins: []kong.Plugin{{ID: kong.String("1")}},
 				KeyAuths: []*KeyAuth{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

KIC `3.0.3` was the last without feature gate `SanitizeKonnectConfigDumps=true` by default (everything works as expected).

For newer versions mapping of `KongConsumer`s to respective `KongConsumersGroup` is broken because the code responsible for sanitization omits consumer groups by mistake.

This field is crucial for proper mapping, see how the config is generated

https://github.com/Kong/kubernetes-ingress-controller/blob/ff2a3d9313651293084e36bafe7479494b3e88c8/internal/dataplane/deckgen/generate.go#L152-L166




<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

fixes https://github.com/Kong/kubernetes-ingress-controller/issues/7143


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
