### PR TITLE
chore(logs): feature gate are logged always in the same order

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -85,10 +87,11 @@ func New(
 		return nil, fmt.Errorf("config invalid: %w", err)
 	}
 	existingFeatureGates := config.GetFeatureGatesDefaults()
-	for feature, enabled := range c.FeatureGates {
-		logger.Info("Found configuration option for gated feature", "feature", feature, "enabled", enabled)
-		if _, ok := existingFeatureGates[feature]; !ok {
-			return nil, fmt.Errorf("%s is not a valid feature, please see the documentation: %s", feature, config.DocsURL)
+	for _, fgName := range slices.Sorted(maps.Keys(c.FeatureGates)) {
+		fgVal := c.FeatureGates[fgName]
+		logger.Info("Found configuration option for gated feature", "feature", fgName, "enabled", fgVal)
+		if _, ok := existingFeatureGates[fgName]; !ok {
+			return nil, fmt.Errorf("%s is not a valid feature, please see the documentation: %s", fgName, config.DocsURL)
 		}
 	}
 

--- a/pkg/manager/config/feature_gates.go
+++ b/pkg/manager/config/feature_gates.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 )
 
 const (
@@ -13,16 +15,15 @@ type FeatureGates map[string]bool
 
 // NewFeatureGates creates FeatureGates from the given feature gate map, overriding the default settings.
 func NewFeatureGates(featureGates map[string]bool) (FeatureGates, error) {
-	// generate a map of feature gates by string names to their controller enablement
+	// Generate a map of feature gates by string names to their controller enablement
 	ctrlMap := GetFeatureGatesDefaults()
 
-	// override the default settings
-	for feature, enabled := range featureGates {
-		_, ok := ctrlMap[feature]
-		if !ok {
-			return ctrlMap, fmt.Errorf("%s is not a valid feature, please see the documentation: %s", feature, DocsURL)
+	// Override the default settings.
+	for _, fgName := range slices.Sorted(maps.Keys(featureGates)) {
+		if _, ok := ctrlMap[fgName]; !ok {
+			return nil, fmt.Errorf("%s is not a valid feature, please see the documentation: %s", fgName, DocsURL)
 		}
-		ctrlMap[feature] = enabled
+		ctrlMap[fgName] = featureGates[fgName]
 	}
 
 	// KongCustomEntity requires FillIDs to be enabled, because custom entities requires stable IDs to fill in its "foreign" fields.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Due to the nature of Go maps, every iteration has a different order. This PR enforces the order for logs related to feature gates and the order of examination (and error return) in case they are wrongly configured. It makes logs easier to follow. 

