### PR TITLE
chore: fix CLI args docs generation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,7 +8,7 @@ content_type: reference
 layout: reference
 tags:
   - crd
-search_aliases: 
+search_aliases:
   - kic CRD
 products:
   - kic

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -58,403 +58,403 @@ columns:
 rows:
   - flag: '`--admission-webhook-cert`'
     type: '`string`'
-    description: Admission server PEM certificate value. Mutually exclusive with --admission-webhook-cert-file.
+    description: "Admission server PEM certificate value. Mutually exclusive with --admission-webhook-cert-file."
     default: ""
   - flag: '`--admission-webhook-cert-file`'
     type: '`string`'
-    description: Admission server PEM certificate file path. If both this and the cert value is unset, defaults to /admission-webhook/tls.crt. Mutually exclusive with --admission-webhook-cert.
+    description: "Admission server PEM certificate file path. If both this and the cert value is unset, defaults to /admission-webhook/tls.crt. Mutually exclusive with --admission-webhook-cert."
     default: ""
   - flag: '`--admission-webhook-key`'
     type: '`string`'
-    description: Admission server PEM private key value. Mutually exclusive with --admission-webhook-key-file.
+    description: "Admission server PEM private key value. Mutually exclusive with --admission-webhook-key-file."
     default: ""
   - flag: '`--admission-webhook-key-file`'
     type: '`string`'
-    description: Admission server PEM private key file path. If both this and the key value is unset, defaults to /admission-webhook/tls.key. Mutually exclusive with --admission-webhook-key.
+    description: "Admission server PEM private key file path. If both this and the key value is unset, defaults to /admission-webhook/tls.key. Mutually exclusive with --admission-webhook-key."
     default: ""
   - flag: '`--admission-webhook-listen`'
     type: '`string`'
-    description: The address to start admission controller on (ip:port). Setting it to 'off' disables the admission controller.
+    description: "The address to start admission controller on (ip:port). Setting it to 'off' disables the admission controller."
     default: '`off`'
   - flag: '`--anonymous-reports`'
     type: '`bool`'
-    description: Send anonymized usage data to help improve Kong.
+    description: "Send anonymized usage data to help improve Kong."
     default: '`true`'
   - flag: '`--apiserver-burst`'
     type: '`int`'
-    description: The Kubernetes API RateLimiter maximum burst queries per second.
+    description: "The Kubernetes API RateLimiter maximum burst queries per second."
     default: '`300`'
   - flag: '`--apiserver-host`'
     type: '`string`'
-    description: The Kubernetes API server URL. If not set, the controller will use cluster config discovery.
+    description: "The Kubernetes API server URL. If not set, the controller will use cluster config discovery."
     default: ""
   - flag: '`--apiserver-qps`'
     type: '`int`'
-    description: The Kubernetes API RateLimiter maximum queries per second.
+    description: "The Kubernetes API RateLimiter maximum queries per second."
     default: '`100`'
   - flag: '`--cache-sync-timeout`'
     type: '`duration`'
-    description: The time limit set to wait for syncing controllers' caches. Set to 0 to use default from controller-runtime.
+    description: "The time limit set to wait for syncing controllers' caches. Set to 0 to use default from controller-runtime."
     default: '`2m0s`'
   - flag: '`--cluster-domain`'
     type: '`string`'
-    description: The cluster domain. This is used e.g. in generating addresses for upstream services.
+    description: "The cluster domain. This is used e.g. in generating addresses for upstream services."
     default: ""
   - flag: '`--combined-services-from-different-httproutes`'
     type: '`bool`'
-    description: Combine rules from different HTTPRoutes that are sharing the same combination of backends to one Kong service to reduce total number of Kong services.
+    description: "Combine rules from different HTTPRoutes that are sharing the same combination of backends to one Kong service to reduce total number of Kong services."
     default: '`false`'
   - flag: '`--configmap-label-selector`'
     type: '`string`'
-    description: Limits the configmaps ingested to those having this label set to "true".
+    description: "Limits the configmaps ingested to those having this label set to "true"."
     default: '`konghq.com/configmap`'
   - flag: '`--dump-config`'
     type: '`bool`'
-    description: Enable config dumps via web interface host:10256/debug/config.
+    description: "Enable config dumps via web interface host:10256/debug/config."
     default: '`false`'
   - flag: '`--dump-sensitive-config`'
     type: '`bool`'
-    description: Include credentials and TLS secrets in configs exposed with --dump-config flag.
+    description: "Include credentials and TLS secrets in configs exposed with --dump-config flag."
     default: '`false`'
   - flag: '`--election-id`'
     type: '`string`'
-    description: Election id to use for status update.
+    description: "Election id to use for status update."
     default: '`5b374a9e.konghq.com`'
   - flag: '`--election-namespace`'
     type: '`string`'
-    description: Leader election namespace to use when running outside a cluster.
+    description: "Leader election namespace to use when running outside a cluster."
     default: ""
   - flag: '`--emit-kubernetes-events`'
     type: '`bool`'
-    description: Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects.
+    description: "Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects."
     default: '`true`'
   - flag: '`--enable-controller-gwapi-gateway`'
     type: '`bool`'
-    description: Enable the Gateway API Gateway controller.
+    description: "Enable the Gateway API Gateway controller."
     default: '`true`'
   - flag: '`--enable-controller-gwapi-grpcroute`'
     type: '`bool`'
-    description: Enable the Gateway API GRPCRoute controller.
+    description: "Enable the Gateway API GRPCRoute controller."
     default: '`true`'
   - flag: '`--enable-controller-gwapi-httproute`'
     type: '`bool`'
-    description: Enable the Gateway API HTTPRoute controller.
+    description: "Enable the Gateway API HTTPRoute controller."
     default: '`true`'
   - flag: '`--enable-controller-gwapi-reference-grant`'
     type: '`bool`'
