### PR TITLE
feat(konnect): Store of konnect licenses to secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,9 @@ Adding a new version? You'll need three changes:
    [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
  - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
    in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
-   control plane. This requires the `Secret` to be created before KIC runs.
+   control plane. This requires the user to create the `Secret` with the given
+   name in the namespace before KIC runs and KIC will update and read the
+   existing `Secret`.
    It is enabled by default when `--konnect-licensing-enabled` is `true`. You
    can set `--konnect-license-storage-enabled` to `false` to disable it.
    [#7488](https://github.com/Kong/kubernetes-ingress-controller/pull/7488)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,9 @@ Adding a new version? You'll need three changes:
    [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
  - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
    in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
-   control plane. If the `Secret` does not exist, KIC will create it.
+   control plane. If the `Secret` does not exist, KIC will create it. However,
+   the `Secret` is not automatically cleaned up so you need to delete it manually
+   when you uninstall KIC.
    It is enabled by default when `--konnect-licensing-enabled` is `true`. You
    can set `--konnect-license-storage-enabled` to `false` to disable it.
    [#7488](https://github.com/Kong/kubernetes-ingress-controller/pull/7488)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ Adding a new version? You'll need three changes:
  - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
    in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
    control plane. This requires the `Secret` to be created before KIC runs.
+   It is enabled by default when `--konnect-licensing-enabled` is `true`. You
+   can set `--konnect-license-storage-enabled` to `false` to disable it.
+   [#7488](https://github.com/Kong/kubernetes-ingress-controller/pull/7488)
 
  ## [3.4.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,7 @@ Adding a new version? You'll need three changes:
    [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
  - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
    in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
-   control plane. This requires the user to create the `Secret` with the given
-   name in the namespace before KIC runs and KIC will update and read the
-   existing `Secret`.
+   control plane. If the `Secret` does not exist, KIC will create it.
    It is enabled by default when `--konnect-licensing-enabled` is `true`. You
    can set `--konnect-license-storage-enabled` to `false` to disable it.
    [#7488](https://github.com/Kong/kubernetes-ingress-controller/pull/7488)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ Adding a new version? You'll need three changes:
  - Added support for drain support functionality.
    It can be enabled by setting the flag `--enable-drain-support` to `true`.
    [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
+ - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
+   in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
+   control plane. This requires the `Secret` to be created before KIC runs.
 
  ## [3.4.6]
 

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ manifests: manifests.rbac manifests.webhook manifests.single
 
 .PHONY: manifests.rbac ## Generate ClusterRole objects.
 manifests.rbac: controller-gen
-	$(CONTROLLER_GEN) rbac:roleName=kong-ingress paths="./internal/controllers/configuration/" paths="./controllers/license/"
+	$(CONTROLLER_GEN) rbac:roleName=kong-ingress paths="./internal/controllers/configuration/" paths="./controllers/license/" paths="./internal/konnect/license/"
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-gateway paths="./internal/controllers/gateway/" output:rbac:artifacts:config=config/rbac/gateway
 	$(CONTROLLER_GEN) rbac:roleName=kong-ingress-crds paths="./internal/controllers/crds/" output:rbac:artifacts:config=config/rbac/crds
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,6 +33,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -28,6 +27,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -74,7 +74,7 @@
 | `--konnect-disable-consumers-sync` | `bool` | Disable synchronization of consumers with Konnect. | `false` |
 | `--konnect-initial-license-polling-period` | `duration` | Polling period to be used before the first license is retrieved. | `1m0s` |
 | `--konnect-license-polling-period` | `duration` | Polling period to be used after the first license is retrieved. | `12h0m0s` |
-| `--konnect-license-storage-enabled` | `bool` | Store licenses fetched from Konnect to Secrets locally in case failed to fetch from Konnect. Only effective when --konnect-licensing-enabled is true. | `true` |
+| `--konnect-license-storage-enabled` | `bool` | Store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when --konnect-licensing-enabled is true. | `true` |
 | `--konnect-licensing-enabled` | `bool` | Retrieve licenses from Konnect if available. Overrides licenses provided via the environment. | `false` |
 | `--konnect-refresh-node-period` | `duration` | Period of uploading status of KIC and controlled Kong instances. | `1m0s` |
 | `--konnect-sync-enabled` | `bool` | Enable synchronization of data plane configuration with a Konnect control plane. | `false` |

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -74,6 +74,7 @@
 | `--konnect-disable-consumers-sync` | `bool` | Disable synchronization of consumers with Konnect. | `false` |
 | `--konnect-initial-license-polling-period` | `duration` | Polling period to be used before the first license is retrieved. | `1m0s` |
 | `--konnect-license-polling-period` | `duration` | Polling period to be used after the first license is retrieved. | `12h0m0s` |
+| `--konnect-license-storage-enabled` | `bool` | Store licenses fetched from Konnect to Secrets locally in case failed to fetch from Konnect. Only effective when --konnect-licensing-enabled is true. | `true` |
 | `--konnect-licensing-enabled` | `bool` | Retrieve licenses from Konnect if available. Overrides licenses provided via the environment. | `false` |
 | `--konnect-refresh-node-period` | `duration` | Period of uploading status of KIC and controlled Kong instances. | `1m0s` |
 | `--konnect-sync-enabled` | `bool` | Enable synchronization of data plane configuration with a Konnect control plane. | `false` |

--- a/internal/cmd/rootcmd/config/cli.go
+++ b/internal/cmd/rootcmd/config/cli.go
@@ -202,6 +202,7 @@ func (c *CLIConfig) bindFlagSet() {
 	// Konnect
 	flagSet.BoolVar(&c.Konnect.ConfigSynchronizationEnabled, "konnect-sync-enabled", false, "Enable synchronization of data plane configuration with a Konnect control plane.")
 	flagSet.BoolVar(&c.Konnect.LicenseSynchronizationEnabled, "konnect-licensing-enabled", false, "Retrieve licenses from Konnect if available. Overrides licenses provided via the environment.")
+	flagSet.BoolVar(&c.Konnect.LicenseStorageEnabled, "konnect-license-storage-enabled", true, "Store licenses fetched from Konnect to Secrets locally in case failed to fetch from Konnect. Only effective when --konnect-licensing-enabled is true.")
 	flagSet.DurationVar(&c.Konnect.InitialLicensePollingPeriod, "konnect-initial-license-polling-period", license.DefaultInitialPollingPeriod, "Polling period to be used before the first license is retrieved.")
 	flagSet.DurationVar(&c.Konnect.LicensePollingPeriod, "konnect-license-polling-period", license.DefaultPollingPeriod, "Polling period to be used after the first license is retrieved.")
 	flagSet.StringVar(&c.Konnect.ControlPlaneID, "konnect-control-plane-id", "", "An ID of a control plane that is to be synchronized with data plane configuration.")

--- a/internal/cmd/rootcmd/config/cli.go
+++ b/internal/cmd/rootcmd/config/cli.go
@@ -202,7 +202,7 @@ func (c *CLIConfig) bindFlagSet() {
 	// Konnect
 	flagSet.BoolVar(&c.Konnect.ConfigSynchronizationEnabled, "konnect-sync-enabled", false, "Enable synchronization of data plane configuration with a Konnect control plane.")
 	flagSet.BoolVar(&c.Konnect.LicenseSynchronizationEnabled, "konnect-licensing-enabled", false, "Retrieve licenses from Konnect if available. Overrides licenses provided via the environment.")
-	flagSet.BoolVar(&c.Konnect.LicenseStorageEnabled, "konnect-license-storage-enabled", true, "Store licenses fetched from Konnect to Secrets locally in case failed to fetch from Konnect. Only effective when --konnect-licensing-enabled is true.")
+	flagSet.BoolVar(&c.Konnect.LicenseStorageEnabled, "konnect-license-storage-enabled", true, "Store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when --konnect-licensing-enabled is true.")
 	flagSet.DurationVar(&c.Konnect.InitialLicensePollingPeriod, "konnect-initial-license-polling-period", license.DefaultInitialPollingPeriod, "Polling period to be used before the first license is retrieved.")
 	flagSet.DurationVar(&c.Konnect.LicensePollingPeriod, "konnect-license-polling-period", license.DefaultPollingPeriod, "Polling period to be used after the first license is retrieved.")
 	flagSet.StringVar(&c.Konnect.ControlPlaneID, "konnect-control-plane-id", "", "An ID of a control plane that is to be synchronized with data plane configuration.")

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -34,7 +34,7 @@ type Client struct {
 var KICLicenseAPIPathPattern = "%s/kic/api/control-planes/%s/v1/licenses"
 
 // NewClient creates a License API Konnect client.
-func NewClient(cfg managercfg.KonnectConfig, licenseStore Storer) (*Client, error) {
+func NewClient(cfg managercfg.KonnectConfig, logger logr.Logger, licenseStore Storer) (*Client, error) {
 	tlsConfig := tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
@@ -52,6 +52,7 @@ func NewClient(cfg managercfg.KonnectConfig, licenseStore Storer) (*Client, erro
 	c.Transport = useragent.NewTransport(transport)
 
 	return &Client{
+		logger:         logger,
 		address:        cfg.Address,
 		controlPlaneID: cfg.ControlPlaneID,
 		httpClient:     c,

--- a/internal/konnect/license/client_test.go
+++ b/internal/konnect/license/client_test.go
@@ -1,13 +1,17 @@
 package license_test
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
+	konnectlicense "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/pkg/metadata"
 )
@@ -32,12 +36,31 @@ func (m *mockKonnectLicenseServer) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	_, _ = w.Write(m.response)
 }
 
+type mockLicenseStorer struct {
+	l license.KonnectLicense
+}
+
+var _ konnectlicense.Storer = &mockLicenseStorer{}
+
+func (m *mockLicenseStorer) Store(_ context.Context, l license.KonnectLicense) error {
+	m.l = l
+	return nil
+}
+
+func (m *mockLicenseStorer) Load(_ context.Context) (license.KonnectLicense, error) {
+	if m.l.Payload == "" {
+		return license.KonnectLicense{}, fmt.Errorf("no available license stored")
+	}
+	return m.l, nil
+}
+
 func TestLicenseClient(t *testing.T) {
 	testCases := []struct {
-		name       string
-		response   []byte
-		status     int
-		assertions func(t *testing.T, c *license.Client)
+		name          string
+		response      []byte
+		status        int
+		storedLicense license.KonnectLicense
+		assertions    func(t *testing.T, c *konnectlicense.Client)
 	}{
 		{
 			name: "200 valid response",
@@ -51,7 +74,7 @@ func TestLicenseClient(t *testing.T) {
 				]
 			}`),
 			status: http.StatusOK,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				licenseOpt, err := c.Get(t.Context())
 				require.NoError(t, err)
 
@@ -65,7 +88,7 @@ func TestLicenseClient(t *testing.T) {
 			name:     "200 but empty response",
 			response: []byte(`{}`),
 			status:   http.StatusOK,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "no license item found in response")
 			},
@@ -74,7 +97,7 @@ func TestLicenseClient(t *testing.T) {
 			name:     "200 but invalid response",
 			response: []byte(`{invalid-json`),
 			status:   http.StatusOK,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "failed to parse response body")
 			},
@@ -91,7 +114,7 @@ func TestLicenseClient(t *testing.T) {
 				]
 			}`),
 			status: http.StatusOK,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "empty id")
 			},
@@ -108,7 +131,7 @@ func TestLicenseClient(t *testing.T) {
 				]
 			}`),
 			status: http.StatusOK,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "empty updated_at")
 			},
@@ -125,7 +148,7 @@ func TestLicenseClient(t *testing.T) {
 				]
 			}`),
 			status: http.StatusOK,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				_, err := c.Get(t.Context())
 				require.ErrorContains(t, err, "empty license")
 			},
@@ -134,7 +157,7 @@ func TestLicenseClient(t *testing.T) {
 			name:     "404 returns empty license with no error",
 			response: nil,
 			status:   http.StatusNotFound,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				l, err := c.Get(t.Context())
 				require.NoError(t, err)
 				require.False(t, l.IsPresent())
@@ -144,9 +167,24 @@ func TestLicenseClient(t *testing.T) {
 			name:     "400 returns error",
 			response: nil,
 			status:   http.StatusBadRequest,
-			assertions: func(t *testing.T, c *license.Client) {
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
 				_, err := c.Get(t.Context())
 				require.Error(t, err)
+			},
+		},
+		{
+			name:     "400 but loaded license from storage",
+			response: nil,
+			status:   http.StatusBadRequest,
+			storedLicense: license.KonnectLicense{
+				ID:        "some-license-id",
+				UpdatedAt: time.Now(),
+				Payload:   "some-license-payload",
+			},
+			assertions: func(t *testing.T, c *konnectlicense.Client) {
+				l, err := c.Get(t.Context())
+				require.NoError(t, err)
+				require.True(t, l.IsPresent())
 			},
 		},
 	}
@@ -157,7 +195,7 @@ func TestLicenseClient(t *testing.T) {
 			ts := httptest.NewServer(server)
 			defer ts.Close()
 
-			c, err := license.NewClient(managercfg.KonnectConfig{Address: ts.URL})
+			c, err := konnectlicense.NewClient(managercfg.KonnectConfig{Address: ts.URL}, &mockLicenseStorer{l: tc.storedLicense})
 			require.NoError(t, err)
 			tc.assertions(t, c)
 		})

--- a/internal/konnect/license/client_test.go
+++ b/internal/konnect/license/client_test.go
@@ -196,7 +196,8 @@ func TestLicenseClient(t *testing.T) {
 			ts := httptest.NewServer(server)
 			defer ts.Close()
 
-			c, err := konnectlicense.NewClient(managercfg.KonnectConfig{Address: ts.URL}, logr.Discard(), &mockLicenseStorer{l: tc.storedLicense})
+			c, err := konnectlicense.NewClient(managercfg.KonnectConfig{Address: ts.URL, LicenseStorageEnabled: true}, logr.Discard())
+			c = c.WithLicenseStore(&mockLicenseStorer{l: tc.storedLicense})
 			require.NoError(t, err)
 			tc.assertions(t, c)
 		})

--- a/internal/konnect/license/client_test.go
+++ b/internal/konnect/license/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
 	konnectlicense "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
@@ -195,7 +196,7 @@ func TestLicenseClient(t *testing.T) {
 			ts := httptest.NewServer(server)
 			defer ts.Close()
 
-			c, err := konnectlicense.NewClient(managercfg.KonnectConfig{Address: ts.URL}, &mockLicenseStorer{l: tc.storedLicense})
+			c, err := konnectlicense.NewClient(managercfg.KonnectConfig{Address: ts.URL}, logr.Discard(), &mockLicenseStorer{l: tc.storedLicense})
 			require.NoError(t, err)
 			tc.assertions(t, c)
 		})

--- a/internal/konnect/license/storage.go
+++ b/internal/konnect/license/storage.go
@@ -18,6 +18,8 @@ import (
 const (
 	// licenseResourceNamePrefix is the prefix of the secret name storing the konnect license.
 	licenseResourceNamePrefix = "konnect-license-"
+	// LabelKeyManagedBy is the label key to mark that the secret is managed by KIC.
+	LabelKeyManagedBy = "managed-by"
 )
 
 // Storer is the interface to store license fetched from Konnect and load license from storage if failed to fetch.
@@ -55,7 +57,13 @@ func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense
 	if err != nil {
 		return err
 	}
-	// TODO: set labels/annotations of the secret?
+
+	// Add label to mark that the secret is managed by KIC.
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[LabelKeyManagedBy] = "konghq.com/ingress-controller"
+
 	secret.StringData = map[string]string{
 		"payload":    l.Payload,
 		"updated_at": strconv.FormatInt(l.UpdatedAt.Unix(), 10),

--- a/internal/konnect/license/storage.go
+++ b/internal/konnect/license/storage.go
@@ -28,13 +28,15 @@ const (
 	secretKeyUpdatedAt = "updated_at"
 )
 
-// Storer is the interface to store license fetched from Konnect and load license from storage if failed to fetch.
+// Storer is used to store license fetched from Konnect or to load it from said storage.
 type Storer interface {
 	Store(context.Context, license.KonnectLicense) error
 	Load(context.Context) (license.KonnectLicense, error)
 }
 
-// SecretLicenseStore is the storage to store the license in a certain secret in the given namespace.
+// SecretLicenseStore is the storage used to store the Konnect license. This store uses
+// the CP ID, a predefined prefix and the provided namespace to designate the target Secret
+// which will be used for storage.
 type SecretLicenseStore struct {
 	cl             client.Client
 	namespace      string
@@ -45,7 +47,7 @@ var _ Storer = &SecretLicenseStore{}
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;update
 
-// NewSecretLicenseStore creates a storage to store the fetched license to a secret.
+// NewSecretLicenseStore creates a storage to store Konnect license to a secret.
 func NewSecretLicenseStore(cl client.Client, namespace, controlPlaneID string) *SecretLicenseStore {
 	return &SecretLicenseStore{
 		cl:             cl,

--- a/internal/konnect/license/storage.go
+++ b/internal/konnect/license/storage.go
@@ -1,0 +1,99 @@
+package license
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
+)
+
+const (
+	// licenseResourceNamePrefix is the prefix of the secret name storing the konnect license.
+	licenseResourceNamePrefix = "konnect-license-"
+)
+
+type Storer interface {
+	Store(context.Context, license.KonnectLicense) error
+	Load(context.Context) (license.KonnectLicense, error)
+}
+
+type SecretLicenseStore struct {
+	cl             client.Client
+	namespace      string
+	controlPlaneID string
+}
+
+var _ Storer = &SecretLicenseStore{}
+
+func NewSecretLicenseStore(cl client.Client, namespace, controlPlaneID string) *SecretLicenseStore {
+	return &SecretLicenseStore{
+		cl:             cl,
+		namespace:      namespace,
+		controlPlaneID: controlPlaneID,
+	}
+}
+
+func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense) error {
+	secret := &corev1.Secret{}
+	err := s.cl.Get(ctx, k8stypes.NamespacedName{
+		Namespace: s.namespace,
+		Name:      licenseResourceNamePrefix + s.controlPlaneID,
+	}, secret)
+	if err != nil {
+		return err
+	}
+	// TODO: set labels/annotations of the secret?
+	secret.StringData = map[string]string{
+		"payload":    l.Payload,
+		"updated_at": strconv.FormatInt(l.UpdatedAt.Unix(), 10),
+		"id":         l.ID,
+	}
+	return s.cl.Update(ctx, secret)
+}
+
+func (s *SecretLicenseStore) Load(
+	ctx context.Context,
+) (license.KonnectLicense, error) {
+	secret := &corev1.Secret{}
+	err := s.cl.Get(ctx, k8stypes.NamespacedName{
+		Namespace: s.namespace,
+		Name:      licenseResourceNamePrefix + s.controlPlaneID,
+	}, secret)
+	if err != nil {
+		return license.KonnectLicense{}, err
+	}
+
+	if (!lo.HasKey(secret.Data, "payload")) || (!lo.HasKey(secret.Data, "updated_at")) || (!lo.HasKey(secret.Data, "id")) {
+		return license.KonnectLicense{}, fmt.Errorf("missing required key in secret %s", secret.Name)
+	}
+
+	decodedPayload, err := base64.StdEncoding.DecodeString(string(secret.Data["payload"]))
+	if err != nil {
+		return license.KonnectLicense{}, fmt.Errorf("failed to decode payload of license stored in secret %s: %w", secret.Name, err)
+	}
+	decodedID, err := base64.StdEncoding.DecodeString(string(secret.Data["id"]))
+	if err != nil {
+		return license.KonnectLicense{}, fmt.Errorf("failed to decode id of license stored in secret %s: %w", secret.Name, err)
+	}
+	decodedUpdateAt, err := base64.StdEncoding.DecodeString(string(secret.Data["updated_at"]))
+	if err != nil {
+		return license.KonnectLicense{}, fmt.Errorf("failed to decode updated_at of license stored in secret %s: %w", secret.Name, err)
+	}
+	updateAt, err := strconv.ParseInt(string(decodedUpdateAt), 10, 64)
+	if err != nil {
+		return license.KonnectLicense{}, fmt.Errorf("failed to parse updated_at of license stored in secret %s: %w", secret.Name, err)
+	}
+	return license.KonnectLicense{
+		Payload:   string(decodedPayload),
+		UpdatedAt: time.Unix(updateAt, 0),
+		ID:        string(decodedID),
+	}, nil
+}

--- a/internal/konnect/license/storage.go
+++ b/internal/konnect/license/storage.go
@@ -89,7 +89,7 @@ func (s *SecretLicenseStore) Load(
 	}
 	updateAt, err := strconv.ParseInt(string(decodedUpdateAt), 10, 64)
 	if err != nil {
-		return license.KonnectLicense{}, fmt.Errorf("failed to parse updated_at of license stored in secret %s: %w", secret.Name, err)
+		return license.KonnectLicense{}, fmt.Errorf("failed to parse updated_at as timestamp of license stored in secret %s: %w", secret.Name, err)
 	}
 	return license.KonnectLicense{
 		Payload:   string(decodedPayload),

--- a/internal/konnect/license/storage.go
+++ b/internal/konnect/license/storage.go
@@ -20,6 +20,7 @@ const (
 	licenseResourceNamePrefix = "konnect-license-"
 )
 
+// Storer is the interface to store license fetched from Konnect and load license from storage if failed to fetch.
 type Storer interface {
 	Store(context.Context, license.KonnectLicense) error
 	Load(context.Context) (license.KonnectLicense, error)
@@ -33,6 +34,9 @@ type SecretLicenseStore struct {
 
 var _ Storer = &SecretLicenseStore{}
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;update
+
+// NewSecretLicenseStore creates a storage to store the fetched license to a secret.
 func NewSecretLicenseStore(cl client.Client, namespace, controlPlaneID string) *SecretLicenseStore {
 	return &SecretLicenseStore{
 		cl:             cl,
@@ -41,6 +45,7 @@ func NewSecretLicenseStore(cl client.Client, namespace, controlPlaneID string) *
 	}
 }
 
+// Store stores license to the secret `konnect-license-<cpid>`.
 func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense) error {
 	secret := &corev1.Secret{}
 	err := s.cl.Get(ctx, k8stypes.NamespacedName{
@@ -59,6 +64,7 @@ func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense
 	return s.cl.Update(ctx, secret)
 }
 
+// Load loads the license from the secret from secret `konnect-license-<cpid>`.
 func (s *SecretLicenseStore) Load(
 	ctx context.Context,
 ) (license.KonnectLicense, error) {

--- a/internal/konnect/license/storage.go
+++ b/internal/konnect/license/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -12,14 +13,19 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/labels"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
 )
 
 const (
 	// licenseResourceNamePrefix is the prefix of the secret name storing the konnect license.
 	licenseResourceNamePrefix = "konnect-license-"
-	// LabelKeyManagedBy is the label key to mark that the secret is managed by KIC.
-	LabelKeyManagedBy = "managed-by"
+	// secretKeyPayload is the key to store the payload of the license in the secret.
+	secretKeyPayload = "payload"
+	// secretKeyID is the key to store the ID of the license.
+	secretKeyID = "id"
+	// secretKeyUpdatedAt is the key to store updated time of the license.
+	secretKeyUpdatedAt = "updated_at"
 )
 
 // Storer is the interface to store license fetched from Konnect and load license from storage if failed to fetch.
@@ -28,6 +34,7 @@ type Storer interface {
 	Load(context.Context) (license.KonnectLicense, error)
 }
 
+// SecretLicenseStore is the storage to store the license in a certain secret in the given namespace.
 type SecretLicenseStore struct {
 	cl             client.Client
 	namespace      string
@@ -62,12 +69,12 @@ func (s *SecretLicenseStore) Store(ctx context.Context, l license.KonnectLicense
 	if secret.Labels == nil {
 		secret.Labels = map[string]string{}
 	}
-	secret.Labels[LabelKeyManagedBy] = "konghq.com/ingress-controller"
+	secret.Labels[labels.ManagedByLabel] = labels.ManagedByLabelValueIngressController
 
 	secret.StringData = map[string]string{
-		"payload":    l.Payload,
-		"updated_at": strconv.FormatInt(l.UpdatedAt.Unix(), 10),
-		"id":         l.ID,
+		secretKeyPayload:   l.Payload,
+		secretKeyUpdatedAt: strconv.FormatInt(l.UpdatedAt.Unix(), 10),
+		secretKeyID:        l.ID,
 	}
 	return s.cl.Update(ctx, secret)
 }
@@ -85,19 +92,26 @@ func (s *SecretLicenseStore) Load(
 		return license.KonnectLicense{}, err
 	}
 
-	if (!lo.HasKey(secret.Data, "payload")) || (!lo.HasKey(secret.Data, "updated_at")) || (!lo.HasKey(secret.Data, "id")) {
-		return license.KonnectLicense{}, fmt.Errorf("missing required key in secret %s", secret.Name)
+	requiredKeys := []string{secretKeyPayload, secretKeyID, secretKeyUpdatedAt}
+	missingKeys := []string{}
+	for _, key := range requiredKeys {
+		if !lo.HasKey(secret.Data, key) {
+			missingKeys = append(missingKeys, key)
+		}
+	}
+	if len(missingKeys) > 0 {
+		return license.KonnectLicense{}, fmt.Errorf("missing required key(s): %s in secret %s", strings.Join(missingKeys, ","), secret.Name)
 	}
 
-	decodedPayload, err := base64.StdEncoding.DecodeString(string(secret.Data["payload"]))
+	decodedPayload, err := base64.StdEncoding.DecodeString(string(secret.Data[secretKeyPayload]))
 	if err != nil {
 		return license.KonnectLicense{}, fmt.Errorf("failed to decode payload of license stored in secret %s: %w", secret.Name, err)
 	}
-	decodedID, err := base64.StdEncoding.DecodeString(string(secret.Data["id"]))
+	decodedID, err := base64.StdEncoding.DecodeString(string(secret.Data[secretKeyID]))
 	if err != nil {
 		return license.KonnectLicense{}, fmt.Errorf("failed to decode id of license stored in secret %s: %w", secret.Name, err)
 	}
-	decodedUpdateAt, err := base64.StdEncoding.DecodeString(string(secret.Data["updated_at"]))
+	decodedUpdateAt, err := base64.StdEncoding.DecodeString(string(secret.Data[secretKeyUpdatedAt]))
 	if err != nil {
 		return license.KonnectLicense{}, fmt.Errorf("failed to decode updated_at of license stored in secret %s: %w", secret.Name, err)
 	}

--- a/internal/konnect/license/storage_test.go
+++ b/internal/konnect/license/storage_test.go
@@ -1,0 +1,71 @@
+package license_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	konnectlicense "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretLicenseStore_Store(t *testing.T) {
+	testCases := []struct {
+		name        string
+		secret      *corev1.Secret
+		license     license.KonnectLicense
+		expectError bool
+	}{
+		{
+			name: "stored secrets",
+			secret: &corev1.Secret{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "konnect-license-test-cp",
+					Namespace: "default",
+				},
+			},
+			license: license.KonnectLicense{
+				Payload:   "some-license-payload",
+				UpdatedAt: time.Now(),
+				ID:        "some-license-id",
+			},
+			expectError: false,
+		},
+		{
+			name: "secret not found",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "another-secret",
+					Namespace: "default",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithObjects(tc.secret).Build()
+			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp")
+			err := s.Store(context.Background(), tc.license)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			secret := &corev1.Secret{}
+			err = cl.Get(context.Background(), client.ObjectKeyFromObject(tc.secret), secret)
+			require.NoError(t, err)
+			// fake client stores stringData of secret as-is.
+			require.Equal(t, tc.license.Payload, secret.StringData["payload"])
+		})
+	}
+}

--- a/internal/konnect/license/storage_test.go
+++ b/internal/konnect/license/storage_test.go
@@ -1,12 +1,12 @@
 package license_test
 
 import (
-	"context"
 	"encoding/base64"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,7 +14,6 @@ import (
 
 	konnectlicense "github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/license"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/license"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSecretLicenseStore_Store(t *testing.T) {
@@ -55,7 +54,7 @@ func TestSecretLicenseStore_Store(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := fake.NewClientBuilder().WithObjects(tc.secret).Build()
 			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp")
-			err := s.Store(context.Background(), tc.license)
+			err := s.Store(t.Context(), tc.license)
 			if tc.expectError {
 				require.Error(t, err)
 				return
@@ -63,7 +62,7 @@ func TestSecretLicenseStore_Store(t *testing.T) {
 
 			require.NoError(t, err)
 			secret := &corev1.Secret{}
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(tc.secret), secret)
+			err = cl.Get(t.Context(), client.ObjectKeyFromObject(tc.secret), secret)
 			require.NoError(t, err)
 			// fake client stores stringData of secret as-is.
 			require.Equal(t, tc.license.Payload, secret.StringData["payload"])
@@ -144,7 +143,7 @@ func TestSecretLicenseStore_Load(t *testing.T) {
 			cl := fake.NewClientBuilder().WithObjects(tc.secret).Build()
 			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp")
 
-			l, err := s.Load(context.Background())
+			l, err := s.Load(t.Context())
 			if tc.expectError {
 				require.Error(t, err)
 				return
@@ -153,6 +152,5 @@ func TestSecretLicenseStore_Load(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.license, l)
 		})
-
 	}
 }

--- a/internal/konnect/license/storage_test.go
+++ b/internal/konnect/license/storage_test.go
@@ -2,6 +2,8 @@ package license_test
 
 import (
 	"context"
+	"encoding/base64"
+	"strconv"
 	"testing"
 	"time"
 
@@ -25,7 +27,6 @@ func TestSecretLicenseStore_Store(t *testing.T) {
 		{
 			name: "stored secrets",
 			secret: &corev1.Secret{
-
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "konnect-license-test-cp",
 					Namespace: "default",
@@ -67,5 +68,91 @@ func TestSecretLicenseStore_Store(t *testing.T) {
 			// fake client stores stringData of secret as-is.
 			require.Equal(t, tc.license.Payload, secret.StringData["payload"])
 		})
+	}
+}
+
+func TestSecretLicenseStore_Load(t *testing.T) {
+	timeNowUnix := time.Now().Unix()
+	testCases := []struct {
+		name        string
+		secret      *corev1.Secret
+		license     license.KonnectLicense
+		expectError bool
+	}{
+		{
+			name: "load license successfully",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "konnect-license-test-cp",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"payload":    []byte(base64.StdEncoding.EncodeToString([]byte("some-license-payload"))),
+					"id":         []byte(base64.StdEncoding.EncodeToString([]byte("some-license-id"))),
+					"updated_at": []byte(base64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(timeNowUnix, 10)))),
+				},
+			},
+			license: license.KonnectLicense{
+				Payload:   "some-license-payload",
+				ID:        "some-license-id",
+				UpdatedAt: time.Unix(timeNowUnix, 0),
+			},
+		},
+		{
+			name: "secret not found",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-other-secret",
+					Namespace: "default",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing payload",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "konnect-license-test-cp",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"id":         []byte(base64.StdEncoding.EncodeToString([]byte("some-license-id"))),
+					"updated_at": []byte(base64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(timeNowUnix, 10)))),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "cannot parse update_at",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "konnect-license-test-cp",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"payload":    []byte(base64.StdEncoding.EncodeToString([]byte("some-license-payload"))),
+					"id":         []byte(base64.StdEncoding.EncodeToString([]byte("some-license-id"))),
+					"updated_at": []byte(base64.StdEncoding.EncodeToString([]byte("not-a-timestamp"))),
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithObjects(tc.secret).Build()
+			s := konnectlicense.NewSecretLicenseStore(cl, "default", "test-cp")
+
+			l, err := s.Load(context.Background())
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.license, l)
+		})
+
 	}
 }

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -12,12 +12,20 @@ const (
 	// ValidateKey is the key used to indicate a Secret contains plugin configuration.
 	ValidateKey = "/validate"
 
+	// ManagedByKey is the key to indicate the contoller that manages the object.
+	ManagedByKey = "/managed-by"
+
 	// CredentialTypeLabel is the label used to indicate a Secret's credential type.
 	CredentialTypeLabel = LabelPrefix + CredentialKey
 
 	// ValidateLabel is applied to plugins used for plugin configuration to allow the admission webhook to check
 	// updates to them.
 	ValidateLabel = LabelPrefix + ValidateKey
+
+	// ManagedByLabel is the label key to mark that the object is managed by a specific controller.
+	ManagedByLabel = LabelPrefix + ManagedByKey
+	// ManagedByLabelValueIngressController is the label value that marks the object is managed byu KIC.
+	ManagedByLabelValueIngressController = LabelPrefix + "/ingress-controller"
 )
 
 // ValidateType indicates the type of validation applied to a Secret.

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -447,20 +447,27 @@ func setupLicenseGetter(
 	// the client and makes it available to all Konnect-related subsystems.
 	if c.Konnect.LicenseSynchronizationEnabled {
 		setupLog.Info("Creating konnect license client")
-		nn, err := util.GetPodNN()
-		if err != nil {
-			return nil, err
-		}
 		konnectLicenseAPIClient, err := konnectLicense.NewClient(
 			c.Konnect,
 			ctrl.LoggerFrom(ctx).WithName("konnect-license-client"),
-			konnectLicense.NewSecretLicenseStore(
-				mgr.GetClient(), nn.Namespace, c.Konnect.ControlPlaneID,
-			),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed creating konnect client: %w", err)
 		}
+
+		if c.Konnect.LicenseStorageEnabled {
+			setupLog.Info("Creating a storage to store fetched Konnect license")
+			nn, err := util.GetPodNN()
+			if err != nil {
+				return nil, err
+			}
+			licenseStore := konnectLicense.NewSecretLicenseStore(
+				mgr.GetClient(), nn.Namespace, c.Konnect.ControlPlaneID,
+			)
+			konnectLicenseAPIClient.WithLicenseStore(licenseStore)
+			konnectLicenseAPIClient = konnectLicenseAPIClient.WithLicenseStore(licenseStore)
+		}
+
 		setupLog.Info("Starting license agent")
 		agent := license.NewAgent(
 			konnectLicenseAPIClient,

--- a/internal/manager/setup.go
+++ b/internal/manager/setup.go
@@ -446,11 +446,14 @@ func setupLicenseGetter(
 	// we probably want to avoid that long term. If we do have separate toggles, we need an AND condition that sets up
 	// the client and makes it available to all Konnect-related subsystems.
 	if c.Konnect.LicenseSynchronizationEnabled {
+		setupLog.Info("Creating konnect license client")
 		nn, err := util.GetPodNN()
 		if err != nil {
 			return nil, err
 		}
-		konnectLicenseAPIClient, err := konnectLicense.NewClient(c.Konnect,
+		konnectLicenseAPIClient, err := konnectLicense.NewClient(
+			c.Konnect,
+			ctrl.LoggerFrom(ctx).WithName("konnect-license-client"),
 			konnectLicense.NewSecretLicenseStore(
 				mgr.GetClient(), nn.Namespace, c.Konnect.ControlPlaneID,
 			),

--- a/pkg/manager/config/konnect.go
+++ b/pkg/manager/config/konnect.go
@@ -18,5 +18,6 @@ type KonnectConfig struct {
 	LicenseSynchronizationEnabled bool
 	InitialLicensePollingPeriod   time.Duration
 	LicensePollingPeriod          time.Duration
+	LicenseStorageEnabled         bool
 	ConsumersSyncDisabled         bool
 }

--- a/pkg/manager/config_test.go
+++ b/pkg/manager/config_test.go
@@ -108,6 +108,7 @@ func TestNewConfig(t *testing.T) {
 				Address:                     "https://us.kic.api.konghq.com",
 				InitialLicensePollingPeriod: license.DefaultInitialPollingPeriod,
 				LicensePollingPeriod:        license.DefaultPollingPeriod,
+				LicenseStorageEnabled:       true,
 				UploadConfigPeriod:          managercfg.DefaultKonnectConfigUploadPeriod,
 				RefreshNodePeriod:           konnect.DefaultRefreshNodePeriod,
 			},

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -3546,7 +3546,6 @@ rules:
   resources:
   - configmaps
   - nodes
-  - secrets
   verbs:
   - list
   - watch
@@ -3565,6 +3564,15 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -3570,6 +3570,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - update


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Store fetched Konnect license to `konnect-license-<cpid>`. When KIC failed to fetch the license from Konnect, it tries to load the stored license from the secret.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7421 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->
TODO:
~- Add cli arg here?~
   Added cli flag `--konnect-license-storage-enabled` and enable it by default.
- Should we put it in 3.4.x or 3.5.x? 

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
