### PR TITLE
Revert "Fix: set protocols in translated expression based routes (#7860) (#7863)"

### DIFF
--- a/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/grpcroute-example/expression-routes-on_golden.yaml
@@ -19,9 +19,6 @@ services:
     name: grpcroute.default.grpcbin.example.com.2.0
     preserve_host: true
     priority: 26766487871743
-    protocols:
-    - http
-    - https
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default
@@ -57,9 +54,6 @@ services:
     name: grpcroute.default.grpcbin.example.com.1.0
     preserve_host: true
     priority: 26766487904511
-    protocols:
-    - http
-    - https
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default
@@ -95,9 +89,6 @@ services:
     name: grpcroute.default.grpcbin.example.com.0.0
     preserve_host: true
     priority: 26766487929087
-    protocols:
-    - http
-    - https
     tags:
     - k8s-name:grpcbin
     - k8s-namespace:default

--- a/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-example/expression-routes-on_golden.yaml
@@ -15,9 +15,6 @@ services:
     name: httproute.default.httproute-testing._.3.0
     preserve_host: true
     priority: 35184414035967
-    protocols:
-    - http
-    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing
@@ -46,9 +43,6 @@ services:
     name: httproute.default.httproute-testing._.2.0
     preserve_host: true
     priority: 35184430813183
-    protocols:
-    - http
-    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing
@@ -63,9 +57,6 @@ services:
     name: httproute.default.httproute-testing._.1.0
     preserve_host: true
     priority: 35184405647359
-    protocols:
-    - http
-    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing
@@ -95,9 +86,6 @@ services:
     name: httproute.default.httproute-testing._.0.0
     preserve_host: true
     priority: 35184514699263
-    protocols:
-    - http
-    - https
     strip_path: true
     tags:
     - k8s-name:httproute-testing

--- a/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/httproute-url-rewrite-path-prefix/expression-routes-on_golden.yaml
@@ -26,9 +26,6 @@ services:
       - k8s-version:v1
     preserve_host: true
     priority: 35184422424575
-    protocols:
-    - http
-    - https
     strip_path: false
     tags:
     - k8s-name:httproute-testing

--- a/internal/dataplane/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-empty-path/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899611649
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-multiple-ports-for-one-service/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.foo.foo-svc.example.net.8000
     preserve_host: true
     priority: 57178899611649
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -52,9 +49,6 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899611649
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-ports-defined-by-name/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.regex-prefix.foo-svc.example.com.http
     preserve_host: true
     priority: 57178899611649
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-regex-prefix-exact-rule/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677193
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-regex-prefixed-path/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.regex-prefix.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677194
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_golden.yaml
@@ -71,9 +71,6 @@ services:
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -91,9 +91,6 @@ services:
     name: bar-namespace.ing-with-tls.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-single-service-in-multiple-ingresses/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -34,9 +31,6 @@ services:
     name: foo-namespace.foo-2.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-with-acme-like-path/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.foo.cert-manager-solver-pod.example.com.80
     preserve_host: true
     priority: 57178899611680
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-with-default-backend/expression-routes-on_golden.yaml
@@ -16,9 +16,6 @@ services:
     name: foo-namespace.foo.foo-svc.example.com.80
     preserve_host: true
     priority: 57178899677185
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -50,9 +47,6 @@ services:
     name: bar-namespace.ing-with-default-backend
     preserve_host: true
     priority: 0
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/kong-service-facade/expression-routes-on_golden.yaml
@@ -35,9 +35,6 @@ services:
     name: default.beta
     preserve_host: true
     priority: 0
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -70,9 +67,6 @@ services:
     name: default.beta..svc-facade-beta.svc.facade
     preserve_host: true
     priority: 54975581454341
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false
@@ -105,9 +99,6 @@ services:
     name: default.alpha..svc-facade-alpha.svc.facade
     preserve_host: true
     priority: 54975581454342
-    protocols:
-    - http
-    - https
     request_buffering: true
     response_buffering: true
     strip_path: false

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc.go
@@ -39,8 +39,7 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 		r := kongstate.Route{
 			Ingress: ingressObjectInfo,
 			Route: kong.Route{
-				Name:      kong.String(routeName),
-				Protocols: kong.StringSlice("http", "https"),
+				Name: kong.String(routeName),
 			},
 			ExpressionRoutes: true,
 		}
