### PR TITLE
ci: fix args passed to .github/workflows/validate_kong_image_trigger_via_label.yaml workflow

### DIFF
--- a/.github/workflows/validate_kong_image_trigger_via_label.yaml
+++ b/.github/workflows/validate_kong_image_trigger_via_label.yaml
@@ -157,8 +157,8 @@ jobs:
         id: run_validate_kong_image
         run: |
           gh workflow run ${WORKFLOW} --ref ${KIC_BRANCH} \
-            -f issue_number=${ISSUE_NUMBER} \
-            -f kong_image_repo=${TEST_KONG_IMAGE_REPO} \
-            -f kong_image_tag=${TEST_KONG_IMAGE_TAG} \
-            -f kong_effective_version=${TEST_KONG_IMAGE_VERSION} \
-            -f e2e_controller_image_tag=${KIC_IMAGE_TAG}
+            -f issue-number=${ISSUE_NUMBER} \
+            -f kong-image-repo=${TEST_KONG_IMAGE_REPO} \
+            -f kong-image-tag=${TEST_KONG_IMAGE_TAG} \
+            -f kong-effective-version=${TEST_KONG_IMAGE_VERSION} \
+            -f e2e-controller-image-tag=${KIC_IMAGE_TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/20272358533/job/58211491984

```
gh workflow run ${WORKFLOW} --ref ${KIC_BRANCH} \
    -f issue_number=${ISSUE_NUMBER} \
    -f kong_image_repo=${TEST_KONG_IMAGE_REPO} \
    -f kong_image_tag=${TEST_KONG_IMAGE_TAG} \
    -f kong_effective_version=${TEST_KONG_IMAGE_VERSION} \
    -f e2e_controller_image_tag=${KIC_IMAGE_TAG}
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
    WORKFLOW: .github/workflows/validate_kong_image.yaml
    ISSUE_NUMBER: 7815
    TEST_KONG_IMAGE_REPO: kong/kong-gateway-dev
    TEST_KONG_IMAGE_TAG: 3.13.0.0-rc.4
    TEST_KONG_IMAGE_VERSION: 3.13.0
    KIC_BRANCH: main
    KIC_IMAGE_TAG: latest
could not create workflow dispatch event: HTTP 422: Unexpected inputs provided: ["e2e_controller_image_tag", "issue_number", "kong_effective_version", "kong_image_repo", "kong_image_tag"] (https://api.github.com/repos/Kong/kubernetes-ingress-controller/actions/workflows/57531601/dispatches)
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