-    description: Enable the Gateway API ReferenceGrant controller.
+    description: "Enable the Gateway API ReferenceGrant controller."
     default: '`true`'
   - flag: '`--enable-controller-ingress-class-networkingv1`'
     type: '`bool`'
-    description: Enable the networking.k8s.io/v1 IngressClass controller.
+    description: "Enable the networking.k8s.io/v1 IngressClass controller."
     default: '`true`'
   - flag: '`--enable-controller-ingress-class-parameters`'
     type: '`bool`'
-    description: Enable the IngressClassParameters controller.
+    description: "Enable the IngressClassParameters controller."
     default: '`true`'
   - flag: '`--enable-controller-ingress-networkingv1`'
     type: '`bool`'
-    description: Enable the networking.k8s.io/v1 Ingress controller.
+    description: "Enable the networking.k8s.io/v1 Ingress controller."
     default: '`true`'
   - flag: '`--enable-controller-kong-custom-entity`'
     type: '`bool`'
-    description: Enable the KongCustomEntity controller.
+    description: "Enable the KongCustomEntity controller."
     default: '`true`'
   - flag: '`--enable-controller-kong-license`'
     type: '`bool`'
-    description: Enable the KongLicense controller.
+    description: "Enable the KongLicense controller."
     default: '`true`'
   - flag: '`--enable-controller-kong-service-facade`'
     type: '`bool`'
-    description: Enable the KongServiceFacade controller.
+    description: "Enable the KongServiceFacade controller."
     default: '`true`'
   - flag: '`--enable-controller-kong-upstream-policy`'
     type: '`bool`'
-    description: Enable the KongUpstreamPolicy controller.
+    description: "Enable the KongUpstreamPolicy controller."
     default: '`true`'
   - flag: '`--enable-controller-kong-vault`'
     type: '`bool`'
-    description: Enable the KongVault controller.
+    description: "Enable the KongVault controller."
     default: '`true`'
   - flag: '`--enable-controller-kongclusterplugin`'
     type: '`bool`'
-    description: Enable the KongClusterPlugin controller.
+    description: "Enable the KongClusterPlugin controller."
     default: '`true`'
   - flag: '`--enable-controller-kongconsumer`'
     type: '`bool`'
-    description: Enable the KongConsumer controller.
+    description: "Enable the KongConsumer controller."
     default: '`true`'
   - flag: '`--enable-controller-kongingress`'
     type: '`bool`'
-    description: Enable the KongIngress controller.
+    description: "Enable the KongIngress controller."
     default: '`true`'
   - flag: '`--enable-controller-kongplugin`'
     type: '`bool`'
-    description: Enable the KongPlugin controller.
+    description: "Enable the KongPlugin controller."
     default: '`true`'
   - flag: '`--enable-controller-service`'
     type: '`bool`'
-    description: Enable the Service controller.
+    description: "Enable the Service controller."
     default: '`true`'
   - flag: '`--enable-controller-tcpingress`'
     type: '`bool`'
-    description: Enable the TCPIngress controller.
+    description: "Enable the TCPIngress controller."
     default: '`true`'
   - flag: '`--enable-controller-udpingress`'
     type: '`bool`'
-    description: Enable the UDPIngress controller.
+    description: "Enable the UDPIngress controller."
     default: '`true`'
   - flag: '`--enable-drain-support`'
     type: '`bool`'
-    description: Include terminating endpoints in Kong upstreams with weight=0 for graceful connection draining.
+    description: "Include terminating endpoints in Kong upstreams with weight=0 for graceful connection draining."
     default: '`false`'
   - flag: '`--enable-reverse-sync`'
     type: '`bool`'
-    description: Send configuration to Kong even if the configuration checksum has not changed since previous update.
+    description: "Send configuration to Kong even if the configuration checksum has not changed since previous update."
     default: '`false`'
   - flag: '`--feature-gates`'
     type: '`list of string=bool`'
-    description: A set of comma separated key=value pairs that describe feature gates for alpha/beta/experimental features. See the Feature Gates documentation for information and available options: https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md.
+    description: "A set of comma separated key=value pairs that describe feature gates for alpha/beta/experimental features. See the Feature Gates documentation for information and available options: https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md."
     default: ""
   - flag: '`--gateway-api-controller-name`'
     type: '`string`'
-    description: The controller name to match on Gateway API resources.
+    description: "The controller name to match on Gateway API resources."
     default: '`konghq.com/kic-gateway-controller`'
   - flag: '`--gateway-discovery-readiness-check-interval`'
     type: '`duration`'
-    description: Interval of readiness checks on gateway admin API clients for discovery.
+    description: "Interval of readiness checks on gateway admin API clients for discovery."
     default: '`10s`'
   - flag: '`--gateway-discovery-readiness-check-timeout`'
     type: '`duration`'
-    description: Timeout of readiness checks on gateway admin clients.
+    description: "Timeout of readiness checks on gateway admin clients."
     default: '`5s`'
   - flag: '`--gateway-to-reconcile`'
     type: '`namespaced-name`'
-    description: Gateway namespaced name in "namespace/name" format. Makes KIC reconcile only the specified Gateway.
+    description: "Gateway namespaced name in "namespace/name" format. Makes KIC reconcile only the specified Gateway."
     default: ""
   - flag: '`--health-probe-bind-address`'
     type: '`string`'
-    description: The address the probe endpoint binds to.
+    description: "The address the probe endpoint binds to."
     default: '`:10254`'
   - flag: '`--ingress-class`'
     type: '`string`'
-    description: Name of the ingress class to route through this controller.
+    description: "Name of the ingress class to route through this controller."
     default: '`kong`'
   - flag: '`--init-cache-sync-duration`'
     type: '`duration`'
