### PR TITLE
Fix(sendconfig): Keep ID of existing plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,16 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+ ## Unreleased
+
+ ### Fixed
+
+ - Keep the plugin's ID unchanged if there is already the same plugin exists
+   when working with DB backed Kong gateways. "Same" plugin is identified by the
+   combination of plugin name, and ID of attached service, route, consumer and
+   consumer group. This prevents the conflicts in upgrading KIC.
+   [#7446](https://github.com/Kong/kubernetes-ingress-controller/pull/7446)
+
 ## [3.4.5]
 
 > Release date: 2025-05-15

--- a/internal/dataplane/sendconfig/dbmode_test.go
+++ b/internal/dataplane/sendconfig/dbmode_test.go
@@ -1,0 +1,283 @@
+package sendconfig
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kong/go-database-reconciler/pkg/state"
+	deckutils "github.com/kong/go-database-reconciler/pkg/utils"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefillPluginIDs(t *testing.T) {
+	testCases := []struct {
+		name             string
+		currentState     *state.KongState
+		targetState      *state.KongState
+		expectedPluginID string
+	}{
+		{
+			name: "plugin attached to the same service should be considered as the same plugin",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-1"),
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-2"),
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+			}),
+			expectedPluginID: "plugin-1",
+		},
+		{
+			name: "plugin attached to different services should not be considered as the same plugin",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-1"),
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-2"),
+						ID:   kong.String("service-2"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-2"),
+						Service: &kong.Service{
+							Name: kong.String("service-2"),
+							ID:   kong.String("service-2"),
+						},
+					},
+				},
+			}),
+			expectedPluginID: "plugin-2",
+		},
+		{
+			name: "plugin attached to the same comblination of route and consumer should be considered as the same plugin",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Routes: []*kong.Route{
+					{
+						Name:  kong.String("route-1"),
+						ID:    kong.String("route-1"),
+						Paths: []*string{kong.String("/")},
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+				Consumers: []*kong.Consumer{
+					{
+						Username: kong.String("consumer-1"),
+						ID:       kong.String("consumer-1"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-1"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("consumer-1"),
+						},
+						Route: &kong.Route{
+							ID: kong.String("route-1"),
+						},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Routes: []*kong.Route{
+					{
+						Name:  kong.String("route-1"),
+						ID:    kong.String("route-1"),
+						Paths: []*string{kong.String("/")},
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+				Consumers: []*kong.Consumer{
+					{
+						Username: kong.String("consumer-1"),
+						ID:       kong.String("consumer-1"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-2"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("consumer-1"),
+						},
+						Route: &kong.Route{
+							ID: kong.String("route-1"),
+						},
+					},
+				},
+			}),
+			expectedPluginID: "plugin-1",
+		},
+		{
+			name: "plugin attached to the same route but different consumers should not be considered as the same plugin",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Routes: []*kong.Route{
+					{
+						Name:  kong.String("route-1"),
+						ID:    kong.String("route-1"),
+						Paths: []*string{kong.String("/")},
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+				Consumers: []*kong.Consumer{
+					{
+						Username: kong.String("consumer-1"),
+						ID:       kong.String("consumer-1"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-1"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("consumer-1"),
+						},
+						Route: &kong.Route{
+							ID: kong.String("route-1"),
+						},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Services: []*kong.Service{
+					{
+						Name: kong.String("service-1"),
+						ID:   kong.String("service-1"),
+						Host: kong.String("kong.test"),
+					},
+				},
+				Routes: []*kong.Route{
+					{
+						Name:  kong.String("route-1"),
+						ID:    kong.String("route-1"),
+						Paths: []*string{kong.String("/")},
+						Service: &kong.Service{
+							Name: kong.String("service-1"),
+							ID:   kong.String("service-1"),
+						},
+					},
+				},
+				Consumers: []*kong.Consumer{
+					{
+						Username: kong.String("consumer-2"),
+						ID:       kong.String("consumer-2"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name: kong.String("request-transformer"),
+						ID:   kong.String("plugin-2"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("consumer-2"),
+						},
+						Route: &kong.Route{
+							ID: kong.String("route-1"),
+						},
+					},
+				},
+			}),
+			expectedPluginID: "plugin-2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &UpdateStrategyDBMode{
+				logger: logr.Discard(),
+			}
+			err := s.refillPluginIDs(tc.currentState, tc.targetState)
+			require.NoError(t, err)
+			_, err = tc.targetState.Plugins.Get(tc.expectedPluginID)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func mustNewKongStateFromRawState(t *testing.T, rawState *deckutils.KongRawState) *state.KongState {
+	kongState, err := state.Get(rawState)
+	require.NoError(t, err, "failed to build Kong state from raw state")
+	return kongState
+}

--- a/internal/dataplane/sendconfig/dbmode_test.go
+++ b/internal/dataplane/sendconfig/dbmode_test.go
@@ -277,6 +277,8 @@ func TestRefillPluginIDs(t *testing.T) {
 }
 
 func mustNewKongStateFromRawState(t *testing.T, rawState *deckutils.KongRawState) *state.KongState {
+	t.Helper()
+
 	kongState, err := state.Get(rawState)
 	require.NoError(t, err, "failed to build Kong state from raw state")
 	return kongState


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Keep the plugin ID (identified by plugin name and attached service, route, consumer, consumer group) to prevent conflicts of two identical plugins (identified by the fields above) having the different ID

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7440
**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
We also needs to add integration tests/e2e tests for upgrading in DB mode: https://github.com/Kong/kubernetes-ingress-controller/issues/7448. Should we finish it also in this PR?
**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
