### PR TITLE
chore(ci): fix token permissions in release workflow 2.12.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,13 +18,17 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   verify-manifest-tag:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       fullversion_tag: ${{ steps.semver_parser.outputs.fullversion }}
     steps:
-      - uses: mukunku/tag-exists-action@78009d2b13e10ba051fe68d8d2f6778a9b2adab3 # v1.4.0
+      - uses: mukunku/tag-exists-action@bdad1eaa119ce71b150b952c97351c75025c06a9 # v1.6.0
         id: check-tag
         name: check if tag already exists
         with:
@@ -35,7 +39,7 @@ jobs:
         if: ${{ steps.check-tag.outputs.exists == 'true' }}
         run: exit 1
       - name: checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Parse semver string
@@ -53,12 +57,13 @@ jobs:
         run: make verify.versions
 
   build-push-images:
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES) }}
     environment: 'Docker Push'
     needs: verify-manifest-tag
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Parse semver string
@@ -69,16 +74,20 @@ jobs:
           version_extractor_regex: 'v(.*)$'
       - name: Add standard tags
         run: |
-          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
-          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          (
+            echo 'TAGS_STANDARD<<EOF'
+            echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}'
+            echo 'EOF'
+          ) >> $GITHUB_ENV
       - name: Add major.minor tag
         if: ${{ steps.semver_parser.outputs.prerelease == '' }}
         run: |
-          echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          (
+            echo 'TAGS_SUPPLEMENTAL<<EOF'
+            echo ""
+            echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}'
+            echo 'EOF'
+          ) >> $GITHUB_ENV
       # Setup Golang to use go pkg cache which is utilized in Dockerfile's cache mount.
       - name: Setup golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -150,8 +159,11 @@ jobs:
       all-supported-k8s-versions: true
 
   publish-release:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs: [build-push-images, test-e2e]
+    permissions:
+      contents: write
     steps:
     - name: Parse semver string
       id: semver_parser
@@ -159,7 +171,7 @@ jobs:
       with:
         input_string: ${{ github.event.inputs.tag }}
         version_extractor_regex: 'v(.*)$'
-    - uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # v1
+    - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
       with:
         body: |
           #### Download Kong Ingress Controller ${{ steps.semver_parser.outputs.fullversion }}:
@@ -180,13 +192,16 @@ jobs:
         makeLatest: ${{ github.event.inputs.latest == 'true' }}
 
   update-latest-branch:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     if: github.event.inputs.latest == 'true'
+    permissions:
+      contents: write
     needs:
     - publish-release
     steps:
     - name: checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
     - name: Parse semver string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Fix 2.12's release workflow token permissions (to align them with `main`'s) so that this: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/14356924192/job/40264036011

```
Error: Error 403: Resource not accessible by integration
```

doesn't happen anymore.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