-    description: The initial delay to wait for Kubernetes object caches to be synced before the initial configuration.
+    description: "The initial delay to wait for Kubernetes object caches to be synced before the initial configuration."
     default: '`5s`'
   - flag: '`--kong-admin-ca-cert`'
     type: '`string`'
-    description: PEM-encoded CA certificate to verify Kong's Admin TLS certificate. Mutually exclusive with --kong-admin-ca-cert-file.
+    description: "PEM-encoded CA certificate to verify Kong's Admin TLS certificate. Mutually exclusive with --kong-admin-ca-cert-file."
     default: ""
   - flag: '`--kong-admin-ca-cert-file`'
     type: '`string`'
-    description: Path to PEM-encoded CA certificate file to verify Kong's Admin TLS certificate. Mutually exclusive with --kong-admin-ca-cert.
+    description: "Path to PEM-encoded CA certificate file to verify Kong's Admin TLS certificate. Mutually exclusive with --kong-admin-ca-cert."
     default: ""
   - flag: '`--kong-admin-concurrency`'
     type: '`int`'
-    description: Max number of concurrent requests sent to Kong's Admin API.
+    description: "Max number of concurrent requests sent to Kong's Admin API."
     default: '`10`'
   - flag: '`--kong-admin-filter-tag`'
     type: '`strings`'
-    description: Tag(s) in comma-separated format (or specify this flag multiple times). They are used to manage and filter entities in Kong. This setting will be silently ignored if the Kong instance has no tags support.
+    description: "Tag(s) in comma-separated format (or specify this flag multiple times). They are used to manage and filter entities in Kong. This setting will be silently ignored if the Kong instance has no tags support."
     default: '`[managed-by-ingress-controller]`'
   - flag: '`--kong-admin-header`'
     type: '`strings`'
-    description: Header(s) (key:value) in comma-separated format (or specify this flag multiple times) to add to every Admin API call.
+    description: "Header(s) (key:value) in comma-separated format (or specify this flag multiple times) to add to every Admin API call."
     default: '`[]`'
   - flag: '`--kong-admin-init-retries`'
     type: '`uint`'
-    description: Number of attempts that will be made initially on controller startup to connect to the Kong Admin API.
+    description: "Number of attempts that will be made initially on controller startup to connect to the Kong Admin API."
     default: '`60`'
   - flag: '`--kong-admin-init-retry-delay`'
     type: '`duration`'
-    description: The time delay between every attempt (on controller startup) to connect to the Kong Admin API.
+    description: "The time delay between every attempt (on controller startup) to connect to the Kong Admin API."
     default: '`1s`'
   - flag: '`--kong-admin-svc`'
     type: '`namespaced-name`'
-    description: Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery.
+    description: "Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery."
     default: ""
   - flag: '`--kong-admin-svc-port-names`'
     type: '`strings`'
-    description: Name(s) of ports on Kong Admin API service in comma-separated format (or specify this flag multiple times) to take into account when doing gateway discovery.
+    description: "Name(s) of ports on Kong Admin API service in comma-separated format (or specify this flag multiple times) to take into account when doing gateway discovery."
     default: '`[admin-tls,kong-admin-tls]`'
   - flag: '`--kong-admin-tls-client-cert`'
     type: '`string`'
-    description: Mutual TLS (mTLS) client certificate for authentication. Mutually exclusive with --kong-admin-tls-client-cert-file.
+    description: "Mutual TLS (mTLS) client certificate for authentication. Mutually exclusive with --kong-admin-tls-client-cert-file."
     default: ""
   - flag: '`--kong-admin-tls-client-cert-file`'
     type: '`string`'
-    description: Mutual TLS (mTLS) client certificate file for authentication. Mutually exclusive with --kong-admin-tls-client-cert.
+    description: "Mutual TLS (mTLS) client certificate file for authentication. Mutually exclusive with --kong-admin-tls-client-cert."
     default: ""
   - flag: '`--kong-admin-tls-client-key`'
     type: '`string`'
-    description: Mutual TLS (mTLS) client key for authentication. Mutually exclusive with --kong-admin-tls-client-key-file.
+    description: "Mutual TLS (mTLS) client key for authentication. Mutually exclusive with --kong-admin-tls-client-key-file."
     default: ""
   - flag: '`--kong-admin-tls-client-key-file`'
     type: '`string`'
-    description: Mutual TLS (mTLS) client key file for authentication. Mutually exclusive with --kong-admin-tls-client-key.
+    description: "Mutual TLS (mTLS) client key file for authentication. Mutually exclusive with --kong-admin-tls-client-key."
     default: ""
   - flag: '`--kong-admin-tls-server-name`'
     type: '`string`'
-    description: SNI name to use to verify the certificate presented by Kong in TLS.
+    description: "SNI name to use to verify the certificate presented by Kong in TLS."
     default: ""
   - flag: '`--kong-admin-tls-skip-verify`'
     type: '`bool`'
-    description: Disable verification of TLS certificate of Kong's Admin endpoint.
+    description: "Disable verification of TLS certificate of Kong's Admin endpoint."
     default: '`false`'
   - flag: '`--kong-admin-token`'
     type: '`string`'
-    description: The Kong Enterprise RBAC token used by the controller. Mutually exclusive with --kong-admin-token-file.
+    description: "The Kong Enterprise RBAC token used by the controller. Mutually exclusive with --kong-admin-token-file."
     default: ""
   - flag: '`--kong-admin-token-file`'
     type: '`string`'
-    description: Path to the Kong Enterprise RBAC token file used by the controller. Mutually exclusive with --kong-admin-token.
+    description: "Path to the Kong Enterprise RBAC token file used by the controller. Mutually exclusive with --kong-admin-token."
     default: ""
   - flag: '`--kong-admin-url`'
     type: '`strings`'
