### PR TITLE
ci: fix .github/workflows/validate_kong_image_trigger_via_label.yaml workflow

### DIFF
--- a/.github/workflows/validate_kong_image_trigger_via_label.yaml
+++ b/.github/workflows/validate_kong_image_trigger_via_label.yaml
@@ -64,7 +64,7 @@ jobs:
           BODY: ${{ github.event.issue.body }}
         # Fail the job if we cannot get "### Container image" keyword from issue body.
         run: |
-          kong_container_image=$(echo ${{ env.BODY }} | grep -A 2 '### Container image' | tail -n 1) && \
+          kong_container_image=$(echo "${{ env.BODY }}" | grep -A 2 '### Container image' | tail -n 1) && \
           echo "TEST_KONG_CONTAINER_IMAGE=${kong_container_image}" >> $GITHUB_ENV
       
       # Split the container into repo and tag by ":" and then extract the first 3 segments of tags as its version.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/20269645552/job/58201754548

```
Run kong_container_image=$(echo ### What component needs testing with KIC?
  kong_container_image=$(echo ### What component needs testing with KIC?
  
  Kong Gateway EE
  
  ### Container image
  
  kong/kong-gateway-dev:3.13.0.0-rc.4
  
  ### Additional information
  
  _No response_ | grep -A 2 '### Container image' | tail -n 1) && \
  echo "TEST_KONG_CONTAINER_IMAGE=${kong_container_image}" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    BODY: ### What component needs testing with KIC?
  
  Kong Gateway EE
  
  ### Container image
  
  kong/kong-gateway-dev:3.13.0.0-rc.4
  
  ### Additional information
  
  _No response_
/home/runner/work/_temp/30b23a4a-37a3-4dfc-8ec9-cc3b89eab4dc.sh: line 12: Kong: command not found
/home/runner/work/_temp/30b23a4a-37a3-4dfc-8ec9-cc3b89eab4dc.sh: line 13: kong/kong-gateway-dev:3.13.0.0-rc.4: No such file or directory
/home/runner/work/_temp/30b23a4a-37a3-4dfc-8ec9-cc3b89eab4dc.sh: line 14: _No: command not found

Run kong_image_repo=$(echo ${TEST_KONG_CONTAINER_IMAGE} | awk -F':' '{print $1}')
  kong_image_repo=$(echo ${TEST_KONG_CONTAINER_IMAGE} | awk -F':' '{print $1}')
  # Limit kong image repo in [kong,kong/kong-gateway,kong/kong-gateway-dev] to prevent from attack of running unknown images
  if [ "$kong_image_repo" != "kong" ] && [  "$kong_image_repo" != "kong/kong-gateway" ] && [ "$kong_image_repo" != "kong/kong-gateway-dev" ]; then
    echo "invalid image repo: $kong_image_repo"
    exit 1
  fi
  echo "TEST_KONG_IMAGE_REPO=$kong_image_repo" >> $GITHUB_OUTPUT
  kong_image_tag=$(echo ${TEST_KONG_CONTAINER_IMAGE} | awk -F':' '{print $2}')
  echo "TEST_KONG_IMAGE_TAG=${kong_image_tag}" >> $GITHUB_OUTPUT
  kong_image_version=$(echo ${kong_image_tag} | awk -F'.' '{printf("%s.%s.%s",$1,$2,$3)}')
  echo "TEST_KONG_IMAGE_VERSION=${kong_image_version}" >> $GITHUB_ENV 
  echo "TEST_KONG_IMAGE_VERSION=${kong_image_version}" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
  env:
    TEST_KONG_CONTAINER_IMAGE: 
invalid image repo: 
```


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
