### PR TITLE
fix: more robust `HTTPRoute` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,9 @@ Adding a new version? You'll need three changes:
     annotation on particular `Ingress`.
 - Sanitize the plugin configuration when `--dump-sensitive-config` isn't set.
   [#7912](https://github.com/Kong/kubernetes-ingress-controller/pull/7912)
+    [#7901](https://github.com/Kong/kubernetes-ingress-controller/pull/7901)
+- More robust validation for `HTTPRoute`, when an unsupported feature is used, and the route refers to existing and non-existing `Gateway`, it will be rejected.
+  [#7913](https://github.com/Kong/kubernetes-ingress-controller/pull/7913)
 
 ## [3.5.6]
 

--- a/internal/admission/validation/gateway/httproute.go
+++ b/internal/admission/validation/gateway/httproute.go
@@ -105,7 +105,7 @@ func ensureHTTPRouteIsManagedByController(ctx context.Context, httproute *gatewa
 			Name:      string(parentRef.Name),
 		}, &gateway); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, nil
+				continue
 			}
 			return false, fmt.Errorf("failed to get Gateway: %w", err)
 		}

--- a/internal/admission/validation/gateway/httproute_test.go
+++ b/internal/admission/validation/gateway/httproute_test.go
@@ -1015,6 +1015,47 @@ func TestValidateHTTPRoute(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			msg: "HTTPRoute with unsupported filter when reference both existing and non-existing gateway should be rejected",
+			cachedObjects: []client.Object{
+				gatewayClass,
+				&gatewayapi.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: corev1.NamespaceDefault,
+						Name:      "existing-managed-gateway",
+					},
+					Spec: gatewayapi.GatewaySpec{GatewayClassName: gatewayClassName},
+				},
+			},
+			route: &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: corev1.NamespaceDefault,
+					Name:      "example-route",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{
+							{
+								Name:      "non-existent-gateway",
+								Namespace: lo.ToPtr(gatewayapi.Namespace(corev1.NamespaceDefault)),
+							},
+							{
+								Name:      "existing-managed-gateway",
+								Namespace: lo.ToPtr(gatewayapi.Namespace(corev1.NamespaceDefault)),
+							},
+						},
+					},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						Filters: []gatewayapi.HTTPRouteFilter{{
+							// RequestMirror is explicitly unsupported — should be rejected.
+							Type: gatewayapi.HTTPRouteFilterRequestMirror,
+						}},
+					}},
+				},
+			},
+			valid:         false,
+			validationMsg: "HTTPRoute spec did not pass validation: rules[0].filters[0]: filter type RequestMirror is unsupported",
+		},
 	} {
 		t.Run(tt.msg, func(t *testing.T) {
 			fakeClient := fakeclient.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

More robust validation for `HTTPRoute`, when an unsupported feature is used, and the route refers to existing and non-existing `Gateway`, it will be rejected.

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

See [this comment](https://github.com/Kong/kubernetes-ingress-controller/security/advisories/GHSA-wq43-7p8f-q5p9#advisory-comment-200301#advisory-comment-200301) for more context

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