-    description: Kong Admin URL(s) in comma-separated format (or specify this flag multiple times) to connect to in the format "protocol://address:port".
+    description: "Kong Admin URL(s) in comma-separated format (or specify this flag multiple times) to connect to in the format "protocol://address:port"."
     default: '`[http://localhost:8001]`'
   - flag: '`--kong-workspace`'
     type: '`string`'
-    description: Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces.
+    description: "Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces."
     default: ""
   - flag: '`--konnect-address`'
     type: '`string`'
-    description: Base address of Konnect API.
+    description: "Base address of Konnect API."
     default: '`https://us.kic.api.konghq.com`'
   - flag: '`--konnect-control-plane-id`'
     type: '`string`'
-    description: An ID of a control plane that is to be synchronized with data plane configuration.
+    description: "An ID of a control plane that is to be synchronized with data plane configuration."
     default: ""
   - flag: '`--konnect-disable-consumers-sync`'
     type: '`bool`'
-    description: Disable synchronization of consumers with Konnect.
+    description: "Disable synchronization of consumers with Konnect."
     default: '`false`'
   - flag: '`--konnect-initial-license-polling-period`'
     type: '`duration`'
-    description: Polling period to be used before the first license is retrieved.
+    description: "Polling period to be used before the first license is retrieved."
     default: '`1m0s`'
   - flag: '`--konnect-license-polling-period`'
     type: '`duration`'
-    description: Polling period to be used after the first license is retrieved.
+    description: "Polling period to be used after the first license is retrieved."
     default: '`12h0m0s`'
   - flag: '`--konnect-license-storage-enabled`'
     type: '`bool`'
-    description: Store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when --konnect-licensing-enabled is true.
+    description: "Store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when --konnect-licensing-enabled is true."
     default: '`true`'
   - flag: '`--konnect-licensing-enabled`'
     type: '`bool`'
-    description: Retrieve licenses from Konnect if available. Overrides licenses provided via the environment.
+    description: "Retrieve licenses from Konnect if available. Overrides licenses provided via the environment."
     default: '`false`'
   - flag: '`--konnect-refresh-node-period`'
     type: '`duration`'
-    description: Period of uploading status of KIC and controlled Kong instances.
+    description: "Period of uploading status of KIC and controlled Kong instances."
     default: '`1m0s`'
   - flag: '`--konnect-sync-enabled`'
     type: '`bool`'
-    description: Enable synchronization of data plane configuration with a Konnect control plane.
+    description: "Enable synchronization of data plane configuration with a Konnect control plane."
     default: '`false`'
   - flag: '`--konnect-tls-client-cert`'
     type: '`string`'
-    description: Konnect TLS client certificate.
+    description: "Konnect TLS client certificate."
     default: ""
   - flag: '`--konnect-tls-client-cert-file`'
     type: '`string`'
-    description: Konnect TLS client certificate file path.
+    description: "Konnect TLS client certificate file path."
     default: ""
   - flag: '`--konnect-tls-client-key`'
     type: '`string`'
-    description: Konnect TLS client key.
+    description: "Konnect TLS client key."
     default: ""
   - flag: '`--konnect-tls-client-key-file`'
     type: '`string`'
-    description: Konnect TLS client key file path.
+    description: "Konnect TLS client key file path."
     default: ""
   - flag: '`--konnect-upload-config-period`'
     type: '`duration`'
-    description: Period of uploading Kong configuration.
+    description: "Period of uploading Kong configuration."
     default: '`30s`'
   - flag: '`--kubeconfig`'
     type: '`string`'
-    description: Path to the kubeconfig file.
+    description: "Path to the kubeconfig file."
     default: ""
   - flag: '`--log-format`'
     type: '`string`'
-    description: Format of logs of the controller. Allowed values are text and json.
+    description: "Format of logs of the controller. Allowed values are text and json."
     default: '`text`'
   - flag: '`--log-level`'
     type: '`string`'
-    description: Level of logging for the controller. Allowed values are trace, debug, info, and error.
+    description: "Level of logging for the controller. Allowed values are trace, debug, info, and error."
     default: '`info`'
   - flag: '`--metrics-access-filter`'
     type: '`string`'
-    description: Specifies the filter access function to be used for accessing the metrics endpoint (possible values: off, rbac).
+    description: "Specifies the filter access function to be used for accessing the metrics endpoint (possible values: off, rbac)."
     default: '`"off"`'
   - flag: '`--metrics-bind-address`'
     type: '`string`'
-    description: The address the metric endpoint binds to.
+    description: "The address the metric endpoint binds to."
     default: '`:10255`'
   - flag: '`--profiling`'
     type: '`bool`'
-    description: Enable profiling via web interface host:10256/debug/pprof/.
+    description: "Enable profiling via web interface host:10256/debug/pprof/."
     default: '`false`'
   - flag: '`--proxy-sync-seconds`'
     type: '`float`'
-    description: Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API.
+    description: "Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API."
     default: '`3`'
   - flag: '`--proxy-timeout-seconds`'
     type: '`float`'
-    description: Sets the timeout (in seconds) for all requests to Kong's Admin API.
+    description: "Sets the timeout (in seconds) for all requests to Kong's Admin API."
     default: '`30`'
   - flag: '`--publish-service`'
     type: '`namespaced-name`'
-    description: Service fronting Ingress resources in "namespace/name" format. The controller will update Ingress status information with this Service's endpoints.
+    description: "Service fronting Ingress resources in "namespace/name" format. The controller will update Ingress status information with this Service's endpoints."
     default: ""
   - flag: '`--publish-service-udp`'
     type: '`namespaced-name`'
-    description: Service fronting UDP routing resources in "namespace/name" format. The controller will update UDP route status information with this Service's endpoints. If omitted, the same Service will be used for both TCP and UDP routes.
+    description: "Service fronting UDP routing resources in "namespace/name" format. The controller will update UDP route status information with this Service's endpoints. If omitted, the same Service will be used for both TCP and UDP routes."
     default: ""
   - flag: '`--publish-status-address`'
     type: '`strings`'
