### PR TITLE
chore: bump Go to 1.24.0 and fix issues reported by linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-ingress-controller/v3
 
-go 1.23.2
+go 1.24.0
 
 // TODO: this is disabled by FOSSA action doesn't support go 1.21's toolchain clause:
 //

--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -1,7 +1,6 @@
 package adminapi_test
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -20,7 +19,7 @@ func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
 	adminAPIServer := httptest.NewServer(adminAPIHandler)
 	t.Cleanup(func() { adminAPIServer.Close() })
 
-	client, err := factory.CreateAdminAPIClient(context.Background(), adminapi.DiscoveredAdminAPI{
+	client, err := factory.CreateAdminAPIClient(t.Context(), adminapi.DiscoveredAdminAPI{
 		Address: adminAPIServer.URL,
 		PodRef: k8stypes.NamespacedName{
 			Namespace: "namespace",

--- a/internal/adminapi/endpoints_test.go
+++ b/internal/adminapi/endpoints_test.go
@@ -1,7 +1,6 @@
 package adminapi
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -638,7 +637,7 @@ func TestDiscoverer_GetAdminAPIsForService(t *testing.T) {
 			discoverer, err := NewDiscoverer(portNames)
 			require.NoError(t, err)
 
-			got, err := discoverer.GetAdminAPIsForService(context.Background(), fakeClient, tt.service)
+			got, err := discoverer.GetAdminAPIsForService(t.Context(), fakeClient, tt.service)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/adminapi/kong_test.go
+++ b/internal/adminapi/kong_test.go
@@ -1,7 +1,6 @@
 package adminapi_test
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -203,7 +202,7 @@ func TestNewKongClientForWorkspace(t *testing.T) {
 			t.Cleanup(func() { adminAPIServer.Close() })
 
 			client, err := adminapi.NewKongClientForWorkspace(
-				context.Background(),
+				t.Context(),
 				adminAPIServer.URL,
 				tc.workspace,
 				adminapi.ClientOpts{},
@@ -282,7 +281,7 @@ func validate(
 
 	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	require.NoError(t, err, "failed to create basic HTTP request")
-	response, err := cl.DoRAW(context.Background(), req)
+	response, err := cl.DoRAW(t.Context(), req)
 	require.NoError(t, err, "Kong API client failed to issue a basic request")
 	defer response.Body.Close()
 

--- a/internal/adminapi/konnect_test.go
+++ b/internal/adminapi/konnect_test.go
@@ -3,7 +3,6 @@
 package adminapi_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 func TestNewKongClientForKonnectControlPlane(t *testing.T) {
 	t.Skip("There's no infrastructure for Konnect tests yet")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	const controlPlaneID = "adf78c28-5763-4394-a9a4-a9436a1bea7d"
 
 	c, err := adminapi.NewKongClientForKonnectControlPlane(adminapi.KonnectConfig{

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -1,7 +1,6 @@
 package admission
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -99,7 +98,7 @@ func TestHandleKongIngress(t *testing.T) {
 
 			responseBuilder := NewResponseBuilder(k8stypes.UID(""))
 
-			got, err := handler.handleKongIngress(context.Background(), request, responseBuilder)
+			got, err := handler.handleKongIngress(t.Context(), request, responseBuilder)
 			require.NoError(t, err)
 			require.True(t, got.Allowed)
 			require.Equal(t, tt.wantWarnings, got.Warnings)
@@ -428,7 +427,7 @@ func TestHandleSecret(t *testing.T) {
 			}
 
 			responseBuilder := NewResponseBuilder(k8stypes.UID(""))
-			got, err := handler.handleSecret(context.Background(), request, responseBuilder)
+			got, err := handler.handleSecret(t.Context(), request, responseBuilder)
 			if tc.expectError {
 				require.Error(t, err)
 				return

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -962,7 +962,7 @@ func TestValidateHTTPRoute(t *testing.T) {
 
 			// Passed routesValidator is irrelevant for the above test cases.
 			valid, validMsg, err := ValidateHTTPRoute(
-				context.Background(), mockRoutesValidator{}, translator.FeatureFlags{}, tt.route, fakeClient,
+				t.Context(), mockRoutesValidator{}, translator.FeatureFlags{}, tt.route, fakeClient,
 			)
 			assert.Equal(t, tt.valid, valid, tt.msg)
 			assert.Equal(t, tt.validationMsg, validMsg, tt.msg)

--- a/internal/admission/validation/ingress/ingress_test.go
+++ b/internal/admission/validation/ingress/ingress_test.go
@@ -50,7 +50,7 @@ func TestValidateIngress(t *testing.T) {
 			})
 			require.NoError(t, err)
 			valid, validMsg, err := ValidateIngress(
-				context.Background(),
+				t.Context(),
 				mockRoutesValidator{},
 				translator.FeatureFlags{},
 				tt.ingress,

--- a/internal/admission/validator_test.go
+++ b/internal/admission/validator_test.go
@@ -299,7 +299,7 @@ func TestKongHTTPValidator_ValidatePlugin(t *testing.T) {
 				},
 				ingressClassMatcher: fakeClassMatcher,
 			}
-			gotOK, gotMessage, err := validator.ValidatePlugin(context.Background(), tt.args.plugin, tt.args.overrideSecrets)
+			gotOK, gotMessage, err := validator.ValidatePlugin(t.Context(), tt.args.plugin, tt.args.overrideSecrets)
 			assert.Equalf(t, tt.wantOK, gotOK,
 				"KongHTTPValidator.ValidatePlugin() want OK: %v, got OK: %v",
 				tt.wantOK, gotOK,
@@ -513,7 +513,7 @@ func TestKongHTTPValidator_ValidateClusterPlugin(t *testing.T) {
 				ingressClassMatcher: fakeClassMatcher,
 			}
 
-			gotOK, gotMessage, err := validator.ValidateClusterPlugin(context.Background(), tt.args.plugin, tt.args.overrideSecrets)
+			gotOK, gotMessage, err := validator.ValidateClusterPlugin(t.Context(), tt.args.plugin, tt.args.overrideSecrets)
 			assert.Equalf(t, tt.wantOK, gotOK,
 				"KongHTTPValidator.ValidateClusterPlugin() want OK: %v, got OK: %v",
 				tt.wantOK, gotOK,
@@ -543,7 +543,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 			ingressClassMatcher: fakeClassMatcher,
 		}
 
-		valid, errText, err := validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
+		valid, errText, err := validator.ValidateConsumer(t.Context(), kongv1.KongConsumer{
 			Username: "username",
 		})
 		require.NoError(t, err)
@@ -553,7 +553,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 		// make services unavailable
 		validator.AdminAPIServicesProvider = fakeServicesProvider{}
 
-		valid, errText, err = validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
+		valid, errText, err = validator.ValidateConsumer(t.Context(), kongv1.KongConsumer{
 			Username: "username",
 		})
 		require.NoError(t, err)
@@ -571,7 +571,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 			ingressClassMatcher: fakeClassMatcher,
 		}
 
-		valid, errText, err := validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
+		valid, errText, err := validator.ValidateConsumer(t.Context(), kongv1.KongConsumer{
 			Username: "username",
 		})
 		require.NoError(t, err)
@@ -617,7 +617,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 			ingressClassMatcher: fakeClassMatcher,
 		}
 
-		valid, _, err := validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
+		valid, _, err := validator.ValidateConsumer(t.Context(), kongv1.KongConsumer{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					annotations.AnnotationPrefix + annotations.PluginsKey: "plugin1,plugin2,plugin3",
@@ -661,7 +661,7 @@ func TestKongHTTPValidator_ValidateConsumer(t *testing.T) {
 			ingressClassMatcher: fakeClassMatcher,
 		}
 
-		valid, errText, err := validator.ValidateConsumer(context.Background(), kongv1.KongConsumer{
+		valid, errText, err := validator.ValidateConsumer(t.Context(), kongv1.KongConsumer{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					annotations.AnnotationPrefix + annotations.PluginsKey: "plugin1,plugin2,plugin3",
@@ -880,7 +880,7 @@ func TestKongHTTPValidator_ValidateConsumerGroup(t *testing.T) {
 				ingressClassMatcher: fakeClassMatcher,
 				Logger:              zapr.NewLogger(zap.NewNop()),
 			}
-			got, gotMsg, err := validator.ValidateConsumerGroup(context.Background(), tt.args.cg)
+			got, gotMsg, err := validator.ValidateConsumerGroup(t.Context(), tt.args.cg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("KongHTTPValidator.ValidateConsumerGroups() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1010,7 +1010,7 @@ func TestKongHTTPValidator_ValidateCredential(t *testing.T) {
 				Logger:                   logr.Discard(),
 			}
 
-			ok, msg := validator.ValidateCredential(context.Background(), tc.secret)
+			ok, msg := validator.ValidateCredential(t.Context(), tc.secret)
 			assert.Equal(t, tc.wantOK, ok)
 			assert.Equal(t, tc.wantMessage, msg)
 		})
@@ -1265,7 +1265,7 @@ func TestValidator_ValidateIngress(t *testing.T) {
 				},
 				Logger: logr.Discard(),
 			}
-			ok, msg, err := validator.ValidateIngress(context.Background(), *tc.ingress)
+			ok, msg, err := validator.ValidateIngress(t.Context(), *tc.ingress)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantOK, ok)
 			assert.Equal(t, tc.wantMessage, msg)
@@ -1401,7 +1401,7 @@ func TestValidator_ValidateVault(t *testing.T) {
 				ingressClassMatcher: fakeClassMatcher,
 				Logger:              logr.Discard(),
 			}
-			ok, msg, err := validator.ValidateVault(context.Background(), tc.kongVault)
+			ok, msg, err := validator.ValidateVault(t.Context(), tc.kongVault)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOK, ok)
 			assert.Contains(t, msg, tc.expectedMessage)
@@ -1541,7 +1541,7 @@ func TestValidator_ValidateCustomEntity(t *testing.T) {
 				},
 				ingressClassMatcher: fakeClassMatcher,
 			}
-			ok, msg, err := validator.ValidateCustomEntity(context.Background(), tc.entity)
+			ok, msg, err := validator.ValidateCustomEntity(t.Context(), tc.entity)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOK, ok)
 			assert.Contains(t, msg, tc.expectedMessage)

--- a/internal/clients/config_status_test.go
+++ b/internal/clients/config_status_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestChannelConfigNotifier(t *testing.T) {
 	n := clients.NewChannelConfigNotifier(logr.Discard())
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	ch := n.SubscribeGatewayConfigStatus()

--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -91,7 +91,7 @@ func TestAdminAPIClientsManager_OnNotifyClientsAreUpdatedAccordingly(t *testing.
 		testURL2 = "http://localhost:8002"
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	logger := zapr.NewLogger(zap.NewNop())
@@ -164,7 +164,7 @@ func TestAdminAPIClientsManager_OnNotifyClientsAreUpdatedAccordingly(t *testing.
 
 func TestNewAdminAPIClientsManager_NoInitialClientsDisallowed(t *testing.T) {
 	_, err := clients.NewAdminAPIClientsManager(
-		context.Background(),
+		t.Context(),
 		zapr.NewLogger(zap.NewNop()),
 		nil,
 		&mockReadinessChecker{},
@@ -178,7 +178,7 @@ func TestAdminAPIClientsManager_NotRunningNotifyLoop(t *testing.T) {
 	testClient, err := adminapi.NewTestClient("localhost:8080")
 	require.NoError(t, err)
 	m, err := clients.NewAdminAPIClientsManager(
-		context.Background(),
+		t.Context(),
 		zapr.NewLogger(zap.NewNop()),
 		[]*adminapi.Client{testClient},
 		&mockReadinessChecker{},
@@ -198,7 +198,7 @@ func TestAdminAPIClientsManager_Clients(t *testing.T) {
 	testClient, err := adminapi.NewTestClient("localhost:8080")
 	require.NoError(t, err)
 	m, err := clients.NewAdminAPIClientsManager(
-		context.Background(),
+		t.Context(),
 		zapr.NewLogger(zap.NewNop()),
 		[]*adminapi.Client{testClient},
 		&mockReadinessChecker{},
@@ -218,7 +218,7 @@ func TestAdminAPIClientsManager_Clients_DBMode(t *testing.T) {
 	require.NoError(t, err)
 
 	m, err := clients.NewAdminAPIClientsManager(
-		context.Background(),
+		t.Context(),
 		zapr.NewLogger(zap.NewNop()),
 		initialClients,
 		&mockReadinessChecker{},
@@ -250,7 +250,7 @@ func TestAdminAPIClientsManager_SubscribeToGatewayClientsChanges(t *testing.T) {
 	testClient, err := adminapi.NewTestClient("http://localhost:8080")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	m, err := clients.NewAdminAPIClientsManager(
 		ctx,
 		zapr.NewLogger(zap.NewNop()),
@@ -343,7 +343,7 @@ func TestAdminAPIClientsManager_ConcurrentNotify(t *testing.T) {
 	testClient, err := adminapi.NewTestClient(testURL1)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	m, err := clients.NewAdminAPIClientsManager(ctx, zapr.NewLogger(zap.NewNop()), []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestAdminAPIClientsManager_GatewayClientsChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	readinessChecker := &mockReadinessChecker{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	m, err := clients.NewAdminAPIClientsManager(ctx, zapr.NewLogger(zap.NewNop()), []*adminapi.Client{testClient}, readinessChecker)
 	require.NoError(t, err)
@@ -482,7 +482,7 @@ func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
 
 	readinessTicker := mocks.NewTicker()
 	readinessChecker := &mockReadinessChecker{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	m, err := clients.NewAdminAPIClientsManager(
 		ctx,

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -255,7 +255,7 @@ func TestDefaultReadinessChecker(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			factory := newMockClientFactory(t, tc.pendingClientsReadiness)
 			checker := clients.NewDefaultReadinessChecker(factory, clients.DefaultReadinessCheckTimeout, logr.Discard())
-			result := checker.CheckReadiness(context.Background(), tc.alreadyCreatedClients, tc.pendingClients)
+			result := checker.CheckReadiness(t.Context(), tc.alreadyCreatedClients, tc.pendingClients)
 
 			turnedPending := lo.Map(result.ClientsTurnedPending, func(c adminapi.DiscoveredAdminAPI, _ int) string { return c.Address })
 			turnedReady := lo.Map(result.ClientsTurnedReady, func(c *adminapi.Client, _ int) string { return c.BaseRootURL() })

--- a/internal/controllers/configuration/kongupstreampolicy_controller_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_controller_test.go
@@ -1,7 +1,6 @@
 package configuration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -414,7 +413,7 @@ func TestGetUpstreamPoliciesForIngressServices(t *testing.T) {
 			}
 
 			// Call the function
-			requests := reconciler.getUpstreamPoliciesForIngressServices(context.Background(), &tt.ingress)
+			requests := reconciler.getUpstreamPoliciesForIngressServices(t.Context(), &tt.ingress)
 
 			// Assert the results
 			assert.ElementsMatch(t, tt.expectedRequests, requests)

--- a/internal/controllers/configuration/kongupstreampolicy_utils_test.go
+++ b/internal/controllers/configuration/kongupstreampolicy_utils_test.go
@@ -1,7 +1,6 @@
 package configuration
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -742,11 +741,11 @@ func TestEnforceKongUpstreamPolicyStatus(t *testing.T) {
 				HTTPRouteEnabled:         true,
 			}
 
-			updated, err := reconciler.enforceKongUpstreamPolicyStatus(context.TODO(), &tc.kongUpstreamPolicy)
+			updated, err := reconciler.enforceKongUpstreamPolicyStatus(t.Context(), &tc.kongUpstreamPolicy)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.updated, updated)
 			newPolicy := &kongv1beta1.KongUpstreamPolicy{}
-			assert.NoError(t, fakeClient.Get(context.TODO(), k8stypes.NamespacedName{
+			assert.NoError(t, fakeClient.Get(t.Context(), k8stypes.NamespacedName{
 				Namespace: tc.kongUpstreamPolicy.Namespace,
 				Name:      tc.kongUpstreamPolicy.Name,
 			}, newPolicy))

--- a/internal/controllers/gateway/backendtlspolicy_utils_test.go
+++ b/internal/controllers/gateway/backendtlspolicy_utils_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -342,7 +341,7 @@ func TestGetBackendTLSPolicyAncestors(t *testing.T) {
 				Client: cl,
 			}
 
-			gateways, err := r.getBackendTLSPolicyAncestors(context.Background(), tt.policy)
+			gateways, err := r.getBackendTLSPolicyAncestors(t.Context(), tt.policy)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -961,7 +960,7 @@ func TestValidateBackendTLSPolicy(t *testing.T) {
 				Client: cl,
 			}
 
-			condition, err := r.validateBackendTLSPolicy(context.Background(), *tt.policy)
+			condition, err := r.validateBackendTLSPolicy(t.Context(), *tt.policy)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/internal/controllers/gateway/gateway_utils_test.go
+++ b/internal/controllers/gateway/gateway_utils_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -118,7 +117,7 @@ func TestGetListenerSupportedRouteKinds(t *testing.T) {
 }
 
 func TestGetListenerStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	scheme := runtime.NewScheme()
 	require.NoError(t, gatewayapi.InstallV1(scheme))
 

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -582,7 +581,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					WithObjects(tt.objects...).
 					Build()
 
-				got, err := getSupportedGatewayForRoute(context.Background(), logr.Discard(), fakeClient, tt.route, controllers.NewOptionalNamespacedName(mo.None[k8stypes.NamespacedName]()))
+				got, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, tt.route, controllers.NewOptionalNamespacedName(mo.None[k8stypes.NamespacedName]()))
 				require.NoError(t, err)
 				require.Len(t, got, len(tt.expected))
 
@@ -852,7 +851,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					WithObjects(tt.objects...).
 					Build()
 
-				got, err := getSupportedGatewayForRoute(context.Background(), logr.Discard(), fakeClient, tt.route, controllers.OptionalNamespacedName{})
+				got, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, tt.route, controllers.OptionalNamespacedName{})
 				require.NoError(t, err)
 				require.Len(t, got, 1)
 				match := got[0]
@@ -1086,7 +1085,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					WithObjects(tt.objects...).
 					Build()
 
-				got, err := getSupportedGatewayForRoute(context.Background(), logr.Discard(), fakeClient, tt.route, controllers.OptionalNamespacedName{})
+				got, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, tt.route, controllers.OptionalNamespacedName{})
 				require.NoError(t, err)
 				require.Len(t, got, 1)
 				match := got[0]
@@ -1307,7 +1306,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					WithObjects(tt.objects...).
 					Build()
 
-				got, err := getSupportedGatewayForRoute(context.Background(), logr.Discard(), fakeClient, tt.route, controllers.OptionalNamespacedName{})
+				got, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, tt.route, controllers.OptionalNamespacedName{})
 				require.NoError(t, err)
 				require.Len(t, got, len(tt.expected))
 
@@ -1337,7 +1336,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 			WithScheme(scheme.Scheme).
 			Build()
 
-		_, err := getSupportedGatewayForRoute(context.Background(), logr.Discard(), fakeClient, bustedParentHTTPRoute, controllers.OptionalNamespacedName{})
+		_, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, bustedParentHTTPRoute, controllers.OptionalNamespacedName{})
 		require.Equal(t, fmt.Errorf("unsupported parent kind %s/%s", string(badGroup), string(badKind)), err)
 	})
 
@@ -1442,7 +1441,7 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 					Build()
 
 				got, err := getSupportedGatewayForRoute(
-					context.Background(),
+					t.Context(),
 					logr.Discard(),
 					fakeClient,
 					tt.route,
@@ -2041,7 +2040,7 @@ func TestEnsureParentsProgrammedCondition(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
 				var (
-					ctx       = context.Background()
+					ctx       = t.Context()
 					httproute = tc.httpRouteFunc()
 					gateways  = tc.gatewayFunc()
 				)
@@ -2536,7 +2535,7 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
-				ctx       = context.Background()
+				ctx       = t.Context()
 				namespace = &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "other-namespace",

--- a/internal/dataplane/address_finder_test.go
+++ b/internal/dataplane/address_finder_test.go
@@ -16,7 +16,7 @@ func TestAddressFinder(t *testing.T) {
 	require.Nil(t, finder.addressGetter)
 
 	t.Log("verifying that a finder with no overrides or getter produces an error")
-	ctx := context.Background()
+	ctx := t.Context()
 	addrs, err := finder.GetAddresses(ctx)
 	require.Error(t, err)
 	require.Empty(t, addrs)

--- a/internal/dataplane/configfetcher/config_fetcher_test.go
+++ b/internal/dataplane/configfetcher/config_fetcher_test.go
@@ -1,7 +1,6 @@
 package configfetcher
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -101,7 +100,7 @@ func TestTryFetchingValidConfigFromGateways(t *testing.T) {
 			require.False(t, ok)
 			require.Nil(t, state)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			clients := tc.adminAPIClients(t)
 			logger := zapr.NewLogger(zap.NewNop())
 			err := fetcher.TryFetchingValidConfigFromGateways(ctx, logger, clients, nil)

--- a/internal/dataplane/deckgen/generate_test.go
+++ b/internal/dataplane/deckgen/generate_test.go
@@ -51,7 +51,7 @@ func TestToDeckContent(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := ToDeckContent(context.Background(), zapr.NewLogger(zap.NewNop()), tc.input, tc.params)
+			result := ToDeckContent(t.Context(), zapr.NewLogger(zap.NewNop()), tc.input, tc.params)
 			require.Equal(t, tc.expected, result)
 		})
 	}
@@ -578,7 +578,7 @@ func TestFillPlugin(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			plugin := tc.plugin.DeepCopy()
-			err := fillPlugin(context.Background(), plugin, tc.schemas)
+			err := fillPlugin(t.Context(), plugin, tc.schemas)
 			if tc.expectedError != nil {
 				require.EqualError(t, err, tc.expectedError.Error())
 			} else {

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -316,7 +316,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 	require.NoError(t, err)
 
 	t.Log("Triggering KongClient.Update")
-	ctx := context.Background()
+	ctx := t.Context()
 	err = kongClient.Update(ctx)
 	if len(objectsToBeConsideredBroken) > 0 {
 		require.Error(t, err, "expected an error when fallback configuration is enabled")

--- a/internal/dataplane/kong_client_test.go
+++ b/internal/dataplane/kong_client_test.go
@@ -192,7 +192,7 @@ func (m *mockFallbackConfigGenerator) GenerateBackfillingBrokenObjects(
 
 func TestKongClientUpdate_AllExpectedClientsAreCalledAndErrorIsPropagated(t *testing.T) {
 	var (
-		ctx                = context.Background()
+		ctx                = t.Context()
 		testGatewayClients = []*adminapi.Client{
 			mustSampleGatewayClient(t),
 			mustSampleGatewayClient(t),
@@ -285,7 +285,7 @@ func TestKongClientUpdate_WhenNoChangeInConfigNoClientGetsCalled(t *testing.T) {
 	kongRawStateGetter := &mockKongLastValidConfigFetcher{}
 	kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, nil, kongRawStateGetter)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := kongClient.Update(ctx)
 	require.NoError(t, err)
 
@@ -413,7 +413,7 @@ func (p *mockKongConfigBuilder) returnTranslationFailuresForAllButFirstCall(fail
 
 func TestKongClientUpdate_ConfigStatusIsNotified(t *testing.T) {
 	var (
-		ctx               = context.Background()
+		ctx               = t.Context()
 		testGatewayClient = mustSampleGatewayClient(t)
 
 		clientsProvider = &mockGatewayClientsProvider{
@@ -528,7 +528,7 @@ func TestKongClient_ApplyConfigurationEvents(t *testing.T) {
 			kongRawStateGetter := &mockKongLastValidConfigFetcher{}
 			kongClient := setupTestKongClient(t, updateStrategyResolver, clientsProvider, configChangeDetector, configBuilder, eventRecorder, kongRawStateGetter)
 
-			err := kongClient.Update(context.Background())
+			err := kongClient.Update(t.Context())
 			require.NoError(t, err)
 
 			if tc.expectEvents {
@@ -544,7 +544,7 @@ func TestKongClient_KubernetesEvents(t *testing.T) {
 	t.Setenv("POD_NAMESPACE", "test-namespace")
 	t.Setenv("POD_NAME", "test-pod")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	configChangeDetector := mocks.ConfigurationChangeDetector{ConfigurationChanged: true}
 	testIngress := helpers.WithTypeMeta(t, &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -719,7 +719,7 @@ func TestKongClient_KubernetesEvents(t *testing.T) {
 
 func TestKongClient_EmptyConfigUpdate(t *testing.T) {
 	var (
-		ctx               = context.Background()
+		ctx               = t.Context()
 		testGatewayClient = mustSampleGatewayClient(t)
 
 		clientsProvider = &mockGatewayClientsProvider{
@@ -851,7 +851,7 @@ func (cf *mockKongLastValidConfigFetcher) TryFetchingValidConfigFromGateways(con
 
 func TestKongClientUpdate_FetchStoreAndPushLastValidConfig(t *testing.T) {
 	var (
-		ctx = context.Background()
+		ctx = t.Context()
 
 		clientsProvider = &mockGatewayClientsProvider{
 			gatewayClients: []*adminapi.Client{
@@ -980,7 +980,7 @@ func TestKongClientUpdate_FetchStoreAndPushLastValidConfig(t *testing.T) {
 }
 
 func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	configChangeDetector := mocks.ConfigurationChangeDetector{ConfigurationChanged: true}
 	lastValidConfigFetcher := &mockKongLastValidConfigFetcher{}
 	diagnosticsCh := make(chan diagnostics.ConfigDump, 10) // make it buffered to avoid blocking
@@ -1138,7 +1138,7 @@ func TestKongClient_FallbackConfiguration_SuccessfulRecovery(t *testing.T) {
 }
 
 func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gwClient := mustSampleGatewayClient(t)
 	clientsProvider := &mockGatewayClientsProvider{
 		gatewayClients: []*adminapi.Client{gwClient},
@@ -1282,7 +1282,7 @@ func TestKongClient_FallbackConfiguration_SkipsUpdateWhenInSync(t *testing.T) {
 }
 
 func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gwClient := mustSampleGatewayClient(t)
 	clientsProvider := &mockGatewayClientsProvider{
 		gatewayClients: []*adminapi.Client{gwClient},
@@ -1360,7 +1360,7 @@ func TestKongClient_FallbackConfiguration_FailedRecovery(t *testing.T) {
 
 func TestKongClient_LastValidCacheSnapshot(t *testing.T) {
 	var (
-		ctx                     = context.Background()
+		ctx                     = t.Context()
 		updateStrategyResolver  = mocks.NewUpdateStrategyResolver()
 		configChangeDetector    = mocks.ConfigurationChangeDetector{ConfigurationChanged: true}
 		configBuilder           = newMockKongConfigBuilder()
@@ -1502,7 +1502,7 @@ func TestKongClient_ConfigDumpSanitization(t *testing.T) {
 				Configs:               diagnosticsCh,
 				DumpsIncludeSensitive: tc.dumpsIncludeSensitive,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			err := kongClient.Update(ctx)
 			require.NoError(t, err)
 
@@ -1520,7 +1520,7 @@ func TestKongClient_ConfigDumpSanitization(t *testing.T) {
 }
 
 func TestKongClient_RecoveringFromGatewaySyncError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	configChangeDetector := mocks.ConfigurationChangeDetector{ConfigurationChanged: true}
 	fallbackConfigGenerator := newMockFallbackConfigGenerator()
 	originalCache := cacheStoresFromObjs(t)

--- a/internal/dataplane/kongstate/customentity_test.go
+++ b/internal/dataplane/kongstate/customentity_test.go
@@ -1,7 +1,6 @@
 package kongstate
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -1102,7 +1101,7 @@ func TestKongState_FillCustomEntities(t *testing.T) {
 
 			ks := tc.initialState
 			ks.FillCustomEntities(
-				context.Background(),
+				t.Context(),
 				logr.Discard(), s,
 				failuresCollector,
 				&fakeSchemaService{schemas: tc.schemas}, "",

--- a/internal/dataplane/sendconfig/backoff_strategy_test.go
+++ b/internal/dataplane/sendconfig/backoff_strategy_test.go
@@ -72,7 +72,7 @@ func newMockBackoffStrategy(allowUpdate bool) *mockBackoffStrategy {
 }
 
 func TestUpdateStrategyWithBackoff(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := zapr.NewLogger(zap.NewNop())
 
 	testCases := []struct {

--- a/internal/dataplane/sendconfig/config_change_detector_test.go
+++ b/internal/dataplane/sendconfig/config_change_detector_test.go
@@ -24,7 +24,7 @@ func (c statusClientMock) Status(context.Context) (*kong.Status, error) {
 }
 
 func TestDefaultConfigurationChangeDetector_HasConfigurationChanged(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testSHAs := [][]byte{
 		[]byte("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
 		[]byte("82e35a63ceba37e9646434c5dd412ea577147f1e4a41ccde1614253187e3dbf9"),
@@ -129,7 +129,7 @@ func TestDefaultConfigurationChangeDetector_HasConfigurationChanged(t *testing.T
 }
 
 func TestKonnectConfigurationChangeDetector(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	testSHAs := [][]byte{
 		[]byte("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
 		[]byte("82e35a63ceba37e9646434c5dd412ea577147f1e4a41ccde1614253187e3dbf9"),

--- a/internal/dataplane/sendconfig/inmemory_test.go
+++ b/internal/dataplane/sendconfig/inmemory_test.go
@@ -154,7 +154,7 @@ func TestUpdateStrategyInMemory(t *testing.T) {
 			configService := &mockConfigService{err: tc.configServiceError}
 			configConverter := &mockConfigConverter{}
 			s := sendconfig.NewUpdateStrategyInMemory(configService, configConverter, logr.Discard())
-			n, err := s.Update(context.Background(), emptyCfg)
+			n, err := s.Update(t.Context(), emptyCfg)
 			require.Equal(t, tc.expectedError, err)
 			if tc.expectedError != nil {
 				// Default value 0 to discard, since error has been returned.

--- a/internal/dataplane/synchronizer_test.go
+++ b/internal/dataplane/synchronizer_test.go
@@ -27,7 +27,7 @@ func TestSynchronizer(t *testing.T) {
 	c := &fakeDataplaneClient{dbmode: dpconf.DBModePostgres}
 
 	t.Log("configuring the dataplane synchronizer")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	t.Log("initializing the dataplane synchronizer")
@@ -76,7 +76,7 @@ func TestSynchronizer(t *testing.T) {
 	totalUpdatesSeenSoFar := c.totalUpdates()
 
 	t.Log("verifying that the server can be started back up with a new context")
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(t.Context())
 	defer cancel()
 	assert.NoError(t, sync.Start(ctx))
 	assert.Eventually(t, func() bool { return sync.IsRunning() }, time.Second, testSynchronizerTick)
@@ -109,7 +109,7 @@ func TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, s)
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			require.NoError(t, s.Start(ctx))
 

--- a/internal/diagnostics/server_test.go
+++ b/internal/diagnostics/server_test.go
@@ -30,7 +30,7 @@ func TestDiagnosticsServer_ConfigDumps(t *testing.T) {
 	port := testhelpers.GetFreePort(t)
 	t.Logf("Obtained a free port: %d", port)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		err := s.Listen(ctx, port)
 		require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestDiagnosticsServer_Diffs(t *testing.T) {
 	port := testhelpers.GetFreePort(t)
 	t.Logf("Obtained a free port: %d", port)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
 		err := s.Listen(ctx, port)

--- a/internal/konnect/config_synchronizer_test.go
+++ b/internal/konnect/config_synchronizer_test.go
@@ -46,7 +46,7 @@ func TestConfigSynchronizer_UpdatesKongConfigAccordingly(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	runSynchronizer(ctx, t, s)
 
@@ -146,7 +146,7 @@ func TestConfigSynchronizer_ConfigIsSanitizedWhenConfiguredSo(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	runSynchronizer(ctx, t, s)
 
@@ -220,7 +220,7 @@ func TestConfigSynchronizer_StatusNotificationIsSent(t *testing.T) {
 					MetricsRecorder:        &mocks.MetricsRecorder{},
 				},
 			)
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			runSynchronizer(ctx, t, s)
 

--- a/internal/konnect/controlplanes/client_test.go
+++ b/internal/konnect/controlplanes/client_test.go
@@ -1,7 +1,6 @@
 package controlplanes_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,7 +40,7 @@ func TestControlPlanesClientUserAgent(t *testing.T) {
 	ts := httptest.NewServer(newMockControlPlanesServer(t))
 	t.Cleanup(ts.Close)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	sdk := sdk.New("kpat_xxx", sdkkonnectgo.WithServerURL(ts.URL))
 
 	_, err := sdk.ControlPlanes.CreateControlPlane(ctx, sdkkonnectcomp.CreateControlPlaneRequest{

--- a/internal/konnect/license/client_test.go
+++ b/internal/konnect/license/client_test.go
@@ -1,7 +1,6 @@
 package license_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,7 +52,7 @@ func TestLicenseClient(t *testing.T) {
 			}`),
 			status: http.StatusOK,
 			assertions: func(t *testing.T, c *license.Client) {
-				licenseOpt, err := c.Get(context.Background())
+				licenseOpt, err := c.Get(t.Context())
 				require.NoError(t, err)
 
 				l, ok := licenseOpt.Get()
@@ -67,7 +66,7 @@ func TestLicenseClient(t *testing.T) {
 			response: []byte(`{}`),
 			status:   http.StatusOK,
 			assertions: func(t *testing.T, c *license.Client) {
-				_, err := c.Get(context.Background())
+				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "no license item found in response")
 			},
 		},
@@ -76,7 +75,7 @@ func TestLicenseClient(t *testing.T) {
 			response: []byte(`{invalid-json`),
 			status:   http.StatusOK,
 			assertions: func(t *testing.T, c *license.Client) {
-				_, err := c.Get(context.Background())
+				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "failed to parse response body")
 			},
 		},
@@ -93,7 +92,7 @@ func TestLicenseClient(t *testing.T) {
 			}`),
 			status: http.StatusOK,
 			assertions: func(t *testing.T, c *license.Client) {
-				_, err := c.Get(context.Background())
+				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "empty id")
 			},
 		},
@@ -110,7 +109,7 @@ func TestLicenseClient(t *testing.T) {
 			}`),
 			status: http.StatusOK,
 			assertions: func(t *testing.T, c *license.Client) {
-				_, err := c.Get(context.Background())
+				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "empty updated_at")
 			},
 		},
@@ -127,7 +126,7 @@ func TestLicenseClient(t *testing.T) {
 			}`),
 			status: http.StatusOK,
 			assertions: func(t *testing.T, c *license.Client) {
-				_, err := c.Get(context.Background())
+				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "empty license")
 			},
 		},
@@ -136,7 +135,7 @@ func TestLicenseClient(t *testing.T) {
 			response: nil,
 			status:   http.StatusNotFound,
 			assertions: func(t *testing.T, c *license.Client) {
-				l, err := c.Get(context.Background())
+				l, err := c.Get(t.Context())
 				require.NoError(t, err)
 				require.False(t, l.IsPresent())
 			},
@@ -146,7 +145,7 @@ func TestLicenseClient(t *testing.T) {
 			response: nil,
 			status:   http.StatusBadRequest,
 			assertions: func(t *testing.T, c *license.Client) {
-				_, err := c.Get(context.Background())
+				_, err := c.Get(t.Context())
 				require.Error(t, err)
 			},
 		},

--- a/internal/konnect/node_agent_test.go
+++ b/internal/konnect/node_agent_test.go
@@ -358,7 +358,7 @@ func TestNodeAgent_StartDoesntReturnUntilContextGetsCancelled(t *testing.T) {
 		newMockManagerInstanceIDProvider(uuid.New()),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	agentReturned := make(chan struct{})
 	go func() {
 		err := nodeAgent.Start(ctx)
@@ -614,7 +614,7 @@ func TestNodeAgent_TickerResetsOnEveryNodesUpdate(t *testing.T) {
 // runAgent runs the agent in a goroutine and cancels the context after the test is done, ensuring that the agent
 // doesn't return prematurely.
 func runAgent(t *testing.T, nodeAgent *konnect.NodeAgent) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// To be used as a barrier to ensure that the agent returned after the context was cancelled.
 	agentReturned := make(chan struct{})

--- a/internal/konnect/nodes/client_test.go
+++ b/internal/konnect/nodes/client_test.go
@@ -1,7 +1,6 @@
 package nodes_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,9 +33,9 @@ func TestNodesClientUserAgent(t *testing.T) {
 	c, err := nodes.NewClient(adminapi.KonnectConfig{Address: ts.URL})
 	require.NoError(t, err)
 
-	_, err = c.GetNode(context.Background(), "test-node-id")
+	_, err = c.GetNode(t.Context(), "test-node-id")
 	require.Error(t, err)
 
-	err = c.DeleteNode(context.Background(), "test-node-id")
+	err = c.DeleteNode(t.Context(), "test-node-id")
 	require.NoError(t, err)
 }

--- a/internal/konnect/tracing/datadog_test.go
+++ b/internal/konnect/tracing/datadog_test.go
@@ -2,7 +2,6 @@ package tracing_test
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -83,7 +82,7 @@ func TestDoRequest(t *testing.T) {
 
 			loggerBuf := &bytes.Buffer{}
 			logger := buflogr.NewWithBuffer(loggerBuf)
-			ctx := log.IntoContext(context.Background(), logger)
+			ctx := log.IntoContext(t.Context(), logger)
 
 			resp, err := tracing.DoRequest(ctx, client, request)
 			require.NoError(t, err)

--- a/internal/license/agent_test.go
+++ b/internal/license/agent_test.go
@@ -72,7 +72,7 @@ func (m *mockKonnectClientClient) GetCalls() []time.Time {
 func TestAgent(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	expectedLicense := license.KonnectLicense{
 		Payload:   "test-license",

--- a/internal/manager/health_check_test.go
+++ b/internal/manager/health_check_test.go
@@ -82,7 +82,7 @@ func TestHealthCheckServer_Start(t *testing.T) {
 	// Get free local port.
 	port := helpers.GetFreePort(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	addr := fmt.Sprintf("localhost:%d", port)
 	// Use discard logger to prevent:
 	// panic: Log in goroutine after TestHealthCheckServer_Start has completed: "level"=0 "msg"="healthz server closed"

--- a/internal/manager/setup_test.go
+++ b/internal/manager/setup_test.go
@@ -83,7 +83,7 @@ func TestAdminAPIClientFromServiceDiscovery(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			discoverer := mocks.NewAdminAPIDiscoverer(tc.discoveredAPIs, tc.discovererErr)
 			factory := mocks.NewAdminAPIClientFactory(tc.factoryErrs)
 

--- a/internal/manager/telemetry/manager_test.go
+++ b/internal/manager/telemetry/manager_test.go
@@ -1,7 +1,6 @@
 package telemetry
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -220,7 +219,7 @@ func runManagerTest(
 	// testFn is a function that will be called with the actual report string.
 	testFn func(t *testing.T, actualReport string),
 ) {
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := createManager(
 		k8sclient,
 		dyn,

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -64,7 +63,7 @@ func TestParseNameNS(t *testing.T) {
 }
 
 func TestGetNodeIP(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	fKNodes := []struct {
 		cs *testclient.Clientset
@@ -180,7 +179,7 @@ func TestGetNodeIP(t *testing.T) {
 }
 
 func TestGetPodDetails(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// POD_NAME & POD_NAMESPACE not exist
 	t.Setenv("POD_NAME", "")
 	t.Setenv("POD_NAMESPACE", "")

--- a/pkg/clientset_test/clientset_test.go
+++ b/pkg/clientset_test/clientset_test.go
@@ -1,7 +1,6 @@
 package clientset_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,7 +20,7 @@ func TestClientset(t *testing.T) {
 		})
 
 		plugin, err := cl.ConfigurationV1().KongPlugins("test-ns").
-			Get(context.Background(), "test-plugin", metav1.GetOptions{})
+			Get(t.Context(), "test-plugin", metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, plugin)
 		require.Equal(t, "test-plugin", plugin.Name)

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -151,7 +151,7 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 
 	client := &http.Client{Timeout: time.Second * 30}
 	t.Log("confirming the second replica is not the leader and is not pushing configuration")
-	forwardCtx, cancel := context.WithCancel(context.Background())
+	forwardCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	localPort := startPortForwarder(forwardCtx, t, env, secondary.Namespace, secondary.Name, "cmetrics")

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -84,7 +84,7 @@ func TestWebhookUpdate(t *testing.T) {
 
 	t.Log("configuring all-in-one-dbless.yaml manifest test")
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	t.Log("building test cluster and environment")

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -96,7 +96,7 @@ const (
 func setupE2ETest(t *testing.T, addons ...clusters.Addon) (context.Context, environments.Environment) {
 	t.Helper()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:usetesting
 	t.Cleanup(cancel)
 
 	t.Log("building test cluster and environment")

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -183,7 +183,7 @@ func extractKongVersionFromDockerImage(t *testing.T, image string) kong.Version 
 	dockerc, err := client.NewClientWithOpts(client.FromEnv)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Log("negotiating docker API version")
 	dockerc.NegotiateAPIVersion(ctx)

--- a/test/envtest/adminapi_discoverer_envtest_test.go
+++ b/test/envtest/adminapi_discoverer_envtest_test.go
@@ -45,7 +45,7 @@ func TestDiscoverer_GetAdminAPIsForServiceReturnsAllAddressesCorrectlyPagingThro
 		t.Run(fmt.Sprintf("%dx%d", tc.subnetC, tc.subnetD), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			const (

--- a/test/envtest/admission_webhook_envtest_test.go
+++ b/test/envtest/admission_webhook_envtest_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestAdmissionWebhook_KongVault(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var (
@@ -177,7 +177,7 @@ func TestAdmissionWebhook_KongVault(t *testing.T) {
 }
 
 func TestAdmissionWebhook_KongPlugins(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var (
@@ -431,7 +431,7 @@ func TestAdmissionWebhook_KongPlugins(t *testing.T) {
 }
 
 func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var (
@@ -695,7 +695,7 @@ func TestAdmissionWebhook_KongClusterPlugins(t *testing.T) {
 }
 
 func TestAdmissionWebhook_KongConsumers(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var (
@@ -775,6 +775,7 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 	}
 	require.NoError(t, ctrlClient.Create(ctx, consumer))
 	t.Cleanup(func() {
+		ctx := t.Context()
 		if err := ctrlClient.Delete(ctx, consumer); err != nil && !apierrors.IsNotFound(err) && !errors.Is(err, context.Canceled) {
 			assert.NoError(t, err)
 		}
@@ -1004,7 +1005,8 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, credential := range tc.credentials {
 				require.NoError(t, ctrlClient.Create(ctx, credential))
-				t.Cleanup(func() {
+				t.Cleanup(func() { //nolint:contextcheck
+					ctx := context.Background() //nolint:usetesting
 					if err := ctrlClient.Delete(ctx, credential); err != nil && !apierrors.IsNotFound(err) {
 						assert.NoError(t, err)
 					}
@@ -1030,7 +1032,7 @@ func TestAdmissionWebhook_KongConsumers(t *testing.T) {
 }
 
 func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// highEndConsumerUsageCount indicates a number of consumers with credentials
@@ -1204,7 +1206,7 @@ func TestAdmissionWebhook_SecretCredentials(t *testing.T) {
 }
 
 func TestAdmissionWebhook_KongCustomEntities(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var (

--- a/test/envtest/configerrorevent_envtest_test.go
+++ b/test/envtest/configerrorevent_envtest_test.go
@@ -39,7 +39,7 @@ func TestConfigErrorEventGenerationInMemoryMode(t *testing.T) {
 		tickTime = 100 * time.Millisecond
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	restConfig := Setup(t, scheme.Scheme)
@@ -295,7 +295,7 @@ func TestConfigErrorEventGenerationDBMode(t *testing.T) {
 		tickTime = 100 * time.Millisecond
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	scheme := Scheme(t, WithKong)

--- a/test/envtest/control_plane_reference_test.go
+++ b/test/envtest/control_plane_reference_test.go
@@ -29,7 +29,7 @@ import (
 func TestControlPlaneReferenceHandling(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	const ingressClassName = "kongenvtest"

--- a/test/envtest/crds_envtest_test.go
+++ b/test/envtest/crds_envtest_test.go
@@ -41,7 +41,7 @@ func TestGatewayAPIControllersMayBeDynamicallyStarted(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme, WithInstallGatewayCRDs(false))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	_, loggerHook := RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
@@ -97,7 +97,7 @@ func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
 	scheme := Scheme(t)
 	envcfg := Setup(t, scheme, WithInstallKongCRDs(false))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	cfg := ConfigForEnvConfig(t, envcfg)
 
@@ -113,7 +113,7 @@ func TestNoKongCRDsInstalledIsFatal(t *testing.T) {
 func TestCRDValidations(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)

--- a/test/envtest/gateway_envtest_test.go
+++ b/test/envtest/gateway_envtest_test.go
@@ -28,7 +28,7 @@ func TestGatewayAddressOverride(t *testing.T) {
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	expected := []string{"10.0.0.1", "10.0.0.2"}
 	udp := []string{"10.0.0.3", "10.0.0.4"}
@@ -78,7 +78,7 @@ func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	gw, _ := deployGateway(ctx, t, ctrlClient)
 	RunManager(ctx, t, envcfg,

--- a/test/envtest/gatewayclass_envtest_test.go
+++ b/test/envtest/gatewayclass_envtest_test.go
@@ -91,7 +91,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 			) {
 				t.Logf("deploying gateway class %s", gwc.Name)
 				require.NoError(t, client.Create(ctx, &gwc))
-				t.Cleanup(func() { _ = client.Delete(context.Background(), &gwc) }) //nolint:contextcheck
+				t.Cleanup(func() { _ = client.Delete(t.Context(), &gwc) }) //nolint:contextcheck
 
 				t.Logf("verifying that the unsupported Gateway %s does not get Accepted or Programmed by the controller", gw.Name)
 				// NOTE: Ideally we wouldn't like to perform a busy wait loop here,
@@ -180,7 +180,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 
 				t.Logf("deploying gateway class %s", gwc.Name)
 				require.NoError(t, client.Create(ctx, &gwc))
-				t.Cleanup(func() { _ = client.Delete(context.Background(), &gwc) }) //nolint:contextcheck
+				t.Cleanup(func() { _ = client.Delete(t.Context(), &gwc) }) //nolint:contextcheck
 
 				// Let's wait and check that the Gateway hasn't been reconciled by the operator.
 				t.Log("verifying the Gateway is not reconciled as it is using a managed GatewayClass")
@@ -278,7 +278,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 
 				t.Logf("deploying gateway class %s", gwc.Name)
 				require.NoError(t, client.Create(ctx, &gwc))
-				t.Cleanup(func() { _ = client.Delete(context.Background(), &gwc) }) //nolint:contextcheck
+				t.Cleanup(func() { _ = client.Delete(t.Context(), &gwc) }) //nolint:contextcheck
 
 				t.Logf("now that the GatewayClass exists, verifying that the Gateway %s gets Accepted and Programmed", gw.Name)
 
@@ -327,9 +327,9 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 
 			// We use a deferred cancel to stop the manager and not wait for its timeout.
 			if deadline, ok := t.Deadline(); ok {
-				ctx, cancel = context.WithDeadline(context.Background(), deadline)
+				ctx, cancel = context.WithDeadline(t.Context(), deadline)
 			} else {
-				ctx, cancel = context.WithCancel(context.Background())
+				ctx, cancel = context.WithCancel(t.Context())
 			}
 			defer cancel()
 
@@ -367,7 +367,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 			t.Logf("deploying gateway %s using %s gateway class", tc.Gateway.Name, tc.GatewayClass.Name)
 			tc.Gateway.Namespace = ns.Name
 			require.NoError(t, client.Create(ctx, &tc.Gateway))
-			t.Cleanup(func() { _ = client.Delete(context.Background(), &tc.Gateway) })
+			t.Cleanup(func() { _ = client.Delete(t.Context(), &tc.Gateway) })
 
 			gwClient := gatewayClient.GatewayV1().Gateways(ns.Name)
 			tc.Test(ctx, t, gwClient, tc.GatewayClass, tc.Gateway)

--- a/test/envtest/httproute_controller_test.go
+++ b/test/envtest/httproute_controller_test.go
@@ -45,7 +45,7 @@ func TestHTTPRouteReconcilerProperlyReactsToReferenceGrant(t *testing.T) {
 	}
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	ns := CreateNamespace(ctx, t, client)
@@ -278,7 +278,7 @@ func TestHTTPRouteReconciler_RemovesOutdatedParentStatuses(t *testing.T) {
 	}
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	ns := CreateNamespace(ctx, t, client)

--- a/test/envtest/ingress_test.go
+++ b/test/envtest/ingress_test.go
@@ -44,7 +44,7 @@ func TestIngressWorksWithServiceBackendsSpecifyingOnlyPortNames(t *testing.T) {
 		tickTime = 10 * time.Millisecond
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// Add Gateway API Schema because its controllers are enabled by default.

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -26,7 +26,7 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	gw, _ := deployGateway(ctx, t, ctrlClient)
 	RunManager(ctx, t, envcfg,
@@ -125,7 +125,7 @@ func Test_WatchNamespaces(t *testing.T) {
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	gw, _ := deployGateway(ctx, t, ctrlClient)
 	hidden := CreateNamespace(ctx, t, ctrlClient)

--- a/test/envtest/kongadminapi_controller_envtest_test.go
+++ b/test/envtest/kongadminapi_controller_envtest_test.go
@@ -131,7 +131,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	}
 
 	t.Run("Endpoints are matched properly", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		adminService, adminPod, n := startKongAdminAPIServiceReconciler(ctx, t, client, cfg)
 		tlsServerName := getTLSServerName(adminService)
@@ -210,7 +210,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	})
 
 	t.Run("terminating Endpoints are not matched", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		adminService, adminPod, n := startKongAdminAPIServiceReconciler(ctx, t, client, cfg)
 		tlsServerName := getTLSServerName(adminService)
@@ -277,7 +277,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	})
 
 	t.Run("multiple EndpointSlices are matched properly", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		adminService, adminPod, n := startKongAdminAPIServiceReconciler(ctx, t, client, cfg)
 		tlsServerName := getTLSServerName(adminService)
@@ -413,7 +413,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	})
 
 	t.Run("with EndpointSlices changing over time the notifications are sent properly", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		adminService, adminPod, n := startKongAdminAPIServiceReconciler(ctx, t, client, cfg)
 		tlsServerName := getTLSServerName(adminService)
@@ -517,7 +517,7 @@ func TestKongAdminAPIController(t *testing.T) {
 	})
 
 	t.Run("when deleted EndpointsSlice is observed notifications are sent properly", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		adminService, adminPod, n := startKongAdminAPIServiceReconciler(ctx, t, client, cfg)
 		tlsServerName := getTLSServerName(adminService)

--- a/test/envtest/konglicense_controller_test.go
+++ b/test/envtest/konglicense_controller_test.go
@@ -23,7 +23,7 @@ func TestKongLicenseController(t *testing.T) {
 	cfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, cfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	reconciler := ctrllicense.NewKongV1Alpha1KongLicenseReconciler(
@@ -128,7 +128,7 @@ func TestKongLicenseControllerValidation(t *testing.T) {
 	cfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, cfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	const (

--- a/test/envtest/kongstate_consumer_failures_test.go
+++ b/test/envtest/kongstate_consumer_failures_test.go
@@ -33,7 +33,7 @@ func TestKongStateFillConsumersAndCredentialsFailure(t *testing.T) {
 	client := NewControllerClient(t, scheme, cfg)
 
 	// We use a deferred cancel to stop the manager and not wait for its timeout.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	ns := CreateNamespace(ctx, t, client)

--- a/test/envtest/kongupstreampolicy_test.go
+++ b/test/envtest/kongupstreampolicy_test.go
@@ -41,7 +41,7 @@ func TestKongUpstreamPolicyWithoutGatewayAPICRDs(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme, WithInstallGatewayCRDs(false))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	ingressClassName := "kongenvtest"
@@ -176,7 +176,7 @@ func TestKongUpstreamPolicyWithHTTPRoute(t *testing.T) {
 	scheme := Scheme(t, WithKong, WithGatewayAPI)
 	envcfg := Setup(t, scheme)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	ingressClassName := "kongenvtest"
@@ -364,7 +364,7 @@ func TestKongUpstreamPolicyNotReferencedInReconciledIngress(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme, WithInstallGatewayCRDs(false))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 	ingressClassName := "kongenvtest"

--- a/test/envtest/manager_debugendpoints_test.go
+++ b/test/envtest/manager_debugendpoints_test.go
@@ -23,7 +23,7 @@ func TestDebugEndpoints(t *testing.T) {
 		tickTime = 10 * time.Millisecond
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	diagPort := helpers.GetFreePort(t)

--- a/test/envtest/manager_envtest_test.go
+++ b/test/envtest/manager_envtest_test.go
@@ -26,7 +26,7 @@ func TestManagerDoesntStartUntilKubernetesAPIReachable(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	t.Log("Setting up a proxy for Kubernetes API server so that we can interrupt it")

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -86,7 +86,7 @@ func TestMetricsAreServed(t *testing.T) {
 			if tc.skippedMessage != "" {
 				t.Skip(tc.skippedMessage)
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), waitTime)
+			ctx, cancel := context.WithTimeout(t.Context(), waitTime)
 			defer cancel()
 
 			var adminAPIOpts []mocks.AdminAPIHandlerOpt

--- a/test/envtest/programmed_condition_envtest_test.go
+++ b/test/envtest/programmed_condition_envtest_test.go
@@ -29,7 +29,7 @@ func TestKongCRDs_ProgrammedCondition(t *testing.T) {
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	ctrlClient := NewControllerClient(t, scheme, envcfg)

--- a/test/envtest/specific_gateway_envtest_test.go
+++ b/test/envtest/specific_gateway_envtest_test.go
@@ -28,7 +28,7 @@ func TestSpecificGatewayNN(t *testing.T) {
 	envcfg := Setup(t, scheme)
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var (

--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -50,7 +50,7 @@ func TestTelemetry(t *testing.T) {
 	// Run a server that will receive the report, it's expected
 	// to be the first connection and the payload.
 	reportChan := make(chan []byte)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go runTelemetryServer(ctx, t, telemetryServerListener, reportChan)
 

--- a/test/integration/admission_webhook_helpers_test.go
+++ b/test/integration/admission_webhook_helpers_test.go
@@ -56,8 +56,10 @@ func ensureAdmissionRegistration(
 	validationWebhookClient := client.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 	webhookConfig, err := validationWebhookClient.Create(ctx, webhookConfig, metav1.CreateOptions{})
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := validationWebhookClient.Delete(ctx, webhookConfig.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	t.Cleanup(func() { //nolint:contextcheck
+		if err := validationWebhookClient.Delete(
+			context.Background(), webhookConfig.Name, metav1.DeleteOptions{},
+		); err != nil && !apierrors.IsNotFound(err) {
 			require.NoError(t, err)
 		}
 	})
@@ -110,7 +112,8 @@ func ensureWebhookService(ctx context.Context, t *testing.T, client *kubernetes.
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
+	t.Cleanup(func() { //nolint:contextcheck
+		ctx := context.Background()
 		if err := client.CoreV1().Services(nn.Namespace).Delete(ctx, validationsService.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			require.NoError(t, err)
 		}

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -36,7 +36,7 @@ func TestConsumerGroup(t *testing.T) {
 
 	RunWhenKongEnterprise(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	// path is the basic path used for most of the test

--- a/test/integration/consumer_test.go
+++ b/test/integration/consumer_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -30,7 +29,7 @@ import (
 )
 
 func TestConsumerCredential(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/examples_test.go
+++ b/test/integration/examples_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
@@ -29,7 +28,7 @@ func TestTLSRouteExample(t *testing.T) {
 
 	var (
 		tlsrouteExampleManifests = fmt.Sprintf("%s/gateway-tlsroute.yaml", examplesDIR)
-		ctx                      = context.Background()
+		ctx                      = t.Context()
 	)
 	_, cleaner := helpers.Setup(ctx, t, env)
 

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -42,7 +41,7 @@ const (
 )
 
 func TestUnmanagedGatewayBasics(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gw *gatewayapi.Gateway
 
@@ -141,7 +140,7 @@ func TestUnmanagedGatewayBasics(t *testing.T) {
 }
 
 func TestGatewayListenerConflicts(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var gw *gatewayapi.Gateway
 
@@ -333,7 +332,7 @@ func TestGatewayListenerConflicts(t *testing.T) {
 }
 
 func TestGatewayFilters(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 

--- a/test/integration/gateway_webhook_test.go
+++ b/test/integration/gateway_webhook_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -20,7 +19,7 @@ import (
 )
 
 func TestGatewayValidationWebhook(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := helpers.Namespace(ctx, t, env)
 

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -83,7 +83,7 @@ func HTTPRouteMatchesAcceptedCallback(t *testing.T, c *gatewayclient.Clientset, 
 
 func httpRouteAcceptedConditionMatches(t *testing.T, c *gatewayclient.Clientset, httpRoute *gatewayapi.HTTPRoute, accepted bool, reason gatewayapi.RouteConditionReason) bool {
 	var err error
-	httpRoute, err = c.GatewayV1().HTTPRoutes(httpRoute.Namespace).Get(context.Background(), httpRoute.Name, metav1.GetOptions{})
+	httpRoute, err = c.GatewayV1().HTTPRoutes(httpRoute.Namespace).Get(t.Context(), httpRoute.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	if len(httpRoute.Status.Parents) == 0 {
@@ -111,7 +111,7 @@ func httpRouteAcceptedConditionMatches(t *testing.T, c *gatewayclient.Clientset,
 // each listener's name.
 func ListenersHaveNAttachedRoutesCallback(t *testing.T, c *gatewayclient.Clientset, namespace, gatewayName string, attachedRoutesByListener map[string]int32) func() bool {
 	return func() bool {
-		gateway, err := c.GatewayV1().Gateways(namespace).Get(context.Background(), gatewayName, metav1.GetOptions{})
+		gateway, err := c.GatewayV1().Gateways(namespace).Get(t.Context(), gatewayName, metav1.GetOptions{})
 		assert.NoError(t, err)
 
 		for _, listenerStatus := range gateway.Status.Listeners {

--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -35,7 +34,7 @@ import (
 var emptyHeaderSet = make(map[string]string)
 
 func TestHTTPRouteEssentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
@@ -347,7 +346,7 @@ func TestHTTPRouteEssentials(t *testing.T) {
 }
 
 func TestHTTPRouteMultipleServices(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
@@ -535,7 +534,7 @@ func TestHTTPRouteMultipleServices(t *testing.T) {
 }
 
 func TestHTTPRouteFilterHosts(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 

--- a/test/integration/httproute_webhook_test.go
+++ b/test/integration/httproute_webhook_test.go
@@ -148,9 +148,9 @@ func invalidRegexInPathTestCase(
 
 func TestHTTPRouteValidationWebhookTraditionalRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavors(context.Background(), t, expressions)
+	skipTestForRouterFlavors(t.Context(), t, expressions)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)
 	testCases := append(
 		commonHTTPRouteValidationTestCases(managedGateway, unmanagedGateway),
@@ -162,9 +162,9 @@ func TestHTTPRouteValidationWebhookTraditionalRouter(t *testing.T) {
 
 func TestHTTPRouteValidationWebhookExpressionsRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavors(context.Background(), t, traditional, traditionalCompatible)
+	skipTestForRouterFlavors(t.Context(), t, traditional, traditionalCompatible)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	namespace, gatewayClient, managedGateway, unmanagedGateway := setUpEnvForTestingHTTPRouteValidationWebhook(ctx, t)
 	testCases := append(
 		commonHTTPRouteValidationTestCases(managedGateway, unmanagedGateway),

--- a/test/integration/ingress_https_test.go
+++ b/test/integration/ingress_https_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 func TestHTTPSRedirect(t *testing.T) {
-	RunWhenKongExpressionRouter(context.Background(), t)
-	ctx := context.Background()
+	RunWhenKongExpressionRouter(t.Context(), t)
+	ctx := t.Context()
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)
@@ -77,7 +77,7 @@ func TestHTTPSRedirect(t *testing.T) {
 }
 
 func TestHTTPSIngress(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/ingress_regex_match_test.go
+++ b/test/integration/ingress_regex_match_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -23,7 +22,7 @@ import (
 )
 
 func TestIngressRegexMatchPath(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	pathRegexPrefix := "/~"
@@ -140,7 +139,7 @@ func TestIngressRegexMatchPath(t *testing.T) {
 }
 
 func TestIngressRegexMatchHeader(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	headerRegexPrefix := "~*"

--- a/test/integration/ingress_test.go
+++ b/test/integration/ingress_test.go
@@ -46,7 +46,7 @@ func TestIngressEssentials(t *testing.T) {
 		ingressClassMutex.Unlock()
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -154,7 +154,7 @@ func TestIngressEssentials(t *testing.T) {
 }
 
 func TestIngressDefaultBackend(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -204,7 +204,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 		ingressClassMutex.Unlock()
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes using the IngressClassName spec")
@@ -301,7 +301,7 @@ func TestIngressClassNameSpec(t *testing.T) {
 func TestIngressServiceUpstream(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Logf("using testing namespace %s", ns.Name)
@@ -354,7 +354,7 @@ func TestIngressServiceUpstream(t *testing.T) {
 func TestIngressStatusUpdatesExtended(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -487,7 +487,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 		ingressClassMutex.Unlock()
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -602,7 +602,7 @@ func TestIngressClassRegexToggle(t *testing.T) {
 }
 
 func TestIngressRegexPrefix(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -765,7 +765,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 		t.Skipf("the case %s should be run separately; please set TEST_RUN_INVALID_CONFIG_CASES to true to run this case", t.Name())
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -970,7 +970,7 @@ func TestIngressRecoverFromInvalidPath(t *testing.T) {
 }
 
 func TestIngressMatchByHost(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
@@ -1070,7 +1070,7 @@ func TestIngressMatchByHost(t *testing.T) {
 }
 
 func TestIngressRewriteURI(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if !strings.Contains(testenv.ControllerFeatureGates(), featuregates.RewriteURIsFeature) {
 		t.Skipf("rewrite uri feature is disabled")

--- a/test/integration/ingress_webhook_test.go
+++ b/test/integration/ingress_webhook_test.go
@@ -79,9 +79,9 @@ func invalidRegexInIngressPathTestCase(wantCreateErrSubstring string) testCaseIn
 
 func TestIngressValidationWebhookTraditionalRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavors(context.Background(), t, expressions)
+	skipTestForRouterFlavors(t.Context(), t, expressions)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, _ := helpers.Setup(ctx, t, env)
 	ensureAdmissionRegistration(ctx, t, env.Cluster().Client(), "kong-validations-ingress", ns.Name)
 
@@ -101,9 +101,9 @@ func TestIngressValidationWebhookTraditionalRouter(t *testing.T) {
 
 func TestIngressValidationWebhookExpressionsRouter(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavors(context.Background(), t, traditional, traditionalCompatible)
+	skipTestForRouterFlavors(t.Context(), t, traditional, traditionalCompatible)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, _ := helpers.Setup(ctx, t, env)
 	ensureAdmissionRegistration(ctx, t, env.Cluster().Client(), "kong-validations-ingress", ns.Name)
 

--- a/test/integration/kongingress_test.go
+++ b/test/integration/kongingress_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,8 +23,8 @@ import (
 )
 
 func TestServiceOverrides(t *testing.T) {
-	skipTestForRouterFlavors(context.Background(), t, expressions)
-	ctx := context.Background()
+	skipTestForRouterFlavors(t.Context(), t, expressions)
+	ctx := t.Context()
 
 	t.Parallel()
 	ns := helpers.Namespace(ctx, t, env)

--- a/test/integration/kongingress_webhook_test.go
+++ b/test/integration/kongingress_webhook_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/samber/lo"
@@ -21,9 +20,9 @@ import (
 
 func TestKongIngressValidationWebhook(t *testing.T) {
 	skipTestForNonKindCluster(t)
-	skipTestForRouterFlavors(context.Background(), t, expressions)
+	skipTestForRouterFlavors(t.Context(), t, expressions)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, _ := helpers.Setup(ctx, t, env)
 
 	ensureAdmissionRegistration(ctx, t, env.Cluster().Client(), "kong-validations-kongingress", ns.Name)

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,7 +34,7 @@ import (
 )
 
 func TestPluginEssentials(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)
@@ -164,7 +163,7 @@ func TestPluginEssentials(t *testing.T) {
 }
 
 func TestPluginConfigPatch(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)
@@ -337,7 +336,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	RunWhenKongEnterprise(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
@@ -483,7 +482,7 @@ func TestPluginOrdering(t *testing.T) {
 // the controller can generate a plugin attached to the generated route and consumer if and only if a ReferenceGrant
 // allows access to the KongPlugin from KongConsumers in a remote namespace.
 func TestPluginCrossNamespaceReference(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)

--- a/test/integration/tcpingress_test.go
+++ b/test/integration/tcpingress_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -36,7 +35,7 @@ var (
 )
 
 func TestTCPIngressTLS(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	RunWhenKongExpressionRouter(ctx, t)
 	t.Parallel()
 
@@ -238,7 +237,7 @@ func TestTCPIngressTLSPassthrough(t *testing.T) {
 		tlsMutex.Unlock()
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("setting up the TCPIngress TLS passthrough tests")

--- a/test/integration/tcproute_test.go
+++ b/test/integration/tcproute_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -25,8 +24,8 @@ import (
 )
 
 func TestTCPRouteReferenceGrant(t *testing.T) {
-	ctx := context.Background()
-	RunWhenKongExpressionRouter(context.Background(), t)
+	ctx := t.Context()
+	RunWhenKongExpressionRouter(t.Context(), t)
 	t.Log("locking TCP port")
 	tcpMutex.Lock()
 	t.Cleanup(func() {

--- a/test/integration/tlsroute_test.go
+++ b/test/integration/tlsroute_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -55,7 +54,7 @@ func TestTLSRoutePassthroughReferenceGrant(t *testing.T) {
 		tlsMutex.Unlock()
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	otherNs, err := clusters.GenerateNamespace(ctx, env.Cluster(), t.Name())
@@ -331,7 +330,7 @@ func TestTLSRoutePassthrough(t *testing.T) {
 		tlsMutex.Unlock()
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("getting gateway client")

--- a/test/integration/translation_failures_test.go
+++ b/test/integration/translation_failures_test.go
@@ -38,7 +38,7 @@ const testTranslationFailuresObjectsPrefix = "translation-failures-"
 // TestTranslationFailures ensures that proper warning Kubernetes events are recorded in case of translation failures
 // encountered.
 func TestTranslationFailures(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	type expectedTranslationFailure struct {
 		causingObjects []client.Object

--- a/test/integration/vault_test.go
+++ b/test/integration/vault_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -37,7 +36,7 @@ func TestCustomVault(t *testing.T) {
 	// TODO: run hcv vault to enable test with DBMode
 	RunWhenKongDBMode(t, dpconf.DBModeOff, "Skipping because DBMode cannot support env vault")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ns, cleaner := helpers.Setup(ctx, t, env)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -81,11 +81,11 @@ func eventuallyGetKongVersion(t *testing.T, adminURL *url.URL) kong.Version {
 		version kong.Version
 	)
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		ctx, cancel := context.WithTimeout(context.Background(), test.RequestTimeout)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(t.Context(), test.RequestTimeout)
 		defer cancel()
 		version, err = helpers.GetKongVersion(ctx, adminURL, consts.KongTestPassword)
-		assert.NoError(t, err)
+		assert.NoError(c, err)
 	}, time.Minute, time.Second)
 	return version
 }
@@ -98,11 +98,11 @@ func eventuallyGetKongDBMode(t *testing.T, adminURL *url.URL) dpconf.DBMode {
 		dbmode dpconf.DBMode
 	)
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		ctx, cancel := context.WithTimeout(context.Background(), test.RequestTimeout)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(t.Context(), test.RequestTimeout)
 		defer cancel()
 		dbmode, err = helpers.GetKongDBMode(ctx, adminURL, consts.KongTestPassword)
-		assert.NoError(t, err)
+		assert.NoError(c, err)
 	}, time.Minute, time.Second)
 	return dbmode
 }

--- a/test/internal/helpers/gatewayapi.go
+++ b/test/internal/helpers/gatewayapi.go
@@ -205,7 +205,7 @@ func verifyProgrammedConditionStatus(t *testing.T,
 	namespace, name string,
 	expectedStatus metav1.ConditionStatus,
 ) bool {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// gather a fresh copy of the route, given the specific protocol type
 	switch protocolType {

--- a/test/internal/helpers/konnect/control_plane.go
+++ b/test/internal/helpers/konnect/control_plane.go
@@ -69,17 +69,19 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
 	require.NoError(t, createRgErr)
 
 	t.Cleanup(func() {
+		ctx = context.Background()
 		t.Logf("deleting test Konnect Control Plane: %q", cpID)
 		err := retry.Do(
-			func() error {
-				_, err := sdk.ControlPlanes.DeleteControlPlane(ctx, cpID)
+			func() error { //nolint:contextcheck
+				_, err := sdk.ControlPlanes.DeleteControlPlane(context.Background(), cpID)
 				return err
 			},
 			retry.Attempts(5), retry.Delay(time.Second),
 		)
 		assert.NoErrorf(t, err, "failed to cleanup a control plane: %q", cpID)
 
-		me, err := sdk.Me.GetUsersMe(ctx,
+		me, err := sdk.Me.GetUsersMe(
+			ctx,
 			// NOTE: Otherwise we use prod server by default.
 			// Related issue: https://github.com/Kong/sdk-konnect-go/issues/20
 			sdkkonnectops.WithServerURL(test.KonnectServerURL()),

--- a/test/internal/helpers/tcp_test.go
+++ b/test/internal/helpers/tcp_test.go
@@ -41,7 +41,7 @@ func TestTCPProxy(t *testing.T) {
 	proxy, err := helpers.NewTCPProxy(ls.Addr().String())
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
 		err := proxy.Run(ctx)

--- a/test/kongintegration/containers/httpbin.go
+++ b/test/kongintegration/containers/httpbin.go
@@ -34,8 +34,8 @@ func NewHTTPBin(ctx context.Context, t *testing.T) HTTPBin {
 	})
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		assert.NoError(t, httpBinC.Terminate(ctx))
+	t.Cleanup(func() { //nolint:contextcheck
+		assert.NoError(t, httpBinC.Terminate(context.Background()))
 	})
 
 	return HTTPBin{

--- a/test/kongintegration/dbmode_update_strategy_test.go
+++ b/test/kongintegration/dbmode_update_strategy_test.go
@@ -1,7 +1,6 @@
 package kongintegration
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -31,7 +30,7 @@ func TestUpdateStrategyDBMode(t *testing.T) {
 		timeout = time.Second * 5
 		period  = time.Millisecond * 200
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a network for Postgres and Kong containers to communicate over.
 	net, err := network.New(ctx)

--- a/test/kongintegration/expression_router_test.go
+++ b/test/kongintegration/expression_router_test.go
@@ -2,7 +2,6 @@ package kongintegration
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -29,7 +28,7 @@ func TestExpressionsRouterMatchers_GenerateValidExpressions(t *testing.T) {
 		period  = time.Millisecond * 200
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	kongC := containers.NewKong(ctx, t)
 	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")

--- a/test/kongintegration/inmemory_update_strategy_test.go
+++ b/test/kongintegration/inmemory_update_strategy_test.go
@@ -1,7 +1,6 @@
 package kongintegration
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -35,7 +34,7 @@ func TestUpdateStrategyInMemory_PropagatesResourcesErrors(t *testing.T) {
 		period  = time.Millisecond * 200
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	kongC := containers.NewKong(ctx, t)
 	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")

--- a/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -37,7 +37,7 @@ const (
 // TestKongClientGoldenTestsOutputs ensures that the KongClient's golden tests outputs are accepted by Kong.
 func TestKongClientGoldenTestsOutputs(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// By default, run only non-EE tests.
 	goldenTestsOutputsPaths := lo.Filter(allGoldenTestsOutputsPaths(t), func(path string, _ int) bool {
@@ -96,7 +96,7 @@ func TestKongClientGoldenTestsOutputs_Konnect(t *testing.T) {
 	konnect.SkipIfMissingRequiredKonnectEnvVariables(t)
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	cpID := konnect.CreateTestControlPlane(ctx, t)
 	cert, key := konnect.CreateClientCertificate(ctx, t, cpID)

--- a/test/kongintegration/kongupstreampolicy_test.go
+++ b/test/kongintegration/kongupstreampolicy_test.go
@@ -1,7 +1,6 @@
 package kongintegration
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -31,7 +30,7 @@ func TestKongUpstreamPolicyTranslation(t *testing.T) {
 		period  = time.Millisecond * 100
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	kongC := containers.NewKong(ctx, t)
 	kongClient, err := adminapi.NewKongAPIClient(kongC.AdminURL(ctx, t), adminapi.ClientOpts{}, "")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Followup for

- https://github.com/Kong/kubernetes-ingress-controller/pull/7145

because it detects more issues when Go version is at least 1.24.0. Spotted in
- https://github.com/Kong/kubernetes-ingress-controller/pull/7160

that requires Go 1.24.0

Failing [e2e-tetsts](https://github.com/Kong/kubernetes-ingress-controller/pull/7161#issuecomment-2679129305) are not related to this change, but rather to https://github.com/kubernetes-sigs/kind/issues/3871 or https://github.com/kubernetes-sigs/kind/issues/3795


<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->