### PR TITLE
test(helpers): remove cleanup of roles after deleting Konnect CPs

### DIFF
--- a/test/internal/helpers/konnect/control_plane.go
+++ b/test/internal/helpers/konnect/control_plane.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
-	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
-	sdkkonnecterrs "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/sdk"
@@ -80,49 +78,7 @@ func CreateTestControlPlane(ctx context.Context, t *testing.T) string {
 		)
 		assert.NoErrorf(t, err, "failed to cleanup a control plane: %q", cpID)
 
-		me, err := sdk.Me.GetUsersMe(
-			ctx,
-			// NOTE: Otherwise we use prod server by default.
-			// Related issue: https://github.com/Kong/sdk-konnect-go/issues/20
-			sdkkonnectops.WithServerURL(test.KonnectServerURL()),
-		)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		// We have to manually delete roles created for the control plane because Konnect doesn't do it automatically.
-		// If we don't do it, we will eventually hit a problem with Konnect APIs answering our requests with 504s
-		// because of a performance issue when there's too many roles for the account
-		// (see https://konghq.atlassian.net/browse/TPS-1319).
-		//
-		// We can drop this once the automated cleanup is implemented on Konnect side:
-		// https://konghq.atlassian.net/browse/TPS-1453.
-		resp, err := sdk.Roles.ListUserRoles(ctx, *me.User.ID,
-			&sdkkonnectops.ListUserRolesQueryParamFilter{},
-			// Related issue: https://github.com/Kong/sdk-konnect-go/issues/20
-			sdkkonnectops.WithServerURL(test.KonnectServerURL()),
-		)
-		require.NoErrorf(t, err, "failed to list control plane roles for cleanup: %q", cpID)
-
-		for _, role := range resp.AssignedRoleCollection.Data {
-			if role.EntityID == nil || role.ID == nil {
-				continue
-			}
-			if *role.EntityID != cpID {
-				continue
-			}
-
-			// Delete only roles created for the control plane.
-			t.Logf("deleting test Konnect Control Plane role: %q", *role.ID)
-			_, err := sdk.Roles.UsersRemoveRole(ctx, *me.User.ID, *role.ID,
-				// Related issue: https://github.com/Kong/sdk-konnect-go/issues/20
-				sdkkonnectops.WithServerURL(test.KonnectServerURL()),
-			)
-			notFoundErr := &sdkkonnecterrs.NotFoundError{}
-			if !errors.As(err, &notFoundErr) {
-				assert.NoErrorf(t, err, "failed to cleanup a control plane role: %q", *role.ID)
-			}
-		}
+		// Since Konnect authorization v2 supports cleanup of roles after control plane deleted, we do not need to delete them manually.
 	})
 
 	t.Logf("created test Konnect Control Plane: %q", cpID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Remove deleting of roles after deleting Konnect control planes since they are now automatically cleaned up in Konnect.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
