### PR TITLE
fix: prioritize exact Ingress regex routes

### DIFF
--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -234,8 +234,8 @@ func (i *ingressTranslationIndex) Translate() map[string]kongstate.Service {
 			route := meta.translateIntoKongExpressionRoute()
 			kongStateService.Routes = append(kongStateService.Routes, *route)
 		} else {
-			route := meta.translateIntoKongRoute()
-			kongStateService.Routes = append(kongStateService.Routes, *route)
+			routes := meta.translateIntoKongRoutes()
+			kongStateService.Routes = append(kongStateService.Routes, routes...)
 		}
 		sort.SliceStable(kongStateService.Routes, func(i, j int) bool {
 			return *kongStateService.Routes[i].Name < *kongStateService.Routes[j].Name
@@ -409,13 +409,38 @@ func (m *ingressTranslationMeta) generateKongServiceName() string {
 	)
 }
 
-func (m *ingressTranslationMeta) translateIntoKongRoute() *kongstate.Route {
+func (m *ingressTranslationMeta) translateIntoKongRoutes() []kongstate.Route {
+	pathsByRegexPriority := map[int][]netv1.HTTPIngressPath{}
+	regexPriorities := []int{}
+	for _, path := range m.paths {
+		regexPriority := regexPriorityFromIngressPath(path)
+		if _, ok := pathsByRegexPriority[regexPriority]; !ok {
+			regexPriorities = append(regexPriorities, regexPriority)
+		}
+		pathsByRegexPriority[regexPriority] = append(pathsByRegexPriority[regexPriority], path)
+	}
+	sort.Ints(regexPriorities)
+
+	routes := make([]kongstate.Route, 0, len(regexPriorities))
+	for _, regexPriority := range regexPriorities {
+		route := m.translateIntoKongRoute(
+			pathsByRegexPriority[regexPriority],
+			routeNameSuffixFromRegexPriority(regexPriority, len(regexPriorities)),
+		)
+		routes = append(routes, *route)
+	}
+
+	return routes
+}
+
+func (m *ingressTranslationMeta) translateIntoKongRoute(paths []netv1.HTTPIngressPath, routeNameSuffix string) *kongstate.Route {
 	ingressHost := m.ingressHost
 	if strings.Contains(ingressHost, "*") {
 		// '_' is not allowed in host, so we use '_' to replace '*' since '*' is not allowed in Kong.
 		ingressHost = strings.ReplaceAll(ingressHost, "*", "_")
 	}
 	routeName := m.backend.intoKongRouteName(k8stypes.NamespacedName{Namespace: m.ingressNamespace, Name: m.ingressName}, ingressHost)
+	routeName += routeNameSuffix
 
 	route := &kongstate.Route{
 		Ingress: util.FromK8sObject(m.parentIngress),
@@ -435,12 +460,12 @@ func (m *ingressTranslationMeta) translateIntoKongRoute() *kongstate.Route {
 		route.Hosts = append(route.Hosts, kong.String(m.ingressHost))
 	}
 
-	for _, httpIngressPath := range m.paths {
-		paths := PathsFromIngressPaths(httpIngressPath)
-		for i, path := range paths {
-			paths[i] = m.addRegexPrefixFn(*path)
+	for _, httpIngressPath := range paths {
+		routePaths := PathsFromIngressPaths(httpIngressPath)
+		for i, path := range routePaths {
+			routePaths[i] = m.addRegexPrefixFn(*path)
 		}
-		route.Paths = append(route.Paths, paths...)
+		route.Paths = append(route.Paths, routePaths...)
 		route.RegexPriority = kong.Int(max(*route.RegexPriority, regexPriorityFromIngressPath(httpIngressPath)))
 	}
 
@@ -502,6 +527,14 @@ func regexPriorityFromIngressPath(httpIngressPath netv1.HTTPIngressPath) int {
 	}
 
 	return len(httpIngressPath.Path)
+}
+
+func routeNameSuffixFromRegexPriority(regexPriority int, routeCount int) string {
+	if routeCount == 1 || regexPriority == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(".exact.%d", regexPriority)
 }
 
 func flattenMultipleSlashes(path string) string {

--- a/internal/dataplane/translator/subtranslator/ingress.go
+++ b/internal/dataplane/translator/subtranslator/ingress.go
@@ -441,6 +441,7 @@ func (m *ingressTranslationMeta) translateIntoKongRoute() *kongstate.Route {
 			paths[i] = m.addRegexPrefixFn(*path)
 		}
 		route.Paths = append(route.Paths, paths...)
+		route.RegexPriority = kong.Int(max(*route.RegexPriority, regexPriorityFromIngressPath(httpIngressPath)))
 	}
 
 	return route
@@ -493,6 +494,14 @@ func PathsFromIngressPaths(httpIngressPath netv1.HTTPIngressPath) []*string {
 
 	routePaths = append(routePaths, routeRegexPaths...)
 	return kong.StringSlice(routePaths...)
+}
+
+func regexPriorityFromIngressPath(httpIngressPath netv1.HTTPIngressPath) int {
+	if httpIngressPath.PathType == nil || *httpIngressPath.PathType != netv1.PathTypeExact {
+		return 0
+	}
+
+	return len(httpIngressPath.Path)
 }
 
 func flattenMultipleSlashes(path string) string {

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -692,19 +692,36 @@ func TestTranslateIngress(t *testing.T) {
 							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
+							Name:              kong.String("default.test-ingress.test-service.konghq.com.80.exact.13"),
+							Hosts:             kong.StringSlice("konghq.com"),
+							Paths:             kong.StringSlice("~/other/path/1$"),
+							PreserveHost:      kong.Bool(true),
+							Protocols:         kong.StringSlice("http", "https"),
+							RegexPriority:     kong.Int(len("/other/path/1")),
+							StripPath:         kong.Bool(false),
+							ResponseBuffering: kong.Bool(true),
+							RequestBuffering:  kong.Bool(true),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
+						},
+					}, {
+						Ingress: util.K8sObjectInfo{
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
+						},
+						Route: kong.Route{
 							Name:  kong.String("default.test-ingress.test-service.konghq.com.80"),
 							Hosts: kong.StringSlice("konghq.com"),
 							Paths: kong.StringSlice(
 								"/v1/api",
 								"/v2/api",
 								"/v3/api",
-								"~/other/path/1$",
 								"/other/path/2",
 								"/",
 							),
 							PreserveHost:      kong.Bool(true),
 							Protocols:         kong.StringSlice("http", "https"),
-							RegexPriority:     kong.Int(len("/other/path/1")),
+							RegexPriority:     kong.Int(0),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
@@ -836,18 +853,34 @@ func TestTranslateIngress(t *testing.T) {
 							GroupVersionKind: ingressGVK,
 						},
 						Route: kong.Route{
+							Name:              kong.String("default.test-ingress.test-service..80.exact.13"),
+							Paths:             kong.StringSlice("~/other/path/1$"),
+							PreserveHost:      kong.Bool(true),
+							Protocols:         kong.StringSlice("http", "https"),
+							RegexPriority:     kong.Int(len("/other/path/1")),
+							StripPath:         kong.Bool(false),
+							ResponseBuffering: kong.Bool(true),
+							RequestBuffering:  kong.Bool(true),
+							Tags:              kong.StringSlice("k8s-name:test-ingress", "k8s-namespace:default", "k8s-kind:Ingress", "k8s-group:networking.k8s.io", "k8s-version:v1"),
+						},
+					}, {
+						Ingress: util.K8sObjectInfo{
+							Name:             "test-ingress",
+							Namespace:        corev1.NamespaceDefault,
+							GroupVersionKind: ingressGVK,
+						},
+						Route: kong.Route{
 							Name: kong.String("default.test-ingress.test-service..80"),
 							Paths: kong.StringSlice(
 								"/v1/api",
 								"/v2/api",
 								"/v3/api",
-								"~/other/path/1$",
 								"/other/path/2",
 								"/",
 							),
 							PreserveHost:      kong.Bool(true),
 							Protocols:         kong.StringSlice("http", "https"),
-							RegexPriority:     kong.Int(len("/other/path/1")),
+							RegexPriority:     kong.Int(0),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
@@ -1678,6 +1711,89 @@ func TestTranslateIngress_ExactPathRegexPriority(t *testing.T) {
 	require.NotNil(t, solverRoute.RegexPriority)
 	require.Greater(t, *solverRoute.RegexPriority, *appRoute.RegexPriority)
 	require.Equal(t, len("/.well-known/acme-challenge/token"), *solverRoute.RegexPriority)
+}
+
+func TestTranslateIngress_ExactPathRegexPriorityDoesNotApplyToPrefixPaths(t *testing.T) {
+	ingresses := []*netv1.Ingress{{
+		TypeMeta: ingressTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{{
+				Host: "example.com",
+				IngressRuleValue: netv1.IngressRuleValue{
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{{
+							Path:     "/very/long/path",
+							PathType: &pathTypeExact,
+							Backend: netv1.IngressBackend{
+								Service: &netv1.IngressServiceBackend{
+									Name: "mixed",
+									Port: netv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}, {
+							Path:     "/api",
+							PathType: &pathTypePrefix,
+							Backend: netv1.IngressBackend{
+								Service: &netv1.IngressServiceBackend{
+									Name: "mixed",
+									Port: netv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}, {
+							Path:     "/api",
+							PathType: &pathTypeExact,
+							Backend: netv1.IngressBackend{
+								Service: &netv1.IngressServiceBackend{
+									Name: "api",
+									Port: netv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}}
+
+	translatedServices := TranslateIngresses(
+		ingresses,
+		configurationv1alpha1.IngressClassParametersSpec{},
+		TranslateIngressFeatureFlags{},
+		noopObjectsCollector{},
+		failures.NewResourceFailuresCollector(logr.Discard()),
+		lo.Must(store.NewFakeStore(store.FakeObjects{})),
+	)
+
+	require.Contains(t, translatedServices, "default.mixed.80")
+	require.Contains(t, translatedServices, "default.api.80")
+	require.Len(t, translatedServices["default.mixed.80"].Routes, 2)
+
+	mixedPrefixRoute := requireRouteWithPath(t, translatedServices["default.mixed.80"].Routes, "~/api$")
+	mixedExactRoute := requireRouteWithPath(t, translatedServices["default.mixed.80"].Routes, "~/very/long/path$")
+	apiExactRoute := requireRouteWithPath(t, translatedServices["default.api.80"].Routes, "~/api$")
+
+	require.Equal(t, 0, *mixedPrefixRoute.RegexPriority)
+	require.Equal(t, len("/very/long/path"), *mixedExactRoute.RegexPriority)
+	require.Equal(t, len("/api"), *apiExactRoute.RegexPriority)
+}
+
+func requireRouteWithPath(t *testing.T, routes []kongstate.Route, expectedPath string) kongstate.Route {
+	t.Helper()
+
+	for _, route := range routes {
+		for _, path := range route.Paths {
+			if path != nil && *path == expectedPath {
+				return route
+			}
+		}
+	}
+
+	require.FailNowf(t, "missing route path", "expected to find route path %q", expectedPath)
+	return kongstate.Route{}
 }
 
 func TestTranslateIngress_KongServiceFacadeFailures(t *testing.T) {

--- a/internal/dataplane/translator/subtranslator/ingress_test.go
+++ b/internal/dataplane/translator/subtranslator/ingress_test.go
@@ -339,7 +339,7 @@ func TestTranslateIngress(t *testing.T) {
 							Paths:             kong.StringSlice("~/api$"),
 							PreserveHost:      kong.Bool(true),
 							Protocols:         kong.StringSlice("http", "https"),
-							RegexPriority:     kong.Int(0),
+							RegexPriority:     kong.Int(len("/api")),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
@@ -704,7 +704,7 @@ func TestTranslateIngress(t *testing.T) {
 							),
 							PreserveHost:      kong.Bool(true),
 							Protocols:         kong.StringSlice("http", "https"),
-							RegexPriority:     kong.Int(0),
+							RegexPriority:     kong.Int(len("/other/path/1")),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
@@ -847,7 +847,7 @@ func TestTranslateIngress(t *testing.T) {
 							),
 							PreserveHost:      kong.Bool(true),
 							Protocols:         kong.StringSlice("http", "https"),
-							RegexPriority:     kong.Int(0),
+							RegexPriority:     kong.Int(len("/other/path/1")),
 							StripPath:         kong.Bool(false),
 							ResponseBuffering: kong.Bool(true),
 							RequestBuffering:  kong.Bool(true),
@@ -1605,6 +1605,79 @@ func TestTranslateIngress(t *testing.T) {
 			require.Empty(t, diff, "expected no difference between expected and translated ingress")
 		})
 	}
+}
+
+func TestTranslateIngress_ExactPathRegexPriority(t *testing.T) {
+	ingresses := []*netv1.Ingress{{
+		TypeMeta: ingressTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{{
+				Host: "example.com",
+				IngressRuleValue: netv1.IngressRuleValue{
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{{
+							Path:     "/",
+							PathType: &pathTypePrefix,
+							Backend: netv1.IngressBackend{
+								Service: &netv1.IngressServiceBackend{
+									Name: "app",
+									Port: netv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}, {
+		TypeMeta: ingressTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "solver",
+			Namespace: corev1.NamespaceDefault,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{{
+				Host: "example.com",
+				IngressRuleValue: netv1.IngressRuleValue{
+					HTTP: &netv1.HTTPIngressRuleValue{
+						Paths: []netv1.HTTPIngressPath{{
+							Path:     "/.well-known/acme-challenge/token",
+							PathType: &pathTypeExact,
+							Backend: netv1.IngressBackend{
+								Service: &netv1.IngressServiceBackend{
+									Name: "solver",
+									Port: netv1.ServiceBackendPort{Number: 8089},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}}
+
+	translatedServices := TranslateIngresses(
+		ingresses,
+		configurationv1alpha1.IngressClassParametersSpec{},
+		TranslateIngressFeatureFlags{},
+		noopObjectsCollector{},
+		failures.NewResourceFailuresCollector(logr.Discard()),
+		lo.Must(store.NewFakeStore(store.FakeObjects{})),
+	)
+
+	require.Contains(t, translatedServices, "default.app.80")
+	require.Contains(t, translatedServices, "default.solver.8089")
+
+	appRoute := translatedServices["default.app.80"].Routes[0]
+	solverRoute := translatedServices["default.solver.8089"].Routes[0]
+	require.NotNil(t, appRoute.RegexPriority)
+	require.NotNil(t, solverRoute.RegexPriority)
+	require.Greater(t, *solverRoute.RegexPriority, *appRoute.RegexPriority)
+	require.Equal(t, len("/.well-known/acme-challenge/token"), *solverRoute.RegexPriority)
 }
 
 func TestTranslateIngress_KongServiceFacadeFailures(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Ingress `pathType: Exact` paths are translated to Kong regex paths in traditional routing mode. Those routes previously kept the same default `regex_priority` as other generated regex paths, which could allow a broader Prefix route to win over an Exact route for the same host depending on Kong route ordering.

This sets a deterministic default regex priority for Exact Ingress paths based on the path length. Prefix and ImplementationSpecific routes keep the existing default priority, and users can still override the value with `konghq.com/regex-priority`.

**Which issue this PR fixes**:

Fixes #7824

**Special notes for your reviewer**:

Validated locally with:

- `go test ./internal/dataplane/translator/subtranslator`
- `go test ./internal/dataplane/translator`
- `go test ./internal/dataplane/translator/...`

I did not add a changelog entry because the changelog only contains released-version sections and no unreleased section for new PR entries.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