@@ -63,8 +62,7 @@ func GenerateKongExpressionRoutesFromGRPCRouteRule(grpcroute *gatewayapi.GRPCRou
 		r := kongstate.Route{
 			Ingress: ingressObjectInfo,
 			Route: kong.Route{
-				Name:      kong.String(routeName),
-				Protocols: kong.StringSlice("http", "https"),
+				Name: kong.String(routeName),
 			},
 			ExpressionRoutes: true,
 		}
@@ -479,7 +477,6 @@ func KongExpressionRouteFromSplitGRPCRouteMatchWithPriority(
 	r := kongstate.Route{
 		Route: kong.Route{
 			Name:         kong.String(routeName),
-			Protocols:    kong.StringSlice("http", "https"),
 			PreserveHost: kong.Bool(true),
 			Tags:         tags,
 		},

--- a/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/grpcroute_atc_test.go
@@ -57,7 +57,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.single-match.0.0"),
-						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path ^= "/service0/") && (http.headers.x_foo == "Bar")`),
 						Priority:   kong.Uint64(1),
 					},
@@ -90,7 +89,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.single-match-with-hostname.0.0"),
-						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path == "/service0/method0") && ((http.host == "foo.com") || (http.host =^ ".foo.com"))`),
 						Priority:   kong.Uint64(1),
 					},
