### PR TITLE
feat(translator): Generate KongConfigurationTranslationFailed event when algorithm=sticky-sessions and kong version < 3.11

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -57,3 +57,6 @@ kongintegration:
 envtests:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
   kong-ee: '3.9.1.1'
+  # This is a version of Kong Gateway that does not support sticky sessions,
+  # all versions >= 3.11.0 support sticky sessions.
+  kong-without-sticky-sessions: '3.9.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Adding a new version? You'll need three changes:
    [#7466](https://github.com/Kong/kubernetes-ingress-controller/pull/7466)
    [#7512](https://github.com/Kong/kubernetes-ingress-controller/pull/7512)
    [#7533](https://github.com/Kong/kubernetes-ingress-controller/pull/7533)
+   [#7538](https://github.com/Kong/kubernetes-ingress-controller/pull/7538)
  - Store the license fetched from Konnect to the `Secret` named `konnect-license-<cpID>`
    in the same namespace where KIC runs. The `cpID` is the ID of the Konnect
    control plane. If the `Secret` does not exist, KIC will create it. However,

--- a/config/crd/incubator/kustomization.yaml
+++ b/config/crd/incubator/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=403ef6b96f0b190acc5d94c3b6d3f08dc3e405ed # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=d5352741776e75f537fc30220e375fa40fbabc3c # Version is auto-updated by the generating script.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=403ef6b96f0b190acc5d94c3b6d3f08dc3e405ed # Version is auto-updated by the generating script.
+  - https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=d5352741776e75f537fc30220e375fa40fbabc3c # Version is auto-updated by the generating script.

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.24.2
 	github.com/kong/go-kong v0.67.0
-	github.com/kong/kubernetes-configuration v1.4.1-0.20250623142530-403ef6b96f0b
+	github.com/kong/kubernetes-configuration v1.4.1-0.20250626121935-d5352741776e
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.2
 	github.com/lithammer/dedent v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/kong/go-database-reconciler v1.24.2 h1:TNY4dy+uJcmSlWAElye65eVl1Wd1xg
 github.com/kong/go-database-reconciler v1.24.2/go.mod h1:fWjwkA2MDQu1QKLV8qeUCagGmOU4wNhPAQkl5LBfYd0=
 github.com/kong/go-kong v0.67.0 h1:54zXKc58IZpZdlJCv8p95SJjejTxT+cwbWXw97icCak=
 github.com/kong/go-kong v0.67.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/kubernetes-configuration v1.4.1-0.20250623142530-403ef6b96f0b h1:IbKRfbeP3bchAoPI9LsOwNRjkKLUF8qKGXykN2UqvR4=
-github.com/kong/kubernetes-configuration v1.4.1-0.20250623142530-403ef6b96f0b/go.mod h1:Pqm6hhgk4CvHpw+OIhlVqdpfrNo0B6Z4zkiI9O7V1jM=
+github.com/kong/kubernetes-configuration v1.4.1-0.20250626121935-d5352741776e h1:9wRdBxG8j0G1/BQDApcFaetPdrLtUfUiJ0now8uyVp4=
+github.com/kong/kubernetes-configuration v1.4.1-0.20250626121935-d5352741776e/go.mod h1:Pqm6hhgk4CvHpw+OIhlVqdpfrNo0B6Z4zkiI9O7V1jM=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=
 github.com/kong/kubernetes-telemetry v0.1.10/go.mod h1:/r/FevTOGegCqaxXCJyGkbE1E3IcYUGJd7xX7D73s2Y=
 github.com/kong/kubernetes-testing-framework v0.47.2 h1:+2Z9anTpbV/hwNeN+NFQz53BMU+g3QJydkweBp3tULo=

--- a/internal/dataplane/kong_client_golden_test.go
+++ b/internal/dataplane/kong_client_golden_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/zapr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -259,7 +260,7 @@ func runKongClientGoldenTest(t *testing.T, tc kongClientGoldenTestCase) {
 	// Create the translator.
 	logger := zapr.NewLogger(zap.NewNop())
 	s := store.New(cacheStores, "kong", logger)
-	p, err := translator.NewTranslator(logger, s, "", tc.featureFlags, fakeSchemaServiceProvier{},
+	p, err := translator.NewTranslator(logger, s, "", semver.MustParse("3.9.1"), tc.featureFlags, fakeSchemaServiceProvier{},
 		translator.Config{
 			ClusterDomain:      consts.DefaultClusterDomain,
 			EnableDrainSupport: consts.DefaultEnableDrainSupport,

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -305,7 +305,10 @@ func (ks *KongState) FillUpstreamOverrides(
 			if kongUpstreamPolicy.Spec.Algorithm != nil && *kongUpstreamPolicy.Spec.Algorithm == "sticky-sessions" &&
 				kongVersion.LT(versions.KongStickySessionsCutoff) {
 				failuresCollector.PushResourceFailure(
-					fmt.Sprintf("sticky sessions algorithm specified in KongUpstreamPolicy '%s' is not supported", kongUpstreamPolicy.Name),
+					fmt.Sprintf(
+						"sticky sessions algorithm specified in KongUpstreamPolicy '%s' is not supported with Kong Gateway versions < %s",
+						kongUpstreamPolicy.Name, versions.KongStickySessionsCutoff,
+					),
 					lo.Map(servicesGroup, servicesAsObjects)...,
 				)
 				continue

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -30,6 +31,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/rels"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
 
 // KongState holds the configuration that should be applied to Kong.
@@ -250,6 +252,7 @@ func (ks *KongState) FillOverrides(
 	logger logr.Logger,
 	s store.Storer,
 	failuresCollector *failures.ResourceFailuresCollector,
+	kongVersion semver.Version,
 ) {
 	for i := 0; i < len(ks.Services); i++ {
 		// Services
@@ -271,13 +274,14 @@ func (ks *KongState) FillOverrides(
 		}
 	}
 
-	ks.FillUpstreamOverrides(s, logger, failuresCollector)
+	ks.FillUpstreamOverrides(s, logger, failuresCollector, kongVersion)
 }
 
 func (ks *KongState) FillUpstreamOverrides(
 	s store.Storer,
 	logger logr.Logger,
 	failuresCollector *failures.ResourceFailuresCollector,
+	kongVersion semver.Version,
 ) {
 	for i := 0; i < len(ks.Upstreams); i++ {
 		servicesGroup := lo.Values(ks.Upstreams[i].Service.K8sServices)
@@ -298,6 +302,14 @@ func (ks *KongState) FillUpstreamOverrides(
 		if err != nil {
 			failuresCollector.PushResourceFailure(err.Error(), lo.Map(servicesGroup, servicesAsObjects)...)
 		} else if kongUpstreamPolicy != nil {
+			if kongUpstreamPolicy.Spec.Algorithm != nil && *kongUpstreamPolicy.Spec.Algorithm == "sticky-sessions" &&
+				kongVersion.LT(versions.KongStickySessionsCutoff) {
+				failuresCollector.PushResourceFailure(
+					fmt.Sprintf("sticky sessions algorithm specified in KongUpstreamPolicy '%s' is not supported", kongUpstreamPolicy.Name),
+					lo.Map(servicesGroup, servicesAsObjects)...,
+				)
+				continue
+			}
 			ks.Upstreams[i].overrideByKongUpstreamPolicy(kongUpstreamPolicy)
 		}
 	}

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -1718,7 +1718,7 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 			},
 			expectedFailures: []failures.ResourceFailure{
 				lo.Must(failures.NewResourceFailure(
-					"sticky sessions algorithm specified in KongUpstreamPolicy 'policy' is not supported",
+					"sticky sessions algorithm specified in KongUpstreamPolicy 'policy' is not supported with Kong Gateway versions < 3.11.0",
 					serviceAnnotatedWithKongUpstreamPolicy(),
 				)),
 			},

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	"github.com/go-logr/zapr"
@@ -37,6 +38,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/store"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/util/rels"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
 
 var kongConsumerTypeMeta = metav1.TypeMeta{
@@ -48,6 +50,8 @@ var serviceTypeMeta = metav1.TypeMeta{
 	APIVersion: "v1",
 	Kind:       "Service",
 }
+
+var defaultTestKongVersion = semver.MustParse("3.9.1")
 
 func TestKongState_SanitizedCopy(t *testing.T) {
 	testedFields := sets.New[string]()
@@ -1550,13 +1554,15 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		upstream             Upstream
+		kongVersion          semver.Version
 		kongUpstreamPolicies []*configurationv1beta1.KongUpstreamPolicy
 		kongIngresses        []*configurationv1.KongIngress
 		expectedUpstream     kong.Upstream
 		expectedFailures     []failures.ResourceFailure
 	}{
 		{
-			name: "upstream with no overrides",
+			name:        "upstream with no overrides",
+			kongVersion: defaultTestKongVersion,
 			upstream: Upstream{
 				Upstream: kong.Upstream{
 					Name: kong.String("foo-upstream"),
@@ -1567,7 +1573,8 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "upstream backed by service annotated with KongUpstreamPolicy",
+			name:        "upstream backed by service annotated with KongUpstreamPolicy",
+			kongVersion: defaultTestKongVersion,
 			upstream: Upstream{
 				Upstream: kong.Upstream{
 					Name: kong.String("foo-upstream"),
@@ -1593,7 +1600,8 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "upstream backed by service annotated with KongUpstreamPolicy that doesn't exist",
+			name:        "upstream backed by service annotated with KongUpstreamPolicy that doesn't exist",
+			kongVersion: defaultTestKongVersion,
 			upstream: Upstream{
 				Upstream: kong.Upstream{
 					Name: kong.String("foo-upstream"),
@@ -1613,7 +1621,8 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "KongUpstreamPolicy is applied even if KongIngress is not found",
+			name:        "KongUpstreamPolicy is applied even if KongIngress is not found",
+			kongVersion: defaultTestKongVersion,
 			upstream: Upstream{
 				Upstream: kong.Upstream{
 					Name: kong.String("foo-upstream"),
@@ -1645,7 +1654,8 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "KongUpstreamPolicy overwrites KongIngress",
+			name:        "KongUpstreamPolicy overwrites KongIngress",
+			kongVersion: defaultTestKongVersion,
 			upstream: Upstream{
 				Upstream: kong.Upstream{
 					Name: kong.String("foo-upstream"),
@@ -1681,6 +1691,65 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 				Algorithm: kong.String("least-connections"),
 			},
 		},
+		{
+			name:        "KongUpstreamPolicy with algorithm sticky-sessions is not supported for Kong < 3.11",
+			kongVersion: defaultTestKongVersion,
+			upstream: Upstream{
+				Upstream: kong.Upstream{
+					Name: kong.String("foo-upstream"),
+				},
+				Service: Service{
+					K8sServices: map[string]*corev1.Service{"": serviceAnnotatedWithKongUpstreamPolicy()},
+				},
+			},
+			kongUpstreamPolicies: []*configurationv1beta1.KongUpstreamPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kongUpstreamPolicyName,
+						Namespace: "default",
+					},
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+					},
+				},
+			},
+			expectedUpstream: kong.Upstream{
+				Name: kong.String("foo-upstream"),
+			},
+			expectedFailures: []failures.ResourceFailure{
+				lo.Must(failures.NewResourceFailure(
+					"sticky sessions algorithm specified in KongUpstreamPolicy 'policy' is not supported",
+					serviceAnnotatedWithKongUpstreamPolicy(),
+				)),
+			},
+		},
+		{
+			name:        "KongUpstreamPolicy with algorithm sticky-sessions is supported for Kong >= 3.11",
+			kongVersion: versions.KongStickySessionsCutoff,
+			upstream: Upstream{
+				Upstream: kong.Upstream{
+					Name: kong.String("foo-upstream"),
+				},
+				Service: Service{
+					K8sServices: map[string]*corev1.Service{"": serviceAnnotatedWithKongUpstreamPolicy()},
+				},
+			},
+			kongUpstreamPolicies: []*configurationv1beta1.KongUpstreamPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kongUpstreamPolicyName,
+						Namespace: "default",
+					},
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("sticky-sessions"),
+					},
+				},
+			},
+			expectedUpstream: kong.Upstream{
+				Name:      kong.String("foo-upstream"),
+				Algorithm: kong.String("sticky-sessions"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1693,7 +1762,7 @@ func TestKongState_FillUpstreamOverrides(t *testing.T) {
 			failuresCollector := failures.NewResourceFailuresCollector(logr.Discard())
 
 			kongState := KongState{Upstreams: []Upstream{tc.upstream}}
-			kongState.FillUpstreamOverrides(s, logr.Discard(), failuresCollector)
+			kongState.FillUpstreamOverrides(s, logr.Discard(), failuresCollector, tc.kongVersion)
 			require.Equal(t, tc.expectedUpstream, kongState.Upstreams[0].Upstream)
 			require.ElementsMatch(t, tc.expectedFailures, failuresCollector.PopResourceFailures())
 		})
@@ -1988,7 +2057,7 @@ func TestFillOverrides_ServiceFailures(t *testing.T) {
 			require.NoError(t, err)
 			logger := zapr.NewLogger(zap.NewNop())
 			failuresCollector := failures.NewResourceFailuresCollector(logger)
-			tt.state.FillOverrides(logger, store, failuresCollector)
+			tt.state.FillOverrides(logger, store, failuresCollector, defaultTestKongVersion)
 			if len(tt.expectedTranslationFailureMessages) > 0 {
 				translationFailures := failuresCollector.PopResourceFailures()
 				for nsName, expectedMessage := range tt.expectedTranslationFailureMessages {

--- a/internal/dataplane/translator/translate_upstreams.go
+++ b/internal/dataplane/translator/translate_upstreams.go
@@ -78,7 +78,12 @@ func (t *Translator) getUpstreams(serviceMap map[string]kongstate.Service) ([]ko
 				serviceMap[serviceName] = service
 
 				// get the new targets for this backend service
-				newTargets := getServiceEndpoints(t.logger, t.storer, k8sService, port, t.clusterDomain, t.enableDrainSupport)
+				newTargets := getServiceEndpoints(
+					t.logger, t.storer,
+					k8sService, port,
+					t.clusterDomain,
+					t.enableDrainSupport,
+				)
 
 				if len(newTargets) == 0 {
 					t.logger.V(logging.InfoLevel).Info("No targets could be found for kubernetes service",

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,6 +98,7 @@ type Translator struct {
 	storer        store.Storer
 	workspace     string
 	licenseGetter license.Getter
+	kongVersion   semver.Version
 	featureFlags  FeatureFlags
 
 	// schemaServiceProvider provides the schema service required for fetching schemas of custom entities.
@@ -125,6 +127,7 @@ func NewTranslator(
 	logger logr.Logger,
 	storer store.Storer,
 	workspace string,
+	kongVersion semver.Version,
 	featureFlags FeatureFlags,
 	schemaServiceProvider SchemaServiceProvider,
 	config Config,
@@ -141,6 +144,7 @@ func NewTranslator(
 		logger:                     logger,
 		storer:                     storer,
 		workspace:                  workspace,
+		kongVersion:                kongVersion,
 		featureFlags:               featureFlags,
 		schemaServiceProvider:      schemaServiceProvider,
 		failuresCollector:          failuresCollector,
@@ -211,7 +215,7 @@ func (t *Translator) BuildKongConfig() KongConfigBuildingResult {
 	}
 
 	// merge KongIngress with Routes, Services and Upstream
-	result.FillOverrides(t.logger, t.storer, t.failuresCollector)
+	result.FillOverrides(t.logger, t.storer, t.failuresCollector, t.kongVersion)
 
 	// generate consumers and credentials
 	result.FillConsumersAndCredentials(t.logger, t.storer, t.failuresCollector)

--- a/internal/dataplane/translator/translator_test.go
+++ b/internal/dataplane/translator/translator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/zapr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
@@ -5430,12 +5431,14 @@ func (p fakeSchemaServiceProvier) GetSchemaService() kong.AbstractSchemaService 
 func mustNewTranslator(t *testing.T, storer store.Storer) *Translator {
 	logger := zapr.NewLogger(zap.NewNop())
 	p, err := NewTranslator(logger, storer, "",
+		semver.MustParse("3.9.1"),
 		FeatureFlags{
 			// We'll assume these are true for all tests.
 			FillIDs:                           true,
 			ReportConfiguredKubernetesObjects: true,
 			KongServiceFacade:                 true,
 		},
+
 		fakeSchemaServiceProvier{},
 		Config{
 			EnableDrainSupport: consts.DefaultEnableDrainSupport,

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -216,7 +216,7 @@ func New(
 	cache := store.NewCacheStores()
 	storer := store.New(cache, c.IngressClassName, logger)
 
-	configTranslator, err := translator.NewTranslator(logger, storer, c.KongWorkspace, translatorFeatureFlags, NewSchemaServiceGetter(clientsManager),
+	configTranslator, err := translator.NewTranslator(logger, storer, c.KongWorkspace, kongSemVersion, translatorFeatureFlags, NewSchemaServiceGetter(clientsManager),
 		translator.Config{
 			ClusterDomain:      c.ClusterDomain,
 			EnableDrainSupport: c.EnableDrainSupport,

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -10,5 +10,8 @@ var KICv3VersionCutoff = semver.Version{Major: 3, Minor: 4, Patch: 1}
 // KongRedirectPluginCutoff is the lowest version of Kong Gateway that supports `redirect` plugin.
 var KongRedirectPluginCutoff = semver.Version{Major: 3, Minor: 9, Patch: 0}
 
+// KongStickySessionsCutoff is the lowest version of Kong Gateway that supports `sticky_sessions` loadbalancing algorithm.
+var KongStickySessionsCutoff = semver.Version{Major: 3, Minor: 11, Patch: 0}
+
 // DeckFileFormatVersion is the version of the decK file format used by KIC everywhere.
 const DeckFileFormatVersion = "3.0"

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-multiple-gateways.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -2865,6 +2865,10 @@ spec:
             is set.
           rule: 'has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie)
             : true'
+        - message: spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions
+            is set.
+          rule: 'has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm
+            == "sticky-sessions") : true'
     served: true
     storage: true
     subresources:

--- a/test/envtest/kong.go
+++ b/test/envtest/kong.go
@@ -25,3 +25,18 @@ func runKongEnterprise(ctx context.Context, t *testing.T) containers.Kong {
 
 	return containers.NewKong(ctx, t, withEnvtestsVersion)
 }
+
+// runKongGatewayWithoutStickySessionsSupport runs a Kong Gateway container that does
+// not support sticky sessions, since every version >= 3.11.0 supports sticky sessions.
+func runKongGatewayWithoutStickySessionsSupport(ctx context.Context, t *testing.T) containers.Kong {
+	// Get the Kong Gateway version to use for the test from `test_dependencies.yaml` file.
+	gatewayTag, err := testenv.GetDependencyVersion("envtests.kong-without-sticky-sessions")
+	require.NoError(t, err)
+
+	// Prepare the container config modifier to set the Kong Gateway version.
+	withEnvtestsVersion := func(request *testcontainers.ContainerRequest) {
+		request.Image = fmt.Sprintf("kong/kong:%s", gatewayTag)
+	}
+
+	return containers.NewKong(ctx, t, withEnvtestsVersion)
+}

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -159,6 +159,12 @@ func WithKongServiceFacadeFeatureEnabled() func(cfg *managercfg.Config) {
 	}
 }
 
+func WithKongUpstreamPolicyEnabled() func(cfg *managercfg.Config) {
+	return func(cfg *managercfg.Config) {
+		cfg.KongUpstreamPolicyEnabled = true
+	}
+}
+
 func WithKongAdminURLs(urls ...string) func(cfg *managercfg.Config) {
 	return func(cfg *managercfg.Config) {
 		cfg.KongAdminURLs = urls


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
When `KongUpstreamPolicy` set algorithm to `sticky-sessions` and  Kong gateway version < 3.11, generate a `KongConfigurationTranslationFailed` event for services using the `KongUpstreamPolicy` and do not override translated `upstream` by `KongUpstreamPolicy`.

**Which issue this PR fixes**:

closes #7537

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Generation of event for Kong Gateway `< 3.11.0` is covered by dedicated envtest `TestStickySessionsNotSupportedEventGeneration`. Big general envtest `TestConfigErrorEventGenerationInMemoryMode` to pass has to detect this event too, because `3.11.0` is not released yet, so there is no support. But `3.11.0` is around the corner, so when it is updated, this test will fail, and someone needs to adjust it as described in the TODO to cover the situation of not generating this event. There is rather no point in introducing some machinery for testing it now. Proper behavior has been tested manually with the release candidate of 3.11.0, so the update will go smoothly

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