-    description: Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service" when that Service lacks useful address information (for example, in bare-metal environments).
+    description: "Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service" when that Service lacks useful address information (for example, in bare-metal environments)."
     default: '`[]`'
   - flag: '`--publish-status-address-udp`'
     type: '`strings`'
-    description: Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service-udp" when that Service lacks useful address information (for example, in bare-metal environments).
+    description: "Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service-udp" when that Service lacks useful address information (for example, in bare-metal environments)."
     default: '`[]`'
   - flag: '`--secret-label-selector`'
     type: '`string`'
-    description: Limits the secrets ingested to those having this label set to "true". If not specified, all secrets are ingested.
+    description: "Limits the secrets ingested to those having this label set to "true". If not specified, all secrets are ingested."
     default: ""
   - flag: '`--skip-ca-certificates`'
     type: '`bool`'
-    description: Disable syncing CA certificate syncing (for use with multi-workspace environments).
+    description: "Disable syncing CA certificate syncing (for use with multi-workspace environments)."
     default: '`false`'
   - flag: '`--sync-period`'
     type: '`duration`'
-    description: Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime.
+    description: "Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime."
     default: '`10h0m0s`'
   - flag: '`--term-delay`'
     type: '`duration`'
-    description: The time delay to sleep before SIGTERM or SIGINT will shut down the ingress controller.
+    description: "The time delay to sleep before SIGTERM or SIGINT will shut down the ingress controller."
     default: '`0s`'
   - flag: '`--update-status`'
     type: '`bool`'
-    description: Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, etc.).
+    description: "Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, etc.)."
     default: '`true`'
   - flag: '`--update-status-queue-buffer-size`'
     type: '`int`'
-    description: Buffer size of the underlying channels used to update the status of resources.
+    description: "Buffer size of the underlying channels used to update the status of resources."
     default: '`8192`'
   - flag: '`--use-last-valid-config-for-fallback`'
     type: '`bool`'
-    description: When recovering from config push failures, use the last valid configuration cache to backfill broken objects. It can only be used with the FallbackConfiguration feature gate enabled.
+    description: "When recovering from config push failures, use the last valid configuration cache to backfill broken objects. It can only be used with the FallbackConfiguration feature gate enabled."
     default: '`false`'
   - flag: '`--watch-namespace`'
     type: '`strings`'
-    description: Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces.
+    description: "Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces."
     default: '`[]`'
 {% endtable %}
 

--- a/scripts/apidocs-gen/post-process-for-konghq.sh
+++ b/scripts/apidocs-gen/post-process-for-konghq.sh
@@ -24,7 +24,7 @@ content_type: reference
 layout: reference
 tags:
   - crd
-search_aliases: 
+search_aliases:
   - kic CRD
 products:
   - kic

