### PR TITLE
test(integration): Use assert.Eventually to update HTTPRoute

### DIFF
--- a/test/integration/httproute_test.go
+++ b/test/integration/httproute_test.go
@@ -648,13 +648,18 @@ func TestHTTPRouteFilterHosts(t *testing.T) {
 	require.Error(t, testGetByHost(t, "another2.specific.io"))
 
 	t.Logf("update hostname in httproute to an unmatched host")
-	httpRoute, err = hClient.Get(ctx, httpRoute.Name, metav1.GetOptions{})
-	require.NoError(t, err)
-	httpRoute.Spec.Hostnames = []gatewayapi.Hostname{
-		gatewayapi.Hostname("another.specific.io"),
-	}
-	httpRoute, err = hClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
-	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		httpRoute, err = hClient.Get(ctx, httpRoute.Name, metav1.GetOptions{})
+		if !assert.NoErrorf(t, err, "failed getting the HTTPRoute %s", httpRoute.Name) {
+			return
+		}
+		httpRoute.Spec.Hostnames = []gatewayapi.Hostname{
+			gatewayapi.Hostname("another.specific.io"),
+		}
+		httpRoute, err = hClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		assert.NoErrorf(c, err, "failed updating the HTTPRoute %s", httpRoute.Name)
+	}, test.RequestTimeout, 100*time.Millisecond)
+
 	t.Logf("status of httproute should contain an 'Accepted' condition with 'False' status")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		currentHTTPRoute, err := hClient.Get(ctx, httpRoute.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Fix error 
```
Operation cannot be fulfilled on httproutes.gateway.networking.k8s.io "ccf15626-bb4a-4481-a859-80fd80723510": the object has been modified; please apply your changes to the latest version and try again
```

in integration tests in CI of #7861 by using `Eventually` to update HTTPRoutes.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
