### PR TITLE
test(e2e): Add postStart hook to set open file limit to at least 4096

### DIFF
--- a/config/base/kong-ingress-dbless.yaml
+++ b/config/base/kong-ingress-dbless.yaml
@@ -74,6 +74,12 @@ spec:
         - name: KONG_ROUTER_FLAVOR
           value: expressions
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash  
+              - -c
+              - "nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi"
           preStop:
             exec:
               command: [ "/bin/bash", "-c", "kong quit" ]

--- a/config/variants/multi-gw/base/gateway_deployment.yaml
+++ b/config/variants/multi-gw/base/gateway_deployment.yaml
@@ -74,6 +74,12 @@ spec:
         - name: KONG_ROUTER_FLAVOR
           value: expressions
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash  
+              - -c
+              - "nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi"
           preStop:
             exec:
               command: [ "/bin/bash", "-c", "kong quit" ]

--- a/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-k4k8s-enterprise.yaml
@@ -4067,6 +4067,13 @@ spec:
           value: expressions
         image: kong/kong-gateway:3.10
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit
+                -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi
           preStop:
             exec:
               command:

--- a/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect-enterprise.yaml
@@ -4077,6 +4077,13 @@ spec:
           value: expressions
         image: kong/kong-gateway:3.10
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit
+                -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi
           preStop:
             exec:
               command:

--- a/test/e2e/manifests/all-in-one-dbless-konnect.yaml
+++ b/test/e2e/manifests/all-in-one-dbless-konnect.yaml
@@ -4079,6 +4079,13 @@ spec:
           value: expressions
         image: kong:3.9
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit
+                -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi
           preStop:
             exec:
               command:

--- a/test/e2e/manifests/all-in-one-dbless.yaml
+++ b/test/e2e/manifests/all-in-one-dbless.yaml
@@ -4064,6 +4064,13 @@ spec:
           value: expressions
         image: kong:3.9
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit
+                -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi
           preStop:
             exec:
               command:

--- a/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
+++ b/test/e2e/manifests/all-in-one-postgres-enterprise.yaml
@@ -4013,6 +4013,13 @@ spec:
           value: /dev/stderr
         image: kong/kong-gateway:3.10
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit
+                -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi
           preStop:
             exec:
               command:

--- a/test/e2e/manifests/all-in-one-postgres.yaml
+++ b/test/e2e/manifests/all-in-one-postgres.yaml
@@ -3968,6 +3968,13 @@ spec:
           value: /dev/stderr
         image: kong:3.9
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - nofilelimit=$(prlimit --nofile --noheadings -oSOFT); if [ $nofilelimit
+                -lt 4096 ]; then prlimit --nofile=4096 --pid=1; fi
           preStop:
             exec:
               command:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Set limit of open files to at least `4096` to fix the flaky tests on GKE.
Kong gateway suggests to set the limit to at least 4096 but GKE has the default value of `1024` which is not enough for stream proxy: https://cloud.google.com/kubernetes-engine/docs/troubleshooting/known-issues

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #7242 

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
