### PR TITLE
chore: re-enable metrics envtest

### DIFF
--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -62,9 +62,7 @@ func TestMetricsAreServed(t *testing.T) {
 	addr := fmt.Sprintf("localhost:%d", helpers.GetFreePort(t))
 	_ = RunManager(t.Context(), t, envcfg,
 		AdminAPIOptFns(adminAPIOpts...),
-		func(cfg *managercfg.Config) {
-			cfg.FeatureGates[managercfg.FallbackConfigurationFeature] = true
-		},
+		WithFeatureGate(managercfg.FallbackConfigurationFeature, true),
 		WithMetricsAddr(addr),
 	)
 

--- a/test/envtest/metrics_envtest_test.go
+++ b/test/envtest/metrics_envtest_test.go
@@ -3,16 +3,16 @@
 package envtest
 
 import (
-	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/avast/retry-go/v4"
 	prom "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
@@ -27,140 +27,84 @@ func TestMetricsAreServed(t *testing.T) {
 	const (
 		waitTime = 200 * time.Second
 		tickTime = 10 * time.Millisecond
-		maxDelay = 500 * time.Millisecond
 	)
+
+	allExpectedMetrics := []string{
+		metrics.MetricNameConfigPushCount,
+		metrics.MetricNameConfigPushBrokenResources,
+		metrics.MetricNameTranslationCount,
+		metrics.MetricNameTranslationDuration,
+		metrics.MetricNameConfigPushSize,
+		metrics.MetricNameTranslationBrokenResources,
+		metrics.MetricNameConfigPushDuration,
+
+		metrics.MetricNameFallbackTranslationBrokenResources,
+		metrics.MetricNameFallbackTranslationCount,
+		metrics.MetricNameFallbackTranslationDuration,
+		metrics.MetricNameFallbackConfigPushSize,
+		metrics.MetricNameFallbackConfigPushCount,
+		metrics.MetricNameFallbackConfigPushSuccessTime,
+		metrics.MetricNameFallbackConfigPushDuration,
+		metrics.MetricNameFallbackConfigPushBrokenResources,
+		metrics.MetricNameProcessedConfigSnapshotCacheHit,
+		metrics.MetricNameProcessedConfigSnapshotCacheMiss,
+	}
 
 	scheme := Scheme(t, WithKong)
 	envcfg := Setup(t, scheme)
 
-	testCases := []struct {
-		name                         string
-		withPushError                bool
-		fallbackConfigurationEnabled bool
-		expectedMetrics              []string
-		skippedMessage               string
-	}{
-		{
-			name:                         "with push error and FallbackConfiguration enabled",
-			skippedMessage:               "flaky, see https://github.com/Kong/kubernetes-ingress-controller/issues/6125",
-			withPushError:                true,
-			fallbackConfigurationEnabled: true,
-			expectedMetrics: []string{
-				metrics.MetricNameConfigPushCount,
-				metrics.MetricNameConfigPushBrokenResources,
-				metrics.MetricNameTranslationCount,
-				metrics.MetricNameTranslationDuration,
-				metrics.MetricNameConfigPushSize,
-				metrics.MetricNameTranslationBrokenResources,
-				metrics.MetricNameConfigPushDuration,
-
-				metrics.MetricNameFallbackTranslationBrokenResources,
-				metrics.MetricNameFallbackTranslationCount,
-				metrics.MetricNameFallbackTranslationDuration,
-				metrics.MetricNameFallbackConfigPushSize,
-				metrics.MetricNameFallbackConfigPushCount,
-				metrics.MetricNameFallbackConfigPushSuccessTime,
-				metrics.MetricNameFallbackConfigPushDuration,
-				metrics.MetricNameFallbackConfigPushBrokenResources,
-				metrics.MetricNameProcessedConfigSnapshotCacheHit,
-				metrics.MetricNameProcessedConfigSnapshotCacheMiss,
-			},
-		},
-		{
-			name:          "without push error",
-			withPushError: false,
-			expectedMetrics: []string{
-				metrics.MetricNameConfigPushCount,
-				metrics.MetricNameConfigPushBrokenResources,
-				metrics.MetricNameTranslationCount,
-				metrics.MetricNameTranslationDuration,
-				metrics.MetricNameConfigPushSize,
-				metrics.MetricNameTranslationBrokenResources,
-				metrics.MetricNameConfigPushDuration,
-				metrics.MetricNameConfigPushSuccessTime,
-			},
-		},
+	// We're going to make the first request to the admin API fail, so that the manager falls back to the last valid
+	// configuration and we can test the fallback metrics.
+	adminAPIOpts := []mocks.AdminAPIHandlerOpt{
+		mocks.WithConfigPostError([]byte(`{"flattened_errors": [{"errors": [{"messages": ["broken object"]}], "entity_tags": ["k8s-name:test-service","k8s-namespace:default","k8s-kind:Service","k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3","k8s-group:","k8s-version:v1"]}]}`)),
+		mocks.WithConfigPostErrorOnlyOnFirstRequest(),
 	}
+	addr := fmt.Sprintf("localhost:%d", helpers.GetFreePort(t))
+	_ = RunManager(t.Context(), t, envcfg,
+		AdminAPIOptFns(adminAPIOpts...),
+		func(cfg *managercfg.Config) {
+			cfg.FeatureGates[managercfg.FallbackConfigurationFeature] = true
+		},
+		WithMetricsAddr(addr),
+	)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.skippedMessage != "" {
-				t.Skip(tc.skippedMessage)
-			}
-			ctx, cancel := context.WithTimeout(t.Context(), waitTime)
-			defer cancel()
+	metricsURL := fmt.Sprintf("http://%s/metrics", addr)
+	t.Logf("waiting for metrics to be available at %q", metricsURL)
 
-			var adminAPIOpts []mocks.AdminAPIHandlerOpt
-			if tc.withPushError {
-				adminAPIOpts = append(adminAPIOpts,
-					mocks.WithConfigPostError([]byte(`{"flattened_errors": [{"errors": [{"messages": ["broken object"]}], "entity_tags": ["k8s-name:test-service","k8s-namespace:default","k8s-kind:Service","k8s-uid:a3b8afcc-9f19-42e4-aa8f-5866168c2ad3","k8s-group:","k8s-version:v1"]}]}`)),
-					mocks.WithConfigPostErrorOnlyOnFirstRequest(),
-				)
-			}
-			addr := fmt.Sprintf("localhost:%d", helpers.GetFreePort(t))
-			_ = RunManager(ctx, t, envcfg,
-				AdminAPIOptFns(adminAPIOpts...),
-				func(cfg *managercfg.Config) {
-					cfg.FeatureGates[managercfg.FallbackConfigurationFeature] = tc.fallbackConfigurationEnabled
-				},
-				WithMetricsAddr(addr),
-			)
-
-			metricsURL := fmt.Sprintf("http://%s/metrics", addr)
-			t.Logf("waiting for metrics to be available at %q", metricsURL)
-
-			for _, metric := range tc.expectedMetrics {
-				t.Run(metric, func(t *testing.T) {
-					require.NoError(t,
-						retry.Do(func() error {
-							resp, err := http.Get(metricsURL)
-							if err != nil {
-								return fmt.Errorf("error %w checking %q", err, metricsURL)
-							}
-							defer resp.Body.Close()
-
-							if http.StatusOK != resp.StatusCode {
-								return fmt.Errorf("status code %v not as expected (200)", resp.StatusCode)
-							}
-
-							var parser expfmt.TextParser
-							mf, err := parser.TextToMetricFamilies(resp.Body)
-							if err != nil {
-								return fmt.Errorf("error %w parsing %q", err, metricsURL)
-							}
-
-							m, ok := mf[metric]
-							if !ok {
-								return fmt.Errorf("metric %q not present yet", metric)
-							}
-
-							for _, m := range m.GetMetric() {
-								containsInstanceID := lo.ContainsBy(m.GetLabel(), func(l *prom.LabelPair) bool {
-									return l.GetName() == metrics.InstanceIDKey && l.GetValue() != ""
-								})
-								if !containsInstanceID {
-									return fmt.Errorf("metric %q does not contain instance id label", metric)
-								}
-							}
-
-							return nil
-						},
-							retry.Context(ctx),
-							retry.Delay(tickTime),
-							retry.MaxDelay(maxDelay),
-							retry.MaxJitter(maxDelay),
-							retry.DelayType(retry.BackOffDelay),
-							retry.Attempts(0), // We're using a context with timeout, so we don't need to limit the number of attempts.
-							retry.LastErrorOnly(true),
-							retry.OnRetry(func(_ uint, err error) {
-								t.Logf("metric %s not present yet, err: %v", metric, err.Error())
-							}),
-						),
-					)
-
-					t.Logf("metric %q is present at /metrics", metric)
-				})
-			}
+	assertMetric := func(t *assert.CollectT, reportedMetrics []*prom.MetricFamily, expectedMetricName string) {
+		m, ok := lo.Find(reportedMetrics, func(m *prom.MetricFamily) bool {
+			return m.GetName() == expectedMetricName
 		})
+		if !assert.True(t, ok, "expected metric %q not found in the response", expectedMetricName) {
+			return
+		}
+		for _, m := range m.GetMetric() {
+			containsInstanceID := lo.ContainsBy(m.GetLabel(), func(l *prom.LabelPair) bool {
+				return l.GetName() == metrics.InstanceIDKey && l.GetValue() != ""
+			})
+			assert.True(t, containsInstanceID, "metric %q does not contain instance id label", expectedMetricName)
+		}
 	}
+	httpClient := http.Client{
+		Timeout: waitTime, // Set a timeout to avoid hanging forever.
+	}
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := httpClient.Get(metricsURL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		reportedMetrics := extractAllMetrics(t, resp.Body)
+		for _, expectedMetricName := range allExpectedMetrics {
+			assertMetric(t, reportedMetrics, expectedMetricName)
+		}
+	}, waitTime, tickTime)
+}
+
+func extractAllMetrics(t *assert.CollectT, body io.Reader) []*prom.MetricFamily {
+	var parser expfmt.TextParser
+	mf, err := parser.TextToMetricFamilies(body)
+	require.NoError(t, err)
+	return lo.Values(mf)
 }

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -197,6 +197,12 @@ func WithCacheSyncTimeout(d time.Duration) func(cfg *managercfg.Config) {
 	}
 }
 
+func WithFeatureGate(name string, enabled bool) func(cfg *managercfg.Config) {
+	return func(cfg *managercfg.Config) {
+		cfg.FeatureGates[name] = enabled
+	}
+}
+
 // AdminAPIOptFns wraps a variadic list of mocks.AdminAPIHandlerOpt and returns
 // a slice containing all of them.
 // The purpose of this is func is to make the call sites a bit less verbose.


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor the `TestMetricsAreServed` envtest so it's stable. Make sure there are timeouts set to avoid hanging on HTTP requests. 

Stability tested with `GOTESTFLAGS="-count=200 -run=TestMetricsAreServed -timeout=3h" make test.envtest`.

**Which issue this PR fixes**:

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6125.

