### PR TITLE
backport(#7517): fixed count in case of HTTPRoute with multiple parentRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,14 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+ ## Unreleased
+
+### Fixed
+
+- Count the `attachedRoutes` of a `Gateway` in the correct way in case of `HTTPRoute`s
+  with multiple parent references.
+  [#7517](https://github.com/Kong/kubernetes-ingress-controller/pull/7517)
+
  ## [3.4.6]
 
  > Release date: 2025-06-06

--- a/internal/controllers/gateway/gateway_utils.go
+++ b/internal/controllers/gateway/gateway_utils.go
@@ -734,6 +734,7 @@ func getAttachedRoutesForListener(ctx context.Context, mgrc client.Client, gatew
 			}
 			if accepted {
 				attachedRoutes++
+				break
 			}
 		}
 	}


### PR DESCRIPTION
* fixing the attachedRoutes count in case of HTTPRoute with multiple parentRefs

* changelog update for #7517

(cherry picked from commit 1ff5b45a08a545b328b94c02d695dd863166b3e5)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
