### PR TITLE
chore(linter): replace deprecated `tenv` with `usetesting`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,7 +41,7 @@ linters:
   - prealloc
   - revive
   - staticcheck
-  - tenv
+  - usetesting
   - typecheck
   - unconvert
   - unparam
@@ -153,8 +153,8 @@ linters-settings:
       - github.com/kong/kubernetes-ingress-controller/v2:
           recommendations:
           - github.com/kong/kubernetes-ingress-controller/v3
-  tenv:
-    all: true
+  usetesting:
+    os-temp-dir: true
   loggercheck:
     kitlog: false
     klog: true

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -798,12 +798,9 @@ func getTemporaryKubeconfig(t *testing.T, env environments.Environment) string {
 	t.Log("creating a tempfile for kubeconfig")
 	kubeconfig, err := generators.NewKubeConfigForRestConfig(env.Name(), env.Cluster().Config())
 	require.NoError(t, err)
-	kubeconfigFile, err := os.CreateTemp(os.TempDir(), "manifest-tests-kubeconfig-")
+	kubeconfigFile, err := os.CreateTemp(t.TempDir(), "manifest-tests-kubeconfig-")
 	require.NoError(t, err)
 	defer kubeconfigFile.Close()
-	t.Cleanup(func() {
-		assert.NoError(t, os.Remove(kubeconfigFile.Name()))
-	})
 
 	t.Logf("dumping kubeconfig to tempfile: %s", kubeconfigFile.Name())
 	written, err := kubeconfigFile.Write(kubeconfig)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Log from `make lint` contains

```log
...
WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting. 
...
```

so this PR implements the advice and furthermore [enable all checks](https://golangci-lint.run/usage/linters/#usetesting) for `usetesting` linter