### PR TITLE
fix(kong_client): Do not check Kong gateway status by /status endpoint if workspace is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ Adding a new version? You'll need three changes:
 - Retry on creating admin API clients. The attempts and delay can be configured
   by the flags `--kong-admin-init-retries` and `--kong-admin-init-retry-delay`.
   [#7255](https://github.com/Kong/kubernetes-ingress-controller/pull/7255)
+- Skip checking whether Kong gateway is ready by `/status` admin API endpoint
+  when KIC is configured to use a specific workspace. This fixes the scenario
+  where KIC is permitted to access only the given workspace but cannot access
+  `/status` endpoint.
+  [#7233](https://github.com/Kong/kubernetes-ingress-controller/pull/7233)
 
 ## [3.4.3]
 

--- a/internal/adminapi/kong.go
+++ b/internal/adminapi/kong.go
@@ -69,12 +69,15 @@ func NewKongClientForWorkspace(
 	if err != nil {
 		return nil, fmt.Errorf("creating Kong client: %w", err)
 	}
-	// Ensure that the client is ready to be used by performing a status check.
-	if _, err := client.Status(ctx); err != nil {
-		return nil, KongClientNotReadyError{Err: err}
-	}
 
-	if wsName != "" {
+	// Ensure that the client is ready to be used by performing a status check.
+	// Only run the check when workspace is not given,
+	// because the client may not be granted to call /status and only allowed to access the given workspace.
+	if wsName == "" {
+		if _, err := client.Status(ctx); err != nil {
+			return nil, KongClientNotReadyError{Err: err}
+		}
+	} else {
 		// If a workspace was provided, verify whether or not it exists.
 		exists, err := client.Workspaces.ExistsByName(ctx, kong.String(wsName))
 		if err != nil {

--- a/test/mocks/admin_api_handler.go
+++ b/test/mocks/admin_api_handler.go
@@ -158,6 +158,27 @@ func NewAdminAPIHandler(t *testing.T, opts ...AdminAPIHandlerOpt) *AdminAPIHandl
 
 		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
 	})
+	// The handler for the status call in a specific workspace.
+	mux.HandleFunc("/workspace/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if !h.ready {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			if !h.workspaceExists && !h.workspaceWasCreated.Load() {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if h.configurationHash != "" {
+				_, _ = w.Write(formatDBLessStatusResponseWithConfigurationHash(h.configurationHash))
+			} else {
+				_, _ = w.Write([]byte(defaultDBLessStatusResponseWithoutConfigurationHash))
+			}
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+	})
 	mux.HandleFunc("/workspace/workspaces/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			if h.workspaceExists {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

When workspace is given, do not access `/status` endpoint for detecting whether Kong gateway is ready. Because in this scenario, KIC is likely to be permitted to only access the given workspace so it does not have the permission to access `/status` endpoint.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #6901 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
