### PR TITLE
fix(translator): check gateway class and do not skip listeners when gateway class is not managed by KIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,15 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
+- Do not skip the gateway listeners without `Programmed` condition set to `True`
+  when the gateway class does not contain `konghq.com/gateway-unmanaged`
+  annotation in extracting certificates from listeners. This fixes the issue
+  that KIC deletes the certificates of listeners on dataplane pods deleted when
+  KIC is running under the control of Kong gateway operator.
+  [#7666](https://github.com/Kong/kubernetes-ingress-controller/pull/7666)
 - Fix the issue that invalid label value causing KIC failed to store the license
-from Konnect into `Secret`.
-[#7648](https://github.com/Kong/kubernetes-ingress-controller/pull/7648)
+  from Konnect into `Secret`.
+  [#7648](https://github.com/Kong/kubernetes-ingress-controller/pull/7648)
 
 ## [3.5.0]
 

--- a/hack/generators/cache-stores/spec.go
+++ b/hack/generators/cache-stores/spec.go
@@ -61,6 +61,11 @@ var supportedTypes = []cacheStoreSupportedType{
 		Package: "gatewayapi",
 	},
 	{
+		Type:    "GatewayClass",
+		Package: "gatewayapi",
+		KeyFunc: clusterWideKeyFunc,
+	},
+	{
 		Type:    "BackendTLSPolicy",
 		Package: "gatewayapi",
 	},

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -143,6 +143,8 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Log:              r.Log.WithName(strings.ToUpper(gatewayapi.V1GroupVersion) + "GatewayClass"),
 		Scheme:           r.Scheme,
 		CacheSyncTimeout: r.CacheSyncTimeout,
+
+		DataplaneClient: r.DataplaneClient,
 	}
 
 	return gwcCTRL.SetupWithManager(mgr)
@@ -440,11 +442,6 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		debug(log, gateway, "Ensured gateway was removed from the data-plane (if ever present)")
 		return ctrl.Result{}, nil
-	}
-	err := r.DataplaneClient.UpdateObject(gwc)
-	if err != nil {
-		debug(log, gwc, "Failed to update GatewayClass in dataplane, requeueing")
-		return ctrl.Result{}, err
 	}
 
 	// if there's any deletion timestamp on the object, we can simply ignore it. At this point

--- a/internal/controllers/gateway/gateway_controller.go
+++ b/internal/controllers/gateway/gateway_controller.go
@@ -181,6 +181,7 @@ func (r *GatewayReconciler) gatewayHasMatchingGatewayClass(obj client.Object) bo
 		r.Log.Error(err, "Could not retrieve gatewayclass", "gatewayclass", gateway.Spec.GatewayClassName)
 		return false
 	}
+
 	return isGatewayClassControlled(gatewayClass)
 }
 
@@ -439,6 +440,11 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		debug(log, gateway, "Ensured gateway was removed from the data-plane (if ever present)")
 		return ctrl.Result{}, nil
+	}
+	err := r.DataplaneClient.UpdateObject(gwc)
+	if err != nil {
+		debug(log, gwc, "Failed to update GatewayClass in dataplane, requeueing")
+		return ctrl.Result{}, err
 	}
 
 	// if there's any deletion timestamp on the object, we can simply ignore it. At this point