@@ -136,7 +134,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.multiple-matches.0.0"),
-						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path =^ "/method0") && ((http.headers.client == "kong-test") && (http.headers.version == "2"))`),
 						Priority:   kong.Uint64(1),
 					},
@@ -150,7 +147,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.multiple-matches.0.1"),
-						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`http.path ~ "^/v[012]/.+"`),
 						Priority:   kong.Uint64(1),
 					},
@@ -190,7 +186,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.single-match-with-annotations.0.0"),
-						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`(http.path == "/service0/method0") && (tls.sni == "kong.foo.com")`),
 						Priority:   kong.Uint64(1),
 					},
@@ -214,7 +209,6 @@ func TestGenerateKongExpressionRoutesFromGRPCRouteRule(t *testing.T) {
 					ExpressionRoutes: true,
 					Route: kong.Route{
 						Name:       kong.String("grpcroute.default.hostname-only.0.0"),
-						Protocols:  kong.StringSlice("http", "https"),
 						Expression: kong.String(`http.host == "foo.com"`),
 						Priority:   kong.Uint64(1),
 					},
@@ -1124,7 +1118,6 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.no-hostname-exact-method._.0.0"),
-					Protocols:    kong.StringSlice("http", "https"),
 					PreserveHost: kong.Bool(true),
 					Expression:   kong.String(`http.path == "/pets/list"`),
 					Priority:     kong.Uint64(1 << 14),
@@ -1177,7 +1170,6 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.precise-hostname-regex-method.foo.com.0.0"),
-					Protocols:    kong.StringSlice("http", "https"),
 					Expression:   kong.String(`(http.path ~ "^/name/[a-z0-9]+") && (http.host == "foo.com")`),
 					PreserveHost: kong.Bool(true),
 					Priority:     kong.Uint64((1 << 31) + 1),
@@ -1247,7 +1239,6 @@ func TestKongExpressionRouteFromSplitGRPCRouteWithPriority(t *testing.T) {
 			expectedRoute: kongstate.Route{
 				Route: kong.Route{
 					Name:         kong.String("grpcroute.default.wildcard-hostname-header-match._.foo.com.0.1"),
-					Protocols:    kong.StringSlice("http", "https"),
 					Expression:   kong.String(`(http.path ^= "/name/") && (http.headers.foo == "bar") && (http.host =^ ".foo.com")`),
 					PreserveHost: kong.Bool(true),
 					Priority:     kong.Uint64((1 << 42) + 1),

--- a/internal/dataplane/translator/subtranslator/httproute_atc.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc.go
@@ -501,7 +501,6 @@ func kongExpressionRouteFromHTTPRouteMatchWithPriority(
 		Route: kong.Route{
 			Name:         kong.String(routeName),
 			PreserveHost: kong.Bool(true),
-			Protocols:    kong.StringSlice("http", "https"),
 			// stripPath needs to be disabled by default to be conformant with the Gateway API
 			StripPath: kong.Bool(false),
 			Tags:      tags,

--- a/internal/dataplane/translator/subtranslator/httproute_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/httproute_atc_test.go
@@ -1218,7 +1218,6 @@ func TestKongExpressionRouteFromHTTPRouteMatchWithPriority(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.routeName, *route.Name, "Should have expected route name")
-			require.ElementsMatch(t, lo.ToSlicePtr([]string{"http", "https"}), route.Protocols)
 			require.True(t, route.ExpressionRoutes, "Should be expression route")
 			require.Equal(t, tc.routeExpresion, *route.Expression, "Should translate to expected expression")
 			require.Equal(t, tc.priority, *route.Priority, "Should have expected priority")

--- a/internal/dataplane/translator/subtranslator/ingress_atc.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc.go
@@ -42,7 +42,6 @@ func (m *ingressTranslationMeta) translateIntoKongExpressionRoute() *kongstate.R
 		Ingress: util.FromK8sObject(m.parentIngress),
 		Route: kong.Route{
 			Name:              kong.String(routeName),
-			Protocols:         kong.StringSlice("http", "https"),
 			StripPath:         kong.Bool(false),
 			PreserveHost:      kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),

--- a/internal/dataplane/translator/subtranslator/ingress_atc_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_atc_test.go
@@ -82,7 +82,6 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.test-service.konghq.com.80"),
-							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && ((http.path == "/api") || (http.path ^= "/api/"))`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   2,
@@ -159,7 +158,6 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.test-service.konghq.com.80"),
-							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/")`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   2,
@@ -246,7 +244,6 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress-annotations.test-service.konghq.com.80"),
-							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/") && (http.headers.foo == "bar") && (http.method == "GET")`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   4,
@@ -351,7 +348,6 @@ func TestTranslateIngressATC(t *testing.T) {
 						},
 						Route: kong.Route{
 							Name:       kong.String("default.test-ingress.konghq.com.svc-facade.svc.facade"),
-							Protocols:  kong.StringSlice("http", "https"),
 							Expression: kong.String(`(http.host == "konghq.com") && (http.path ^= "/api/")`),
 							Priority: kong.Uint64(IngressRoutePriorityTraits{
 								MatchFields:   2,

--- a/internal/dataplane/translator/translate_ingress.go
+++ b/internal/dataplane/translator/translate_ingress.go
@@ -245,7 +245,6 @@ func translateIngressDefaultBackendRoute(ingress *netv1.Ingress, tags []*string,
 		Ingress: util.FromK8sObject(ingress),
 		Route: kong.Route{
 			Name:              kong.String(ingress.Namespace + "." + ingress.Name),
-			Protocols:         kong.StringSlice("http", "https"),
 			StripPath:         kong.Bool(false),
 			PreserveHost:      kong.Bool(true),
 			RequestBuffering:  kong.Bool(true),
@@ -263,6 +262,7 @@ func translateIngressDefaultBackendRoute(ingress *netv1.Ingress, tags []*string,
 		atc.ApplyExpression(&r.Route, catchAllMatcher, subtranslator.IngressDefaultBackendPriority)
 	} else {
 		r.Paths = kong.StringSlice("/")
+		r.Protocols = kong.StringSlice("http", "https")
 		r.RegexPriority = kong.Int(0)
 	}
 	return r

--- a/internal/dataplane/translator/translate_ingress_test.go
+++ b/internal/dataplane/translator/translate_ingress_test.go
@@ -360,7 +360,6 @@ func TestGetDefaultBackendService(t *testing.T) {
 				require.Equal(t, tc.expectedServiceHost, *svc.Host)
 				require.Len(t, svc.Routes, 1)
 				route := svc.Routes[0]
-				require.ElementsMatch(t, lo.ToSlicePtr([]string{"http", "https"}), route.Protocols)
 				if tc.featureFlags.ExpressionRoutes {
 					require.Equal(t, `(http.path ^= "/") && ((net.protocol == "http") || (net.protocol == "https"))`, *route.Expression)
 					require.Equal(t, subtranslator.IngressDefaultBackendPriority, *route.Priority)


### PR DESCRIPTION
This reverts commit 2c637a25f2843831d305734e2eca5a99810e3b81.

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