--- a/scripts/cli-arguments-docs-gen/main.go
+++ b/scripts/cli-arguments-docs-gen/main.go
@@ -66,7 +66,7 @@ func main() {
 
 		mustWrite(&markdown, fmt.Sprintf("  - flag: '%s'\n", name))
 		mustWrite(&markdown, fmt.Sprintf("    type: '%s'\n", typ))
-		mustWrite(&markdown, fmt.Sprintf("    description: %s\n", description))
+		mustWrite(&markdown, fmt.Sprintf("    description: \"%s\"\n", description))
 		mustWrite(&markdown, fmt.Sprintf("    default: %s\n", defaultValue))
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Fix errors like: https://app.netlify.com/projects/kongdeveloper/deploys/687dfe9cff316000097daabc#L493 during docs build:

```
10:53:12 AM:   Liquid Exception: On `kubernetes-ingress-controller/reference/configuration-options.md`, the following {% table %} block contains a malformed yaml: 0: columns: 1: - title: Flag 2: key: flag 3: - title: Type 4: key: type 5: - title: Description 6: key: description 7: - title: Default 8: key: default 9: rows: 10: - flag: '`--admission-webhook-cert`' 11: type: '`string`' 12: description: Admission server PEM certificate value. Mutually exclusive with --admission-webhook-cert-file. 13: default: "" 14: - flag: '`--admission-webhook-cert-file`' 15: type: '`string`' 16: description: Admission server PEM certificate file path. If both this and the cert value is unset, defaults to /admission-webhook/tls.crt. Mutually exclusive with --admission-webhook-cert. 17: default: "" 18: - flag: '`--admission-webhook-key`' 19: type: '`string`' 20: description: Admission server PEM private key value. Mutually exclusive with --admission-webhook-key-file. 21: default: "" 22: - flag: '`--admission-webhook-key-file`' 23: type: '`string`' 24: description: Admission server PEM private key file path. If both this and the key value is unset, defaults to /admission-webhook/tls.key. Mutually exclusive with --admission-webhook-key. 25: default: "" 26: - flag: '`--admission-webhook-listen`' 27: type: '`string`' 28: description: The address to start admission controller on (ip:port). Setting it to 'off' disables the admission controller. 29: default: '`off`' 30: - flag: '`--anonymous-reports`' 31: type: '`bool`' 32: description: Send anonymized usage data to help improve Kong. 33: default: '`true`' 34: - flag: '`--apiserver-burst`' 35: type: '`int`' 36: description: The Kubernetes API RateLimiter maximum burst queries per second. 37: default: '`300`' 38: - flag: '`--apiserver-host`' 39: type: '`string`' 40: description: The Kubernetes API server URL. If not set, the controller will use cluster config discovery. 41: default: "" 42: - flag: '`--apiserver-qps`' 43: type: '`int`' 44: description: The Kubernetes API RateLimiter maximum queries per second. 45: default: '`100`' 46: - flag: '`--cache-sync-timeout`' 47: type: '`duration`' 48: description: The time limit set to wait for syncing controllers' caches. Set to 0 to use default from controller-runtime. 49: default: '`2m0s`' 50: - flag: '`--cluster-domain`' 51: type: '`string`' 52: description: The cluster domain. This is used e.g. in generating addresses for upstream services. 53: default: "" 54: - flag: '`--combined-services-from-different-httproutes`' 55: type: '`bool`' 56: description: Combine rules from different HTTPRoutes that are sharing the same combination of backends to one Kong service to reduce total number of Kong services. 57: default: '`false`' 58: - flag: '`--configmap-label-selector`' 59: type: '`string`' 60: description: Limits the configmaps ingested to those having this label set to "true". 61: default: '`konghq.com/configmap`' 62: - flag: '`--dump-config`' 63: type: '`bool`' 64: description: Enable config dumps via web interface host:10256/debug/config. 65: default: '`false`' 66: - flag: '`--dump-sensitive-config`' 67: type: '`bool`' 68: description: Include credentials and TLS secrets in configs exposed with --dump-config flag. 69: default: '`false`' 70: - flag: '`--election-id`' 71: type: '`string`' 72: description: Election id to use for status update. 73: default: '`5b374a9e.konghq.com`' 74: - flag: '`--election-namespace`' 75: type: '`string`' 76: description: Leader election namespace to use when running outside a cluster. 77: default: "" 78: - flag: '`--emit-kubernetes-events`' 79: type: '`bool`' 80: description: Emit Kubernetes events for successful configuration applies, translation failures and configuration apply failures on managed objects. 81: default: '`true`' 82: - flag: '`--enable-controller-gwapi-gateway`' 83: type: '`bool`' 84: description: Enable the Gateway API Gateway controller. 85: default: '`true`' 86: - flag: '`--enable-controller-gwapi-grpcroute`' 87: type: '`bool`' 88: description: Enable the Gateway API GRPCRoute controller. 89: default: '`true`' 90: - flag: '`--enable-controller-gwapi-httproute`' 91: type: '`bool`' 92: description: Enable the Gateway API HTTPRoute controller. 93: default: '`true`' 94: - flag: '`--enable-controller-gwapi-reference-grant`' 95: type: '`bool`' 96: description: Enable the Gateway API ReferenceGrant controller. 97: default: '`true`' 98: - flag: '`--enable-controller-ingress-class-networkingv1`' 99: type: '`bool`' 100: description: Enable the networking.k8s.io/v1 IngressClass controller. 101: default: '`true`' 102: - flag: '`--enable-controller-ingress-class-parameters`' 103: type: '`bool`' 104: description: Enable the IngressClassParameters controller. 105: default: '`true`' 106: - flag: '`--enable-controller-ingress-networkingv1`' 107: type: '`bool`' 108: description: Enable the networking.k8s.io/v1 Ingress controller. 109: default: '`true`' 110: - flag: '`--enable-controller-kong-custom-entity`' 111: type: '`bool`' 112: description: Enable the KongCustomEntity controller. 113: default: '`true`' 114: - flag: '`--enable-controller-kong-license`' 115: type: '`bool`' 116: description: Enable the KongLicense controller. 117: default: '`true`' 118: - flag: '`--enable-controller-kong-service-facade`' 119: type: '`bool`' 120: description: Enable the KongServiceFacade controller. 121: default: '`true`' 122: - flag: '`--enable-controller-kong-upstream-policy`' 123: type: '`bool`' 124: description: Enable the KongUpstreamPolicy controller. 125: default: '`true`' 126: - flag: '`--enable-controller-kong-vault`' 127: type: '`bool`' 128: description: Enable the KongVault controller. 129: default: '`true`' 130: - flag: '`--enable-controller-kongclusterplugin`' 131: type: '`bool`' 132: description: Enable the KongClusterPlugin controller. 133: default: '`true`' 134: - flag: '`--enable-controller-kongconsumer`' 135: type: '`bool`' 136: description: Enable the KongConsumer controller. 137: default: '`true`' 138: - flag: '`--enable-controller-kongingress`' 139: type: '`bool`' 140: description: Enable the KongIngress controller. 141: default: '`true`' 142: - flag: '`--enable-controller-kongplugin`' 143: type: '`bool`' 144: description: Enable the KongPlugin controller. 145: default: '`true`' 146: - flag: '`--enable-controller-service`' 147: type: '`bool`' 148: description: Enable the Service controller. 149: default: '`true`' 150: - flag: '`--enable-controller-tcpingress`' 151: type: '`bool`' 152: description: Enable the TCPIngress controller. 153: default: '`true`' 154: - flag: '`--enable-controller-udpingress`' 155: type: '`bool`' 156: description: Enable the UDPIngress controller. 157: default: '`true`' 158: - flag: '`--enable-drain-support`' 159: type: '`bool`' 160: description: Include terminating endpoints in Kong upstreams with weight=0 for graceful connection draining. 161: default: '`false`' 162: - flag: '`--enable-reverse-sync`' 163: type: '`bool`' 164: description: Send configuration to Kong even if the configuration checksum has not changed since previous update. 165: default: '`false`' 166: - flag: '`--feature-gates`' 167: type: '`list of string=bool`' 168: description: A set of comma separated key=value pairs that describe feature gates for alpha/beta/experimental features. See the Feature Gates documentation for information and available options: https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_GATES.md. 169: default: "" 170: - flag: '`--gateway-api-controller-name`' 171: type: '`string`' 172: description: The controller name to match on Gateway API resources. 173: default: '`konghq.com/kic-gateway-controller`' 174: - flag: '`--gateway-discovery-readiness-check-interval`' 175: type: '`duration`' 176: description: Interval of readiness checks on gateway admin API clients for discovery. 177: default: '`10s`' 178: - flag: '`--gateway-discovery-readiness-check-timeout`' 179: type: '`duration`' 180: description: Timeout of readiness checks on gateway admin clients. 181: default: '`5s`' 182: - flag: '`--gateway-to-reconcile`' 183: type: '`namespaced-name`' 184: description: Gateway namespaced name in "namespace/name" format. Makes KIC reconcile only the specified Gateway. 185: default: "" 186: - flag: '`--health-probe-bind-address`' 187: type: '`string`' 188: description: The address the probe endpoint binds to. 189: default: '`:10254`' 190: - flag: '`--ingress-class`' 191: type: '`string`' 192: description: Name of the ingress class to route through this controller. 193: default: '`kong`' 194: - flag: '`--init-cache-sync-duration`' 195: type: '`duration`' 196: description: The initial delay to wait for Kubernetes object caches to be synced before the initial configuration. 197: default: '`5s`' 198: - flag: '`--kong-admin-ca-cert`' 199: type: '`string`' 200: description: PEM-encoded CA certificate to verify Kong's Admin TLS certificate. Mutually exclusive with --kong-admin-ca-cert-file. 201: default: "" 202: - flag: '`--kong-admin-ca-cert-file`' 203: type: '`string`' 204: description: Path to PEM-encoded CA certificate file to verify Kong's Admin TLS certificate. Mutually exclusive with --kong-admin-ca-cert. 205: default: "" 206: - flag: '`--kong-admin-concurrency`' 207: type: '`int`' 208: description: Max number of concurrent requests sent to Kong's Admin API. 209: default: '`10`' 210: - flag: '`--kong-admin-filter-tag`' 211: type: '`strings`' 212: description: Tag(s) in comma-separated format (or specify this flag multiple times). They are used to manage and filter entities in Kong. This setting will be silently ignored if the Kong instance has no tags support. 213: default: '`[managed-by-ingress-controller]`' 214: - flag: '`--kong-admin-header`' 215: type: '`strings`' 216: description: Header(s) (key:value) in comma-separated format (or specify this flag multiple times) to add to every Admin API call. 217: default: '`[]`' 218: - flag: '`--kong-admin-init-retries`' 219: type: '`uint`' 220: description: Number of attempts that will be made initially on controller startup to connect to the Kong Admin API. 221: default: '`60`' 222: - flag: '`--kong-admin-init-retry-delay`' 223: type: '`duration`' 224: description: The time delay between every attempt (on controller startup) to connect to the Kong Admin API. 225: default: '`1s`' 226: - flag: '`--kong-admin-svc`' 227: type: '`namespaced-name`' 228: description: Kong Admin API Service namespaced name in "namespace/name" format, to use for Kong Gateway service discovery. 229: default: "" 230: - flag: '`--kong-admin-svc-port-names`' 231: type: '`strings`' 232: description: Name(s) of ports on Kong Admin API service in comma-separated format (or specify this flag multiple times) to take into account when doing gateway discovery. 233: default: '`[admin-tls,kong-admin-tls]`' 234: - flag: '`--kong-admin-tls-client-cert`' 235: type: '`string`' 236: description: Mutual TLS (mTLS) client certificate for authentication. Mutually exclusive with --kong-admin-tls-client-cert-file. 237: default: "" 238: - flag: '`--kong-admin-tls-client-cert-file`' 239: type: '`string`' 240: description: Mutual TLS (mTLS) client certificate file for authentication. Mutually exclusive with --kong-admin-tls-client-cert. 241: default: "" 242: - flag: '`--kong-admin-tls-client-key`' 243: type: '`string`' 244: description: Mutual TLS (mTLS) client key for authentication. Mutually exclusive with --kong-admin-tls-client-key-file. 245: default: "" 246: - flag: '`--kong-admin-tls-client-key-file`' 247: type: '`string`' 248: description: Mutual TLS (mTLS) client key file for authentication. Mutually exclusive with --kong-admin-tls-client-key. 249: default: "" 250: - flag: '`--kong-admin-tls-server-name`' 251: type: '`string`' 252: description: SNI name to use to verify the certificate presented by Kong in TLS. 253: default: "" 254: - flag: '`--kong-admin-tls-skip-verify`' 255: type: '`bool`' 256: description: Disable verification of TLS certificate of Kong's Admin endpoint. 257: default: '`false`' 258: - flag: '`--kong-admin-token`' 259: type: '`string`' 260: description: The Kong Enterprise RBAC token used by the controller. Mutually exclusive with --kong-admin-token-file. 261: default: "" 262: - flag: '`--kong-admin-token-file`' 263: type: '`string`' 264: description: Path to the Kong Enterprise RBAC token file used by the controller. Mutually exclusive with --kong-admin-token. 265: default: "" 266: - flag: '`--kong-admin-url`' 267: type: '`strings`' 268: description: Kong Admin URL(s) in comma-separated format (or specify this flag multiple times) to connect to in the format "protocol://address:port". 269: default: '`[http://localhost:8001/]`' 270: - flag: '`--kong-workspace`' 271: type: '`string`' 272: description: Kong Enterprise workspace to configure. Leave this empty if not using Kong workspaces. 273: default: "" 274: - flag: '`--konnect-address`' 275: type: '`string`' 276: description: Base address of Konnect API. 277: default: '`https://us.kic.api.konghq.com/`' 278: - flag: '`--konnect-control-plane-id`' 279: type: '`string`' 280: description: An ID of a control plane that is to be synchronized with data plane configuration. 281: default: "" 282: - flag: '`--konnect-disable-consumers-sync`' 283: type: '`bool`' 284: description: Disable synchronization of consumers with Konnect. 285: default: '`false`' 286: - flag: '`--konnect-initial-license-polling-period`' 287: type: '`duration`' 288: description: Polling period to be used before the first license is retrieved. 289: default: '`1m0s`' 290: - flag: '`--konnect-license-polling-period`' 291: type: '`duration`' 292: description: Polling period to be used after the first license is retrieved. 293: default: '`12h0m0s`' 294: - flag: '`--konnect-license-storage-enabled`' 295: type: '`bool`' 296: description: Store licenses fetched from Konnect to Secrets locally to use them later when connection to Konnect is broken. Only effective when --konnect-licensing-enabled is true. 297: default: '`true`' 298: - flag: '`--konnect-licensing-enabled`' 299: type: '`bool`' 300: description: Retrieve licenses from Konnect if available. Overrides licenses provided via the environment. 301: default: '`false`' 302: - flag: '`--konnect-refresh-node-period`' 303: type: '`duration`' 304: description: Period of uploading status of KIC and controlled Kong instances. 305: default: '`1m0s`' 306: - flag: '`--konnect-sync-enabled`' 307: type: '`bool`' 308: description: Enable synchronization of data plane configuration with a Konnect control plane. 309: default: '`false`' 310: - flag: '`--konnect-tls-client-cert`' 311: type: '`string`' 312: description: Konnect TLS client certificate. 313: default: "" 314: - flag: '`--konnect-tls-client-cert-file`' 315: type: '`string`' 316: description: Konnect TLS client certificate file path. 317: default: "" 318: - flag: '`--konnect-tls-client-key`' 319: type: '`string`' 320: description: Konnect TLS client key. 321: default: "" 322: - flag: '`--konnect-tls-client-key-file`' 323: type: '`string`' 324: description: Konnect TLS client key file path. 325: default: "" 326: - flag: '`--konnect-upload-config-period`' 327: type: '`duration`' 328: description: Period of uploading Kong configuration. 329: default: '`30s`' 330: - flag: '`--kubeconfig`' 331: type: '`string`' 332: description: Path to the kubeconfig file. 333: default: "" 334: - flag: '`--log-format`' 335: type: '`string`' 336: description: Format of logs of the controller. Allowed values are text and json. 337: default: '`text`' 338: - flag: '`--log-level`' 339: type: '`string`' 340: description: Level of logging for the controller. Allowed values are trace, debug, info, and error. 341: default: '`info`' 342: - flag: '`--metrics-access-filter`' 343: type: '`string`' 344: description: Specifies the filter access function to be used for accessing the metrics endpoint (possible values: off, rbac). 345: default: '`"off"`' 346: - flag: '`--metrics-bind-address`' 347: type: '`string`' 348: description: The address the metric endpoint binds to. 349: default: '`:10255`' 350: - flag: '`--profiling`' 351: type: '`bool`' 352: description: Enable profiling via web interface host:10256/debug/pprof/. 353: default: '`false`' 354: - flag: '`--proxy-sync-seconds`' 355: type: '`float`' 356: description: Define the rate (in seconds) in which configuration updates will be applied to the Kong Admin API. 357: default: '`3`' 358: - flag: '`--proxy-timeout-seconds`' 359: type: '`float`' 360: description: Sets the timeout (in seconds) for all requests to Kong's Admin API. 361: default: '`30`' 362: - flag: '`--publish-service`' 363: type: '`namespaced-name`' 364: description: Service fronting Ingress resources in "namespace/name" format. The controller will update Ingress status information with this Service's endpoints. 365: default: "" 366: - flag: '`--publish-service-udp`' 367: type: '`namespaced-name`' 368: description: Service fronting UDP routing resources in "namespace/name" format. The controller will update UDP route status information with this Service's endpoints. If omitted, the same Service will be used for both TCP and UDP routes. 369: default: "" 370: - flag: '`--publish-status-address`' 371: type: '`strings`' 372: description: Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service" when that Service lacks useful address information (for example, in bare-metal environments). 373: default: '`[]`' 374: - flag: '`--publish-status-address-udp`' 375: type: '`strings`' 376: description: Addresses in comma-separated format (or specify this flag multiple times), for use in lieu of "publish-service-udp" when that Service lacks useful address information (for example, in bare-metal environments). 377: default: '`[]`' 378: - flag: '`--secret-label-selector`' 379: type: '`string`' 380: description: Limits the secrets ingested to those having this label set to "true". If not specified, all secrets are ingested. 381: default: "" 382: - flag: '`--skip-ca-certificates`' 383: type: '`bool`' 384: description: Disable syncing CA certificate syncing (for use with multi-workspace environments). 385: default: '`false`' 386: - flag: '`--sync-period`' 387: type: '`duration`' 388: description: Determine the minimum frequency at which watched resources are reconciled. Set to 0 to use default from controller-runtime. 389: default: '`10h0m0s`' 390: - flag: '`--term-delay`' 391: type: '`duration`' 392: description: The time delay to sleep before SIGTERM or SIGINT will shut down the ingress controller. 393: default: '`0s`' 394: - flag: '`--update-status`' 395: type: '`bool`' 396: description: Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, etc.). 397: default: '`true`' 398: - flag: '`--update-status-queue-buffer-size`' 399: type: '`int`' 400: description: Buffer size of the underlying channels used to update the status of resources. 401: default: '`8192`' 402: - flag: '`--use-last-valid-config-for-fallback`' 403: type: '`bool`' 404: description: When recovering from config push failures, use the last valid configuration cache to backfill broken objects. It can only be used with the FallbackConfiguration feature gate enabled. 405: default: '`false`' 406: - flag: '`--watch-namespace`' 407: type: '`strings`' 408: description: Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces. 409: default: '`[]`' (<unknown>): mapping values are not allowed in this context at line 169 column 198 in kubernetes-ingress-controller/reference/configuration-options.md
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Manually adjusted in https://github.com/Kong/developer.konghq.com/pull/2066/commits/355b7307e641e5bc4b5aa97f763ba17639fd1568

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