--- a/internal/dataplane/fallback/graph_dependencies.go
+++ b/internal/dataplane/fallback/graph_dependencies.go
@@ -62,6 +62,7 @@ func ResolveDependencies(cache store.CacheStores, obj client.Object) ([]client.O
 		*discoveryv1.EndpointSlice,
 		*gatewayapi.ReferenceGrant,
 		*gatewayapi.Gateway,
+		*gatewayapi.GatewayClass,
 		*gatewayapi.BackendTLSPolicy,
 		*configurationv1.KongIngress,
 		*configurationv1beta1.KongUpstreamPolicy,

--- a/internal/dataplane/translator/translate_certs.go
+++ b/internal/dataplane/translator/translate_certs.go
@@ -79,9 +79,10 @@ func (t *Translator) getGatewayCerts() []certWrapper {
 				continue
 			}
 
-			// Check if listener is marked as programmed when the gateway is controlled by KIC in its spec and has the "Unmanaged" annotation.
-			// If the GatewayClass is does not satify the condition, the gateway is considered to be managed by other components (for example Kong Oprator),
-			// So we do not check the "Programmed" condition before extracting the certificate from the listener.
+			// Check if listener is marked as programmed when the gateway is controlled by KIC  and corresponding GatewayClass has the "Unmanaged" annotation.
+			// If the GatewayClass does not satisfy the condition, the gateway is considered to be managed by other components (for example Kong Operator),
+			// so we do not check the "Programmed" condition before extracting the certificate from the listener
+			// to prevent unexpected deletion of certificates when the instancec is managed by Kong Operator.
 			if gwc.Spec.ControllerName == gatewayapi.GatewayController(t.gatewayControllerName) &&
 				annotations.ExtractUnmanagedGatewayClassMode(gwc.Annotations) != "" &&
 				!util.CheckCondition(

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -123,7 +123,7 @@ type Config struct {
 	ClusterDomain string
 
 	// GatewayControllerName is the gateway controller name used by KIC.
-	// GatewayClasses with this controller name in spec.ControllerName are managed by KIC, otherwise they are managed by other components(like Kong Operator).
+	// GatewayClasses with this controller name in spec.ControllerName are managed by KIC, otherwise they are managed by other  (like Kong Operator).
 	GatewayControllerName string
 }
 

--- a/internal/dataplane/translator/translator.go
+++ b/internal/dataplane/translator/translator.go
@@ -109,8 +109,9 @@ type Translator struct {
 	failuresCollector          *failures.ResourceFailuresCollector
 	translatedObjectsCollector *ObjectsCollector
 
-	clusterDomain      string
-	enableDrainSupport bool
+	clusterDomain         string
+	enableDrainSupport    bool
+	gatewayControllerName string
 }
 
 // Config is a configuration for the Translator.
@@ -120,6 +121,10 @@ type Config struct {
 
 	// ClusterDomain is the cluster domain used for translating Kubernetes objects.
 	ClusterDomain string
+
+	// GatewayControllerName is the gateway controller name used by KIC.
+	// GatewayClasses with this controller name in spec.ControllerName are managed by KIC, otherwise they are managed by other components(like Kong Operator).
+	GatewayControllerName string
 }
 
 // NewTranslator produces a new Translator object provided a logging mechanism
@@ -152,6 +157,7 @@ func NewTranslator(
 		translatedObjectsCollector: translatedObjectsCollector,
 		clusterDomain:              config.ClusterDomain,
 		enableDrainSupport:         config.EnableDrainSupport,
+		gatewayControllerName:      config.GatewayControllerName,
 	}, nil
 }
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -221,8 +221,9 @@ func New(
 
 	configTranslator, err := translator.NewTranslator(logger, storer, c.KongWorkspace, kongSemVersion, translatorFeatureFlags, NewSchemaServiceGetter(clientsManager),
 		translator.Config{
-			ClusterDomain:      c.ClusterDomain,
-			EnableDrainSupport: c.EnableDrainSupport,
+			ClusterDomain:         c.ClusterDomain,
+			EnableDrainSupport:    c.EnableDrainSupport,
+			GatewayControllerName: c.GatewayAPIControllerName,
 		},
 	)
 	if err != nil {

--- a/internal/store/fake_store.go
+++ b/internal/store/fake_store.go
@@ -41,6 +41,7 @@ type FakeObjects struct {
 	GRPCRoutes                     []*gatewayapi.GRPCRoute
 	ReferenceGrants                []*gatewayapi.ReferenceGrant
 	Gateways                       []*gatewayapi.Gateway
+	GatewayClasses                 []*gatewayapi.GatewayClass
 	BackendTLSPolicies             []*gatewayapi.BackendTLSPolicy
 	TCPIngresses                   []*configurationv1beta1.TCPIngress
 	UDPIngresses                   []*configurationv1beta1.UDPIngress

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,6 +99,7 @@ type Storer interface {
 
 	// Gateway API resources.
 	GetGateway(namespace string, name string) (*gatewayapi.Gateway, error)
+	GetGatewayClass(name string) (*gatewayapi.GatewayClass, error)
 	ListHTTPRoutes() ([]*gatewayapi.HTTPRoute, error)
 	ListUDPRoutes() ([]*gatewayapi.UDPRoute, error)
 	ListTCPRoutes() ([]*gatewayapi.TCPRoute, error)
@@ -605,6 +606,18 @@ func (s Store) GetGateway(namespace string, name string) (*gatewayapi.Gateway, e
 		return nil, NotFoundError{fmt.Sprintf("Gateway %v not found", name)}
 	}
 	return obj.(*gatewayapi.Gateway), nil
+}
+
+// GetGatewayClass returns gatewayclass resource having the specified name.
+func (s Store) GetGatewayClass(name string) (*gatewayapi.GatewayClass, error) {
+	obj, exists, err := s.stores.GatewayClass.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, NotFoundError{fmt.Sprintf("GatewayClass %v not found", name)}
+	}
+	return obj.(*gatewayapi.GatewayClass), nil
 }
 
 // GetKongVault returns kongvault resource having specified name.

--- a/internal/store/zz_generated.cache_stores.go
+++ b/internal/store/zz_generated.cache_stores.go
@@ -36,6 +36,7 @@ type CacheStores struct {
 	GRPCRoute                      cache.Store
 	ReferenceGrant                 cache.Store
 	Gateway                        cache.Store
+	GatewayClass                   cache.Store
 	BackendTLSPolicy               cache.Store
 	Plugin                         cache.Store
 	ClusterPlugin                  cache.Store
@@ -69,6 +70,7 @@ func NewCacheStores() CacheStores {
 		GRPCRoute:                      cache.NewStore(namespacedKeyFunc),
 		ReferenceGrant:                 cache.NewStore(namespacedKeyFunc),
 		Gateway:                        cache.NewStore(namespacedKeyFunc),
+		GatewayClass:                   cache.NewStore(clusterWideKeyFunc),
 		BackendTLSPolicy:               cache.NewStore(namespacedKeyFunc),
 		Plugin:                         cache.NewStore(namespacedKeyFunc),
 		ClusterPlugin:                  cache.NewStore(clusterWideKeyFunc),
@@ -119,6 +121,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.ReferenceGrant.Get(obj)
 	case *gatewayapi.Gateway:
 		return c.Gateway.Get(obj)
+	case *gatewayapi.GatewayClass:
+		return c.GatewayClass.Get(obj)
 	case *gatewayapi.BackendTLSPolicy:
 		return c.BackendTLSPolicy.Get(obj)
 	case *kongv1.KongPlugin:
@@ -182,6 +186,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.ReferenceGrant.Add(obj)
 	case *gatewayapi.Gateway:
 		return c.Gateway.Add(obj)
+	case *gatewayapi.GatewayClass:
+		return c.GatewayClass.Add(obj)
 	case *gatewayapi.BackendTLSPolicy:
 		return c.BackendTLSPolicy.Add(obj)
 	case *kongv1.KongPlugin:
@@ -245,6 +251,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.ReferenceGrant.Delete(obj)
 	case *gatewayapi.Gateway:
 		return c.Gateway.Delete(obj)
+	case *gatewayapi.GatewayClass:
+		return c.GatewayClass.Delete(obj)
 	case *gatewayapi.BackendTLSPolicy:
 		return c.BackendTLSPolicy.Delete(obj)
 	case *kongv1.KongPlugin:
@@ -291,6 +299,7 @@ func (c CacheStores) ListAllStores() []cache.Store {
 		c.GRPCRoute,
 		c.ReferenceGrant,
 		c.Gateway,
+		c.GatewayClass,
 		c.BackendTLSPolicy,
 		c.Plugin,
 		c.ClusterPlugin,
@@ -323,6 +332,7 @@ func (c CacheStores) SupportedTypes() []client.Object {
 		&gatewayapi.GRPCRoute{},
 		&gatewayapi.ReferenceGrant{},
 		&gatewayapi.Gateway{},
+		&gatewayapi.GatewayClass{},
 		&gatewayapi.BackendTLSPolicy{},
 		&kongv1.KongPlugin{},
 		&kongv1.KongClusterPlugin{},

--- a/internal/store/zz_generated.cache_stores_test.go
+++ b/internal/store/zz_generated.cache_stores_test.go
@@ -91,6 +91,11 @@ func TestCacheStores(t *testing.T) {
 		},
 
 		{
+			name:          "GatewayClass",
+			objectToStore: &gatewayapi.GatewayClass{},
+		},
+
+		{
 			name:          "BackendTLSPolicy",
 			objectToStore: &gatewayapi.BackendTLSPolicy{},
 		},


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Do not skip checking certificates in gateway listeners that does not has "Programmed" condition if the `GatewayClass` is not managed by KIC. The change fixes an issue when KIC is deployed by gateway operator, certificates gets deleted when dataplane (Kong gateway) pods are changed.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

fixes #7660 (then also https://github.com/Kong/kong-operator/issues/1769)

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
