### PR TITLE
chore: allow passing rest config via GetKubeconfig

### DIFF
--- a/internal/manager/utils/kubeconfig.go
+++ b/internal/manager/utils/kubeconfig.go
@@ -11,12 +11,10 @@ import (
 
 // GetKubeconfig returns a Kubernetes REST config object based on the configuration.
 func GetKubeconfig(c managercfg.Config) (*rest.Config, error) {
-	var (
-		config *rest.Config
-		err    error
-	)
+	var config *rest.Config
 	switch c.KubeRestConfig {
 	case nil:
+		var err error
 		// If no kubeconfig path or REST config is provided, use the in-cluster config.
 		config, err = clientcmd.BuildConfigFromFlags(c.APIServerHost, c.KubeconfigPath)
 		if err != nil {
@@ -47,7 +45,7 @@ func GetKubeconfig(c managercfg.Config) (*rest.Config, error) {
 		config.Impersonate.UserName = c.Impersonate
 	}
 
-	return config, err
+	return config, nil
 }
 
 // GetKubeClient returns a Kubernetes client based on the configuration.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR allows using the pre created rest config when using `GetKubeconfig`. This is used in KO and without this change we get an error from `manager.NewManager`:

```
{
	"level": "error",
	"ts": "2025-06-12T16:06:33.039+0200",
	"msg": "Reconciler error",
	"controller": "controlplane",
	"controllerGroup": "gateway-operator.konghq.com",
	"controllerKind": "ControlPlane",
	"ControlPlane": {
		"name": "controlplane-v2",
		"namespace": "default"
	},
	"namespace": "default",
	"name": "controlplane-v2",
	"reconcileID": "dc60bd72-97e9-4a65-9183-ec47f2271fe2",
	"error": "failed to create manager: failed to create manager: unable to build kong api client(s): failed to get kubernetes client: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable",
	"stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/USER/.gvm/pkgsets/go1.24.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:353\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/USER/.gvm/pkgsets/go1.24.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:300\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.1\n\t/Users/USER/.gvm/pkgsets/go1.24.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:202"
}
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
