### PR TITLE
chore: make multimanager implement Runnable interface

### DIFF
--- a/pkg/manager/multiinstance/manager.go
+++ b/pkg/manager/multiinstance/manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/manager"
 )
@@ -50,6 +51,8 @@ type Manager struct {
 	diagnosticsExposer DiagnosticsExposer
 }
 
+var _ ctrlmanager.Runnable = &Manager{}
+
 // ManagerOption is a functional option that can be used to configure a new multi-instance manager.
 type ManagerOption func(*Manager)
 
@@ -74,8 +77,8 @@ func NewManager(logger logr.Logger, opts ...ManagerOption) *Manager {
 	return m
 }
 
-// Run starts the multi-instance manager and blocks until the context is canceled. It should only be called once.
-func (m *Manager) Run(ctx context.Context) error {
+// Start starts the multi-instance manager and blocks until the context is canceled. It should only be called once.
+func (m *Manager) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/manager/multiinstance/manager_test.go
+++ b/pkg/manager/multiinstance/manager_test.go
@@ -51,7 +51,7 @@ func TestManager_Scheduling(t *testing.T) {
 	t.Run("can run the manager", func(t *testing.T) {
 		go func() {
 			close(managerRunning)
-			require.NoError(t, multiManager.Run(ctx))
+			require.NoError(t, multiManager.Start(ctx))
 		}()
 	})
 
@@ -97,7 +97,7 @@ func TestManager_WithDiagnosticsExposer(t *testing.T) {
 	multiManager := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagnosticsExposer))
 
 	go func() {
-		require.NoError(t, multiManager.Run(ctx))
+		require.NoError(t, multiManager.Start(ctx))
 	}()
 
 	instanceID1 := manager.NewRandomID()

--- a/test/envtest/multiinstance_manager_diagnostics_test.go
+++ b/test/envtest/multiinstance_manager_diagnostics_test.go
@@ -41,7 +41,7 @@ func TestMultiInstanceManagerDiagnostics(t *testing.T) {
 	}()
 	multimgr := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagServer))
 	go func() {
-		require.NoError(t, multimgr.Run(ctx))
+		require.NoError(t, multimgr.Start(ctx))
 	}()
 
 	t.Log("Setting up two instances of the manager and scheduling them in the multi-instance manager")
@@ -92,7 +92,7 @@ func TestMultiInstanceManager_Profiling(t *testing.T) {
 	}()
 	multimgr := multiinstance.NewManager(testr.New(t), multiinstance.WithDiagnosticsExposer(diagServer))
 	go func() {
-		require.NoError(t, multimgr.Run(ctx))
+		require.NoError(t, multimgr.Start(ctx))
 	}()
 
 	m1 := SetupManager(ctx, t, lo.Must(manager.NewID("cp-1")), envcfg, AdminAPIOptFns(), WithDiagnosticsWithoutServer())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This is needed to make it run as a Runnable in KGO's manager.