### PR TITLE
fix(konnect): Use correct label value of secret to store license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,14 @@ Adding a new version? You'll need three changes:
 - [0.0.5](#005)
 - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- Fix the issue that invalid label value causing KIC failed to store the license
+from Konnect into `Secret`.
+[#7648](https://github.com/Kong/kubernetes-ingress-controller/pull/7648)
+
 ## [3.5.0]
 
 > Release date: 2025-07-02

--- a/internal/konnect/license/client.go
+++ b/internal/konnect/license/client.go
@@ -94,7 +94,9 @@ func (c *Client) Get(ctx context.Context) (mo.Option[license.KonnectLicense], er
 
 	if c.enableLicenseStorage && l.IsPresent() {
 		err = c.licenseStore.Store(ctx, l.MustGet())
-		c.logger.Error(err, "failed to store retrieved license to local storage")
+		if err != nil {
+			c.logger.Error(err, "failed to store retrieved license to local storage")
+		}
 	}
 
 	return l, nil

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -25,7 +25,7 @@ const (
 	// ManagedByLabel is the label key to mark that the object is managed by a specific controller.
 	ManagedByLabel = LabelPrefix + ManagedByKey
 	// ManagedByLabelValueIngressController is the label value that marks the object is managed byu KIC.
-	ManagedByLabelValueIngressController = LabelPrefix + "/ingress-controller"
+	ManagedByLabelValueIngressController = "kong-ingress-controller"
 )
 
 // ValidateType indicates the type of validation applied to a Secret.

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -24,7 +24,7 @@ const (
 
 	// ManagedByLabel is the label key to mark that the object is managed by a specific controller.
 	ManagedByLabel = LabelPrefix + ManagedByKey
-	// ManagedByLabelValueIngressController is the label value that marks the object is managed byu KIC.
+	// ManagedByLabelValueIngressController is the label value that marks the object is managed by KIC.
 	ManagedByLabelValueIngressController = "kong-ingress-controller"
 )
 

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -122,6 +123,15 @@ func TestKonnectLicenseActivation(t *testing.T) {
 		}
 		return license.License.Expiration != ""
 	}, adminAPIWait, time.Second)
+
+	skipTestIfControllerVersionBelow(t, semver.MustParse("3.5.1"))
+	t.Log("checking if the license is stored in the local secret")
+	secret, err := env.Cluster().Client().CoreV1().Secrets(namespace).Get(
+		ctx, "konnect-license-"+rgID, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, secret.Data, "secret to store Konnect license should not be empty")
+	require.NotEmpty(t, secret.Data["id"], "stored license should have a non-empty ID")
+
 	t.Log("done")
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -189,8 +189,6 @@ func extractVersionFromImage(imageName string) (semver.Version, error) {
 // below the minVersion.
 // if the override KIC image is not set, it assumes that the latest image is used, so it never skips
 // the test if override image is not given.
-//
-//lint:ignore U1000 retained for future use
 func skipTestIfControllerVersionBelow(t *testing.T, minVersion semver.Version) {
 	if testenv.ControllerImageTag() == "" {
 		return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
The `Secret` to store Konnect licenses was using an invalid label value causing that the `Secret` cannot be created/updated.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
