### PR TITLE
fix(kong_client): return error in fetching listeners when no ready kong clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ Adding a new version? You'll need three changes:
   where KIC is permitted to access only the given workspace but cannot access
   `/status` endpoint.
   [#7233](https://github.com/Kong/kubernetes-ingress-controller/pull/7233)
+- Return error when no ready Kong admin API clients in fetching listeners in
+  the reconciliation of `Gateway`s to trigger a requeue when no Kong gateways
+  are available.
+  [#7293](https://github.com/Kong/kubernetes-ingress-controller/pull/7293)
 
 ## [3.4.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,9 +122,8 @@ Adding a new version? You'll need three changes:
   where KIC is permitted to access only the given workspace but cannot access
   `/status` endpoint.
   [#7233](https://github.com/Kong/kubernetes-ingress-controller/pull/7233)
-- Return error when no ready Kong admin API clients in fetching listeners in
-  the reconciliation of `Gateway`s to trigger a requeue when no Kong gateways
-  are available.
+- Report an error and requeue when there are no ready Kong admin API clients
+  during the reconciliation of `Gateway`s.
   [#7293](https://github.com/Kong/kubernetes-ingress-controller/pull/7293)
 
 ## [3.4.3]

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -872,17 +872,17 @@ func (r *GatewayReconciler) updateAddressesAndListenersStatus(
 			Reason:             string(gatewayapi.GatewayReasonProgrammed),
 		}
 		setGatewayCondition(gateway, programmedCondition)
-
+		info(log, gateway, "Gateway Programmed status updated")
 		err := r.Status().Update(ctx, pruneGatewayStatusConds(gateway))
 		return handleUpdateError(err, r.Log, gateway)
 	}
 	if !isEqualListenersStatus(gateway.Status.Listeners, listenerStatuses) {
 		gateway.Status.Listeners = listenerStatuses
-
+		info(log, gateway, "Gateway listener status updated")
 		err := r.Status().Update(ctx, gateway)
 		return handleUpdateError(err, r.Log, gateway)
 	}
 
-	info(log, gateway, "Gateway status updated")
+	debug(log, gateway, "Gateway status not updated")
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -32,6 +33,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/controllers"
 	ctrlref "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/reference"
 	ctrlutils "github.com/kong/kubernetes-ingress-controller/v3/internal/controllers/utils"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/gatewayapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/logging"
 )
@@ -583,6 +585,18 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 		debug(log, gateway, "Determining listener configurations from Kong data-plane")
 		kongListeners, err = r.determineListenersFromDataPlane(ctx, svc, kongListeners)
 		if err != nil {
+			errNoReadyClient := dataplane.NoReadyGatewayClientsError{}
+			if errors.As(err, &errNoReadyClient) {
+				// Requeue the request to reconcile the gateway again after `retryAfter` but not return the error to trigger a Reconcile Error
+				// when no gateway is available to fetch information of listeners.
+				// REVIEW: Should we implement some exponential backoff strategy here instead of a fixed retry delay?
+				retryAfter := time.Second
+				info(log, gateway,
+					"Cannot determine listeners because no available Kong gateway clients now, retrying...",
+					"retry_after", retryAfter.String(),
+				)
+				return ctrl.Result{Requeue: true, RequeueAfter: retryAfter}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		combinedAddresses = append(combinedAddresses, kongAddresses...)

--- a/internal/controllers/gateway/utils.go
+++ b/internal/controllers/gateway/utils.go
@@ -21,7 +21,7 @@ func debug(log logr.Logger, obj client.Object, msg string, keysAndValues ...inte
 }
 
 // info is an alias for the longer log.V(util.InfoLevel).Info for convenience.
-func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) { //nolint:unparam
+func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) {
 	keysAndValues = append([]interface{}{
 		"namespace", obj.GetNamespace(),
 		"name", obj.GetName(),

--- a/internal/controllers/gateway/utils.go
+++ b/internal/controllers/gateway/utils.go
@@ -21,7 +21,7 @@ func debug(log logr.Logger, obj client.Object, msg string, keysAndValues ...inte
 }
 
 // info is an alias for the longer log.V(util.InfoLevel).Info for convenience.
-func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) {
+func info(log logr.Logger, obj client.Object, msg string, keysAndValues ...interface{}) { //nolint:unparam
 	keysAndValues = append([]interface{}{
 		"namespace", obj.GetNamespace(),
 		"name", obj.GetName(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Return an error when no ready clients in fetching listeners. It will trigger a `Reconciler Error` in setting listener status in reconciling `Gateway`s.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7015
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
