### PR TITLE
fix(translator): Generate regex match for prefix match if replacePrefixMatch URLRewrite filter in the rule in translating HTTPRoute match to routes when expression router enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ Adding a new version? You'll need three changes:
   [#7293](https://github.com/Kong/kubernetes-ingress-controller/pull/7293)
 - Corrected the resource status handling logic for the fallbackConfiguration feature.
   [#7306](https://github.com/Kong/kubernetes-ingress-controller/pull/7306)
+- Fixed an issue in translation to expression routes that match rules other than
+  path (hostname, headers, ...) disappear when the `HTTPRoute` rule contains a
+  `URLRewrite` filter with the `ReplaceMatchPrefix` path modifier.
+  [#7269](https://github.com/Kong/kubernetes-ingress-controller/pull/7269)
 
 ## [3.4.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ Adding a new version? You'll need three changes:
 - Corrected the resource status handling logic for the fallbackConfiguration feature.
   [#7306](https://github.com/Kong/kubernetes-ingress-controller/pull/7306)
 - Fixed an issue in translation to expression routes that match rules other than
-  path (hostname, headers, ...) disappear when the `HTTPRoute` rule contains a
+  path (hostname, headers, ...) would disappear when the `HTTPRoute` rule contains a
   `URLRewrite` filter with the `ReplaceMatchPrefix` path modifier.
   [#7269](https://github.com/Kong/kubernetes-ingress-controller/pull/7269)
 

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -16,11 +16,11 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 )
 
-func generateMatcherFromHTTPRouteMatch(match gatewayapi.HTTPRouteMatch) atc.Matcher {
+func generateMatcherFromHTTPRouteMatch(match gatewayapi.HTTPRouteMatch, containReplacePrefixMatchURLRewriteFilter bool) atc.Matcher {
 	matcher := atc.And()
 
 	if match.Path != nil {
-		pathMatcher := pathMatcherFromHTTPPathMatch(match.Path)
+		pathMatcher := pathMatcherFromHTTPPathMatch(match.Path, containReplacePrefixMatchURLRewriteFilter)
 		matcher.And(pathMatcher)
 	}
 
@@ -49,21 +49,43 @@ func appendRegexBeginIfNotExist(regex string) string {
 	return regex
 }
 
-func pathMatcherFromHTTPPathMatch(pathMatch *gatewayapi.HTTPPathMatch) atc.Matcher {
+func pathMatcherFromHTTPPathMatch(pathMatch *gatewayapi.HTTPPathMatch, containReplacePrefixMatchURLRewriteFilter bool) atc.Matcher {
 	path := ""
 	if pathMatch.Value != nil {
 		path = *pathMatch.Value
 	}
+
 	switch *pathMatch.Type {
 	case gatewayapi.PathMatchExact:
 		return atc.NewPredicateHTTPPath(atc.OpEqual, path)
 	case gatewayapi.PathMatchPathPrefix:
-		if path == "" || path == "/" {
+		// if path ends with /, we should remove the trailing / because it should be ignored.
+		// So we normalize the path when the path match type is prefix.
+		// https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.PathMatchType
+		path = normalizePath(path)
+		pathIsRoot := isPathRoot(path)
+		// When the path match type is `prefix` and the rule contains a URLRewrite filtre with `ReplacePrefixMatch`,
+		// we should generate a regex matcher with a capture group for the match to let the plugin to extract the path segment to replace.
+		if containReplacePrefixMatchURLRewriteFilter {
+			exactPrefixPredicate := atc.NewPredicateHTTPPath(atc.OpEqual, path)
+			subpathsPredicate := func() atc.Predicate {
+				if pathIsRoot {
+					// If the path is "/", we don't capture the slash as Kong Route's path has to begin with a slash.
+					// If we captured the slash, we'd generate "(/.*)", and it'd be rejected by Kong.
+					return atc.NewPredicateHTTPPath(atc.OpRegexMatch, "^/(.*)")
+				}
+				// If the path is not "/", i.e. it has a prefix, we capture the slash to make it possible to
+				// route "/prefix" to "/replacement" and "/prefix/" to "/replacement/" correctly.
+				return atc.NewPredicateHTTPPath(atc.OpRegexMatch, fmt.Sprintf("^%s(/.*)", path))
+			}()
+			return atc.Or(exactPrefixPredicate, subpathsPredicate)
+		}
+		// Otherwise, we generate an "Or" expression of an exact match and a prefix match, like
+		// path == "/prefix" || path ^= "/prefix/".
+		if pathIsRoot {
 			return atc.NewPredicateHTTPPath(atc.OpPrefixMatch, "/")
 		}
-		// if path ends with /, we should remove the trailing / because it should be ignored:
-		// https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.PathMatchType
-		path = strings.TrimSuffix(path, "/")
+
 		return atc.Or(
 			atc.NewPredicateHTTPPath(atc.OpEqual, path),
 			atc.NewPredicateHTTPPath(atc.OpPrefixMatch, path+"/"),
@@ -460,6 +482,11 @@ func kongExpressionRouteFromHTTPRouteMatchWithPriority(
 		match.MatchIndex,
 	)
 
+	containReplacePrefixMatchURLRewriteFilter := lo.ContainsBy(httproute.Spec.Rules[match.RuleIndex].Filters, func(filter gatewayapi.HTTPRouteFilter) bool {
+		return filter.Type == gatewayapi.HTTPRouteFilterURLRewrite &&
+			filter.URLRewrite.Path != nil && filter.URLRewrite.Path.Type == gatewayapi.PrefixMatchHTTPPathModifier
+	})
+
 	r := &kongstate.Route{
 		Route: kong.Route{
 			Name:         kong.String(routeName),
@@ -475,7 +502,7 @@ func kongExpressionRouteFromHTTPRouteMatchWithPriority(
 	hostnames := []string{match.Hostname}
 	matchers := matchersFromParentHTTPRoute(hostnames, httproute.Annotations)
 	// generate ATC matcher from split HTTPRouteMatch itself.
-	matchers = append(matchers, generateMatcherFromHTTPRouteMatch(match.Match))
+	matchers = append(matchers, generateMatcherFromHTTPRouteMatch(match.Match, containReplacePrefixMatchURLRewriteFilter))
 
 	atc.ApplyExpression(&r.Route, atc.And(matchers...), httpRouteMatchWithPriority.Priority)
 

--- a/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -569,42 +569,6 @@ func TestGenerateRequestTransformerForURLRewrite(t *testing.T) {
 	}
 }
 
-func TestGenerateKongRouteModifierForURLRewritePrefixMatch_ExpressionsRouter(t *testing.T) {
-	testCases := []struct {
-		name                      string
-		path                      string
-		expectedRouteModification kongstate.Route
-	}{
-		{
-			name: "root path",
-			path: "/",
-			expectedRouteModification: kongstate.Route{
-				Route: kong.Route{
-					Expression: lo.ToPtr(`(http.path == "/") || (http.path ~ "^/(.*)")`),
-				},
-			},
-		},
-		{
-			name: "prefix path",
-			path: "/prefix",
-			expectedRouteModification: kongstate.Route{
-				Route: kong.Route{
-					Expression: lo.ToPtr(`(http.path == "/prefix") || (http.path ~ "^/prefix(/.*)")`),
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			modifier := generateKongRouteModifierForURLRewritePrefixMatch(tc.path, true)
-			route := kongstate.Route{}
-			modifier(&route)
-			require.Equal(t, tc.expectedRouteModification, route)
-		})
-	}
-}
-
 func TestMergePluginsOfTheSameType(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Generate regex match if the rule contains `ReplacePrefixMatch` URL rewrite filter in translating prefix path match into route if expression route enabled, instead of modifying the route after the matches are translated. This fixes the bug where `ReplacePrefixMatch` URL rewrite filter will make the matches for hostnames/headers/... lost.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7081 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
