### PR TITLE
fix: fix the FallbackConfiguration object report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ Adding a new version? You'll need three changes:
 - Report an error and requeue when there are no ready Kong admin API clients
   during the reconciliation of `Gateway`s.
   [#7293](https://github.com/Kong/kubernetes-ingress-controller/pull/7293)
+- Corrected the resource status handling logic for the fallbackConfiguration feature.
+  [#7306](https://github.com/Kong/kubernetes-ingress-controller/pull/7306)
 
 ## [3.4.3]
 

--- a/examples/ingress-broken-plugin-fallback.yaml
+++ b/examples/ingress-broken-plugin-fallback.yaml
@@ -1,0 +1,95 @@
+# This configuration file presents fallback configuration (feature gate FallbackConfiguration=true),
+# it contains a plugin that is misconfigured and will not work. The whole route /for-auth-users won't
+# be configured. Only the route /ingress-testing will be configured.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-1
+  labels:
+    app: echo-1
+spec:
+  selector:
+    matchLabels:
+      app: echo-1
+  template:
+    metadata:
+      labels:
+        app: echo-1
+    spec:
+      containers:
+      - name: echo-1
+        image: kong/go-echo:0.3.0
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "250m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: echo-1
+  name: echo-1
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 1027
+  selector:
+    app: echo-1
+  type: ClusterIP
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: for-auth
+  annotations:
+    konghq.com/plugins: key-auth
+spec:
+  ingressClassName: kong
+  rules:
+    - http:
+        paths:
+          - path: /for-auth-users
+            pathType: Prefix
+            backend:
+              service:
+                name: echo-1
+                port:
+                  number: 80
+
+---
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: key-auth
+plugin: key-auth
+config:
+  # Should be key_names, not keys.
+  keys: ["key"]
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: working-ingress
+spec:
+  ingressClassName: kong
+  rules:
+    - http:
+        paths:
+          - path: /ingress-testing
+            pathType: Prefix
+            backend:
+              service:
+                name: echo-1
+                port:
+                  number: 80

--- a/internal/dataplane/kong_client.go
+++ b/internal/dataplane/kong_client.go
@@ -670,6 +670,13 @@ func (c *KongClient) tryRecoveringWithFallbackConfiguration(
 	}
 	c.maybeUpdateKonnectKongState(fallbackParsingResult.KongState, isFallback)
 
+	// Report on configured Kubernetes objects if enabled for fallback configuration
+	if c.AreKubernetesObjectReportsEnabled() {
+		c.logger.V(logging.DebugLevel).Info("Triggering report for configured Kubernetes objects in fallback configuration",
+			"count", len(fallbackParsingResult.ConfiguredKubernetesObjects))
+		c.triggerKubernetesObjectReport(fallbackParsingResult.ConfiguredKubernetesObjects, fallbackParsingResult.TranslationFailures)
+	}
+
 	// Configuration was successfully recovered with the fallback configuration. Store the last valid configuration.
 	c.maybePreserveTheLastValidConfigCache(fallbackCache)
 	return nil

--- a/test/integration/isolated/examples_ingress_fallback_test.go
+++ b/test/integration/isolated/examples_ingress_fallback_test.go
@@ -1,0 +1,154 @@
+//go:build integration_tests
+
+package isolated
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/diagnostics"
+	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/integration/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
+)
+
+func TestIngressWithBrokenPluginFallback(t *testing.T) {
+	ingressWithBrokenPluginFallback := examplesManifestPath("ingress-broken-plugin-fallback.yaml")
+
+	replaceIngressClassAnnotationInManifests := func(manifests string, ingressClass string) string {
+		return strings.ReplaceAll(manifests, "ingressClassName: kong", fmt.Sprintf("ingressClassName: %s", ingressClass))
+	}
+
+	f := features.
+		New("example").
+		WithLabel(testlabels.Example, testlabels.ExampleTrue).
+		WithLabel(testlabels.NetworkingFamily, testlabels.NetworkingFamilyIngress).
+		WithLabel(testlabels.Kind, testlabels.KindIngress).
+		WithSetup("deploy kong addon into cluster", featureSetup(
+			withControllerManagerOpts(
+				helpers.ControllerManagerOptAdditionalWatchNamespace("default"),
+			),
+			withControllerManagerFeatureGates(map[string]string{managercfg.FallbackConfigurationFeature: "true"}),
+		)).
+		Assess("deploying to cluster works and HTTP traffic is routed to the service",
+			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+				cleaner := GetFromCtxForT[*clusters.Cleaner](ctx, t)
+				cluster := GetClusterFromCtx(ctx)
+				proxyURL := GetHTTPURLFromCtx(ctx)
+
+				t.Logf("applying yaml manifest %s", ingressWithBrokenPluginFallback)
+				b, err := os.ReadFile(ingressWithBrokenPluginFallback)
+				assert.NoError(t, err)
+				manifest := replaceIngressClassAnnotationInManifests(string(b), GetIngressClassFromCtx(ctx))
+				assert.NoError(t, clusters.ApplyManifestByYAML(ctx, cluster, manifest))
+				cleaner.AddManifest(manifest)
+
+				t.Logf("verifying that the Ingress routes traffic properly to the /ingress-testing path")
+				helpers.EventuallyGETPath(
+					t,
+					proxyURL,
+					proxyURL.Host,
+					"/ingress-testing",
+					nil,
+					http.StatusOK,
+					"Running on Pod",
+					nil,
+					consts.IngressWait,
+					consts.WaitTick,
+				)
+
+				return ctx
+			}).
+		Assess("verify that valid Ingress's status contains LoadBalancer information", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			cluster := GetClusterFromCtx(ctx)
+			// Verify Ingress status contains LoadBalancer information
+			require.Eventually(t, func() bool {
+				ingress, err := cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, "working-ingress", metav1.GetOptions{})
+				if err != nil {
+					t.Logf("Failed to get Ingress: %v", err)
+					return false
+				}
+				lbStatus := ingress.Status.LoadBalancer.Ingress
+				return len(lbStatus) > 0
+			}, consts.IngressWait, consts.WaitTick)
+			return ctx
+		}).
+		Assess("verify that route with misconfigured plugin is not operational", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			proxyURL := GetHTTPURLFromCtx(ctx)
+			t.Logf("verifying that Kong gateway response is returned instead of desired site")
+
+			helpers.EventuallyGETPath(
+				t,
+				proxyURL,
+				proxyURL.Host,
+				"/for-auth-users",
+				nil,
+				http.StatusNotFound,
+				"no Route matched with those values",
+				nil,
+				consts.IngressWait,
+				consts.WaitTick,
+			)
+			return ctx
+		}).
+		Assess("verify that invalid Ingress's status doesn't contain LoadBalancer information", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			cluster := GetClusterFromCtx(ctx)
+			// Verify Ingress status contains LoadBalancer information
+			require.Eventually(t, func() bool {
+				ingress, err := cluster.Client().NetworkingV1().Ingresses("default").Get(ctx, "for-auth", metav1.GetOptions{})
+				if err != nil {
+					t.Logf("Failed to get Ingress: %v", err)
+					return false
+				}
+				lbStatus := ingress.Status.LoadBalancer.Ingress
+				return len(lbStatus) == 0
+			}, consts.IngressWait, consts.WaitTick)
+			return ctx
+		}).
+		Assess("verify diagnostic server fallback info", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			diagURL := GetDiagURLFromCtx(ctx)
+			t.Logf("verifying diag available")
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				cl := helpers.DefaultHTTPClient()
+				resp, err := cl.Do(helpers.MustHTTPRequest(t, http.MethodGet, diagURL.Host, "/debug/config/fallback", nil))
+				if !assert.NoError(c, err) {
+					return
+				}
+				defer resp.Body.Close()
+
+				if !assert.Equal(c, http.StatusOK, resp.StatusCode) {
+					return
+				}
+
+				response := diagnostics.FallbackResponse{}
+				err = json.NewDecoder(resp.Body).Decode(&response)
+				if !assert.NoError(c, err) {
+					return
+				}
+				assert.Equal(t, response.Status, diagnostics.FallbackStatusTriggered)
+				assert.NotEmpty(t, response.ExcludedObjects)
+				contains := lo.ContainsBy(response.ExcludedObjects, func(obj diagnostics.FallbackAffectedObjectMeta) bool {
+					return obj.Group == "configuration.konghq.com" && obj.Kind == "KongPlugin" && obj.Name == "key-auth"
+				})
+				assert.Truef(t, contains, "expected to find KongPlugin key-auth in excluded objects, got: %v", response.ExcludedObjects)
+			}, consts.IngressWait, consts.WaitTick)
+			return ctx
+		}).
+		Teardown(featureTeardown())
+
+	tenv.Test(t, f.Feature())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

 

As described in https://github.com/Kong/kubernetes-ingress-controller/issues/7172 , when the FallbackConfiguration feature is enabled and an Ingress references a plugin with incorrect configuration, even the correct Ingress resource cannot update its status. This PR fixes that issue.

The changes include adding a new example configuration file, updating the client to report configured Kubernetes objects, and adding integration tests to verify the functionality.

Key changes:

### New Example Configuration:
* Added `examples/ingress-broken-plugin-fallback.yaml` to demonstrate the fallback configuration with a misconfigured plugin.

### Client Updates:
* Updated `tryRecoveringWithFallbackConfiguration` method in `internal/dataplane/kong_client.go` to report configured Kubernetes objects when fallback configuration is enabled.

### Integration Tests:
* Added `test/integration/isolated/examples_ingress_fallback_test.go` to test the ingress with broken plugin fallback, ensuring that valid configurations are applied and misconfigured routes are handled correctly.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes: https://github.com/Kong/kubernetes-ingress-controller/issues/7172

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
