### PR TITLE
fix: Do not add request-termination on TLSRoute / TCPRoute

### DIFF
--- a/internal/dataplane/translator/translate_utils.go
+++ b/internal/dataplane/translator/translate_utils.go
@@ -79,13 +79,15 @@ func generateKongServiceFromBackendRefWithName(
 		if service.Plugins == nil {
 			service.Plugins = make([]kong.Plugin, 0)
 		}
-		service.Plugins = append(service.Plugins, kong.Plugin{
-			Name: kong.String("request-termination"),
-			Config: kong.Configuration{
-				"status_code": 500,
-				"message":     "no existing backendRef provided",
-			},
-		})
+		if strings.Contains(service.Service.Protocol, "http") || strings.Contains(service.Service.Protocol, "grpc") {
+			service.Plugins = append(service.Plugins, kong.Plugin{
+				Name: kong.String("request-termination"),
+				Config: kong.Configuration{
+					"status_code": 500,
+					"message":     "no existing backendRef provided",
+				},
+			})
+		}
 	}
 
 	return service, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->
The request-termination was added to return 500 error when no backendRef is provided, this should not be done on TLS/TCP route as HTTP errors are not valid with those protocols. Also the request-termination plugin is only accepting HTTP/HTTPS/GRPC/GRPCS

https://developer.konghq.com/plugins/request-termination/reference/

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
https://github.com/Kong/kubernetes-ingress-controller/issues/7699

#fix 7699

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
