### PR TITLE
chore: fix kubernetes-configuration CRD installation in integration tests

### DIFF
--- a/test/util/crds.go
+++ b/test/util/crds.go
@@ -23,16 +23,16 @@ func DeployCRDsForCluster(ctx context.Context, cluster clusters.Cluster) error {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Kong CRDs to cluster\n")
+	fmt.Printf("INFO: deploying Kong CRDs (%s) to cluster\n", kongCRDsKustomize)
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongCRDsKustomize); err != nil {
 		return err
 	}
-	fmt.Printf("INFO: deploying Kong incubator CRDs to cluster\n")
+	fmt.Printf("INFO: deploying Kong incubator CRDs (%s) to cluster\n", kongIncubatorCRDsKustomize)
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, kongIncubatorCRDsKustomize); err != nil {
 		return err
 	}
 
-	fmt.Printf("INFO: deploying Gateway CRDs to cluster\n")
+	fmt.Printf("INFO: deploying Gateway CRDs (%s) to cluster\n", consts.GatewayExperimentalCRDsKustomizeURL)
 	if err := clusters.KustomizeDeployForCluster(ctx, cluster, consts.GatewayExperimentalCRDsKustomizeURL); err != nil {
 		return err
 	}

--- a/test/util/gomod_test.go
+++ b/test/util/gomod_test.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHashFromPseudoVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		pseudoVersion string
+		expectedHash  string
+		expectedOK    bool
+	}{
+		{
+			name:          "valid pseudo version",
+			pseudoVersion: "v1.1.1-20250217181409-44e5ddce290d",
+			expectedHash:  "44e5ddce290d",
+			expectedOK:    true,
+		},
+		{
+			name:          "valid pseudo version with different format",
+			pseudoVersion: "v0.2.3-20210101120000-abcdef123456",
+			expectedHash:  "abcdef123456",
+			expectedOK:    true,
+		},
+		{
+			name:          "regular version tag",
+			pseudoVersion: "v1.2.3",
+			expectedHash:  "",
+			expectedOK:    false,
+		},
+		{
+			name:          "invalid version format",
+			pseudoVersion: "invalid-version",
+			expectedHash:  "",
+			expectedOK:    false,
+		},
+		{
+			name:          "empty string",
+			pseudoVersion: "",
+			expectedHash:  "",
+			expectedOK:    false,
+		},
+		{
+			name:          "pseudo version with multiple hyphens",
+			pseudoVersion: "v1.0.0-rc1-0.20250101000000-abc123def456",
+			expectedHash:  "abc123def456",
+			expectedOK:    true,
+		},
+		{
+			name:          "semver alpha",
+			pseudoVersion: "v1.0.0-alpha.0",
+			expectedHash:  "",
+			expectedOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash, ok := GetHashFromPseudoVersion(tt.pseudoVersion)
+			require.Equal(t, tt.expectedOK, ok)
+			require.Equal(t, tt.expectedHash, hash)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`>= 2` was making the code to split the alpha/beta/rc versions (returning empty string from `DependencyModuleVersionGit` which when passed to `kustomize` gets the latest version of provided module) where in reality this was only meant to do so for Go mod pseudo versions.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

Additionally now the version of a module from which the CRDs are being installed is printed in the logs:

```
INFO: deploying Kong CRDs (github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=v2.0.0-alpha.1) to cluster
INFO: deploying Kong incubator CRDs (github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=v2.0.0-alpha.1) to cluster
INFO: deploying Gateway CRDs (github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.3.0) to cluster
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
