### PR TITLE
fix(konnect): Do not mark pod ready when no konnect licenses available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,20 +111,20 @@ Adding a new version? You'll need three changes:
 
  ### Added
 
- - Added support for drain support functionality.
-   It can be enabled by setting the flag `--enable-drain-support` to `true`.
-   [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
-   [#7512](https://github.com/Kong/kubernetes-ingress-controller/pull/7512)
-   [#7533](https://github.com/Kong/kubernetes-ingress-controller/pull/7533)
-   [#7538](https://github.com/Kong/kubernetes-ingress-controller/pull/7538)
- - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
-   in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
-   control plane. If the `Secret` does not exist, KIC will create it. However,
-   the `Secret` is not automatically cleaned up so you need to delete it manually
-   when you uninstall KIC.
-   It is enabled by default when `--konnect-licensing-enabled` is `true`. You
-   can set `--konnect-license-storage-enabled` to `false` to disable it.
-   [#7488](https://github.com/Kong/kubernetes-ingress-controller/pull/7488)
+- Added support for drain support functionality.
+  It can be enabled by setting the flag `--enable-drain-support` to `true`.
+  [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
+  [#7512](https://github.com/Kong/kubernetes-ingress-controller/pull/7512)
+  [#7533](https://github.com/Kong/kubernetes-ingress-controller/pull/7533)
+  [#7538](https://github.com/Kong/kubernetes-ingress-controller/pull/7538)
+- Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
+  in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
+  control plane. If the `Secret` does not exist, KIC will create it. However,
+  the `Secret` is not automatically cleaned up so you need to delete it manually
+  when you uninstall KIC.
+  It is enabled by default when `--konnect-licensing-enabled` is `true`. You
+  can set `--konnect-license-storage-enabled` to `false` to disable it.
+  [#7488](https://github.com/Kong/kubernetes-ingress-controller/pull/7488)
 
   ### Changed
 
@@ -135,11 +135,11 @@ Adding a new version? You'll need three changes:
    
 ### Fixed
 
-  - When synchronization of license with Konnect is enabled 
-    (`--konnect-licensing-enabled` is `true`), do not mark the pod as ready
-    until there is an available license fetched from Konnect or stored in the
-    `Secret`.
-    [#7520](https://github.com/Kong/kubernetes-ingress-controller/pull/7520)
+- When synchronization of license with Konnect is enabled 
+  (`--konnect-licensing-enabled` is `true`), do not mark the pod as ready
+  until there is an available license fetched from Konnect or stored in the
+  `Secret`.
+  [#7520](https://github.com/Kong/kubernetes-ingress-controller/pull/7520)
 
 
 ## [3.4.7]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,14 @@ Adding a new version? You'll need three changes:
    deprecated since version [3.4.0](#340). They are available in a dedicated [repository][kconf].
    If you depend on them, please update your dependencies to use the new repository.
    [#7540](https://github.com/Kong/kubernetes-ingress-controller/pull/7540)
+   
+### Fixed
+
+  - When synchronization of license with Konnect is enabled 
+    (`--konnect-licensing-enabled` is `true`), do not mark the pod as ready
+    until there is an available license fetched from Konnect or stored in the
+    `Secret`.
+    [#7520](https://github.com/Kong/kubernetes-ingress-controller/pull/7520)
 
 
 ## [3.4.7]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

When konnect license synchronization is enabled, mark KIC pod as ready until there is a license available (fetched from Konnect or stored in secret).

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
fixes #7422

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
