### PR TITLE
fix(sendconfig): Do not skip when SHA is not changed if the update is performed by a fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,9 @@ Adding a new version? You'll need three changes:
 - Fill IDs of translated Kong plugins to prevent errors in `go-database-reconciler`
   when a plugin's attached entities is changed.
   [#7410](https://github.com/Kong/kubernetes-ingress-controller/pull/7410)
+- Do not skip updating when the SHA of the current configuration is the same as
+  the SHA of the last valid configuration in applying fallback configuration.
+  [#7380](https://github.com/Kong/kubernetes-ingress-controller/pull/7380)
 
 ## [3.4.4]
 

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -58,8 +58,11 @@ func PerformUpdate(
 		return oldSHA, fmt.Errorf("failed to generate SHA for target content: %w", err)
 	}
 
-	// disable optimization if reverse sync is enabled
-	if !config.EnableReverseSync {
+	// Disable the optimization by checking if the configuration is same as the last applied configuration if:
+	// - reverse sync is enabled
+	// - or the update is performed by a fallback process because in DBmode, when applying fails, some entities are applied successfully, then the Kong gateway may be in a "partial success" state.
+	// REVIEW: Only disable the check on fallback in DBmode?
+	if !config.EnableReverseSync || !isFallback {
 		configurationChanged, err := configChangeDetector.HasConfigurationChanged(ctx, oldSHA, newSHA, targetContent, client.AdminAPIClient())
 		if err != nil {
 			return nil, fmt.Errorf("failed to detect configuration change: %w", err)

--- a/internal/dataplane/sendconfig/sendconfig.go
+++ b/internal/dataplane/sendconfig/sendconfig.go
@@ -58,11 +58,11 @@ func PerformUpdate(
 		return oldSHA, fmt.Errorf("failed to generate SHA for target content: %w", err)
 	}
 
-	// Disable the optimization by checking if the configuration is same as the last applied configuration if:
+	// Disable the optimization in DB mode by checking if the configuration is same as the last applied configuration if:
 	// - reverse sync is enabled
 	// - or the update is performed by a fallback process because in DBmode, when applying fails, some entities are applied successfully, then the Kong gateway may be in a "partial success" state.
-	// REVIEW: Only disable the check on fallback in DBmode?
-	if !config.EnableReverseSync || !isFallback {
+	if config.InMemory ||
+		(!config.EnableReverseSync && !isFallback) {
 		configurationChanged, err := configChangeDetector.HasConfigurationChanged(ctx, oldSHA, newSHA, targetContent, client.AdminAPIClient())
 		if err != nil {
 			return nil, fmt.Errorf("failed to detect configuration change: %w", err)

--- a/test/integration/consumer_group_test.go
+++ b/test/integration/consumer_group_test.go
@@ -200,7 +200,7 @@ func TestConsumerGroup(t *testing.T) {
 			return
 		}
 		defer resp.Body.Close()
-		if !assert.Equal(c, resp.StatusCode, http.StatusOK) {
+		if !assert.Equal(c, http.StatusOK, resp.StatusCode) {
 			return
 		}
 		hv := resp.Header.Get(addedHeader.K)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Do not skip the update of config if the SHA is the same as last valid configuration when the update is performed by a fallback. This fixes the issue that in DB mode, if the fallback configuration is the same as the last  valid configuration, the entities that should be purged together with the invalid entities still remains.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7374 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
