### PR TITLE
test(isolated_integration): Bump source version of KIC upgrade test

### DIFF
--- a/test/integration/isolated/upgrade_test.go
+++ b/test/integration/isolated/upgrade_test.go
@@ -44,7 +44,9 @@ var (
 
 const (
 	defaultOldKICImageRepo = "kong/kubernetes-ingress-controller"
-	defaultOldKICImageTag  = "3.4.4"
+	// Use the version that sets routes' protocol to `http,https` explicitly
+	// to be compatible with newer version of Kong gateway that sets the default protocols to `https` only.
+	defaultOldKICImageTag = "3.4.12"
 )
 
 func TestUpgradeKICWithExistingPlugins(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Bump the source version of KIC upgrade test to `3.4.12` that sets `protocols` of translated routes to `http,https` in expression based routes to be compatible with newer verion of Kong gateway. 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
