### PR TITLE
test(e2e): Dump Kong config for e2e tests if failed

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -115,6 +115,7 @@ func TestWebhookUpdate(t *testing.T) {
 	logClusterInfo(t, cluster)
 
 	defer func() {
+		helpers.DumpDiagnosticsIfFailed(ctx, t, env.Cluster())
 		helpers.TeardownCluster(ctx, t, env.Cluster())
 	}()
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/annotations"
 	"github.com/kong/kubernetes-ingress-controller/v3/test"
@@ -110,6 +113,10 @@ func setupE2ETest(t *testing.T, addons ...clusters.Addon) (context.Context, envi
 	require.NoError(t, clusters.KustomizeDeployForCluster(ctx, env.Cluster(), conststest.IncubatorCRDKustomizeDir))
 
 	t.Cleanup(func() {
+		output := helpers.DumpDiagnosticsIfFailed(ctx, t, env.Cluster())
+		if t.Failed() {
+			dumpKongConfiguration(ctx, t, env.Cluster(), output)
+		}
 		helpers.TeardownCluster(ctx, t, env.Cluster())
 	})
 
@@ -880,6 +887,70 @@ func scaleDeployment(ctx context.Context, t *testing.T, env environments.Environ
 		}
 		return deployment.Status.ReadyReplicas == replicas
 	}, time.Minute*3, time.Second, "deployment %s did not scale to %d replicas", deployment.Name, replicas)
+}
+
+func createGatewayAdminExposeService(ctx context.Context, t *testing.T, cluster clusters.Cluster, namespace string) *corev1.Service {
+	t.Helper()
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "kong-admin-expose-",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{
+				"app": "proxy-kong",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "admin-tls",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8444,
+					TargetPort: intstr.FromInt(8444),
+				},
+			},
+		},
+	}
+
+	service, err := cluster.Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+	return service
+}
+
+func dumpKongConfiguration(ctx context.Context, t *testing.T, cluster clusters.Cluster, outputDir string) {
+	t.Helper()
+
+	t.Log("Creating a service to expose admin APIs to dump gateway configuration")
+	adminExposeService := createGatewayAdminExposeService(ctx, t, cluster, namespace)
+	adminExposeServiceIP := ""
+	require.Eventually(t, func() bool {
+		serviceClient := cluster.Client().CoreV1().Services(namespace)
+		svc, err := serviceClient.Get(ctx, adminExposeService.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		if len(svc.Status.LoadBalancer.Ingress) > 0 {
+			adminExposeServiceIP = svc.Status.LoadBalancer.Ingress[0].IP
+			return true
+		}
+		return false
+	}, ingressWait, 5*time.Second, "Cannot get loadbalancer IP for service to expose admin APIs")
+
+	t.Logf("Dumping Kong configuration from service %s/%s", namespace, adminExposeService.Name)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec
+			},
+		},
+	}
+	kongClient, err := kong.NewTestClient(lo.ToPtr("https://"+adminExposeServiceIP+":8444"), httpClient)
+	require.NoError(t, err, "failed to create Kong client")
+	time.Sleep(5 * time.Second)
+	cfg, err := kongClient.Config(ctx)
+	require.NoError(t, err, "failed to dump configuration from Kong")
+	filepath := path.Join(outputDir, "kong-config.yaml")
+	err = os.WriteFile(filepath, cfg, 0o644) //nolint:gosec
+	require.NoError(t, err, "failed to write Kong configuration to "+filepath)
 }
 
 func (d Deployments) Restart(ctx context.Context, t *testing.T, env environments.Environment) {

--- a/test/internal/helpers/teardown.go
+++ b/test/internal/helpers/teardown.go
@@ -17,7 +17,6 @@ import (
 func TeardownCluster(ctx context.Context, t *testing.T, cluster clusters.Cluster) {
 	t.Helper()
 
-	DumpDiagnosticsIfFailed(ctx, t, cluster)
 	const environmentCleanupTimeout = 10 * time.Minute
 	ctx, cancel := context.WithTimeout(ctx, environmentCleanupTimeout)
 	defer cancel()
@@ -35,13 +34,15 @@ func RemoveCluster(ctx context.Context, cluster clusters.Cluster) error {
 	return nil
 }
 
-// DumpDiagnosticsIfFailed dumps the diagnostics if the test failed.
-func DumpDiagnosticsIfFailed(ctx context.Context, t *testing.T, cluster clusters.Cluster) {
+// DumpDiagnosticsIfFailed dumps the diagnostics and returns the outpur directory if the test failed.
+func DumpDiagnosticsIfFailed(ctx context.Context, t *testing.T, cluster clusters.Cluster) string {
 	t.Helper()
 
 	if t.Failed() {
 		output, err := cluster.DumpDiagnostics(ctx, t.Name())
 		t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
 		assert.NoError(t, err)
+		return output
 	}
+	return ""
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
Dump Kong configuration to `/tmp/ktf-*/kong-config.yaml` when e2e test fails. This helps to locate the problems happening in e2e test cases in GKE.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
First step of #7242 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
