### PR TITLE
fix: fix unsanitized KongPlugin being included in sanitzed config dump (#7912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ Adding a new version? You'll need three changes:
   - For `HTTPRoute`, protocol now matches the attached Gateway listener protocol (and when `parentRef.sectionName` is set, it must match that specific listener). When `parentRef.sectionName` is not specified it binds to all `Gateway`s listeners.
   - For `Ingress`, default protocol relies on Kong Gateway, can be set explicitly via `konghq.com/protocols: "http"` (or `https`)
     annotation on particular `Ingress`.
+- Sanitize the plugin configuration when `--dump-sensitive-config` isn't set.
+  [#7912](https://github.com/Kong/kubernetes-ingress-controller/pull/7912)
 
 ## [3.4.13]
 

--- a/internal/dataplane/kongstate/kongstate.go
+++ b/internal/dataplane/kongstate/kongstate.go
@@ -62,7 +62,14 @@ func (ks *KongState) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KongState 
 			})
 		}(),
 		CACertificates: ks.CACertificates,
-		Plugins:        ks.Plugins,
+		Plugins: func() []Plugin {
+			if ks.Plugins == nil {
+				return nil
+			}
+			return lo.Map(ks.Plugins, func(p Plugin, _ int) Plugin {
+				return p.SanitizedCopy()
+			})
+		}(),
 		Consumers: func() []Consumer {
 			if ks.Consumers == nil {
 				return nil

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -107,7 +107,7 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 				Upstreams:      []Upstream{{Upstream: kong.Upstream{ID: kong.String("1")}}},
 				Certificates:   []Certificate{{Certificate: kong.Certificate{ID: kong.String("1"), Key: redactedString}}},
 				CACertificates: []kong.CACertificate{{ID: kong.String("1")}},
-				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: kong.String("1"), Config: map[string]interface{}{"key": "secret"}}}}, // We don't redact plugins' config.
+				Plugins:        []Plugin{{Plugin: kong.Plugin{ID: kong.String("1"), Config: map[string]any{"key": "{REDACTED}"}}}},
 				Consumers: []Consumer{
 					{
 						KeyAuths: []*KeyAuth{

--- a/internal/dataplane/kongstate/plugin.go
+++ b/internal/dataplane/kongstate/plugin.go
@@ -354,3 +354,12 @@ type PluginRelatedEntitiesRefs struct {
 	RelatedEntities      map[string]RelatedEntitiesRef
 	RouteAttachedService map[string]*Service
 }
+
+func (p *Plugin) SanitizedCopy() Plugin {
+	sanitized := p.DeepCopy()
+	// Replace all config values with a redaction marker.
+	for k := range sanitized.Config {
+		sanitized.Config[k] = "{REDACTED}"
+	}
+	return sanitized
+}

--- a/internal/dataplane/kongstate/plugin_test.go
+++ b/internal/dataplane/kongstate/plugin_test.go
@@ -765,3 +765,158 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 		})
 	}
 }
+
+func TestPluginSanitizedCopy(t *testing.T) {
+	parent := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plugin-parent",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		in        Plugin
+		want      Plugin
+		postCheck func(t *testing.T, in Plugin, got Plugin)
+	}{
+		{
+			name: "redacts all top level config values and preserves other fields",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					ID:           kong.String("plugin-id"),
+					Name:         kong.String("rate-limiting"),
+					InstanceName: kong.String("instance-name"),
+					RunOn:        kong.String("first"),
+					Enabled:      kong.Bool(false),
+					Protocols:    kong.StringSlice("http", "https"),
+					Tags:         []*string{kong.String("tag-1"), kong.String("tag-2")},
+					Ordering: &kong.PluginOrdering{
+						Before: map[string][]string{
+							"access": {"key-auth"},
+						},
+					},
+					Config: kong.Configuration{
+						"string":  "secret",
+						"number":  123,
+						"boolean": true,
+						"object": map[string]any{
+							"nested": "secret",
+						},
+						"array": []any{"first", "second"},
+						"null":  nil,
+					},
+				},
+				K8sParent: parent,
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					ID:           kong.String("plugin-id"),
+					Name:         kong.String("rate-limiting"),
+					InstanceName: kong.String("instance-name"),
+					RunOn:        kong.String("first"),
+					Enabled:      kong.Bool(false),
+					Protocols:    kong.StringSlice("http", "https"),
+					Tags:         []*string{kong.String("tag-1"), kong.String("tag-2")},
+					Ordering: &kong.PluginOrdering{
+						Before: map[string][]string{
+							"access": {"key-auth"},
+						},
+					},
+					Config: kong.Configuration{
+						"string":  "{REDACTED}",
+						"number":  "{REDACTED}",
+						"boolean": "{REDACTED}",
+						"object":  "{REDACTED}",
+						"array":   "{REDACTED}",
+						"null":    "{REDACTED}",
+					},
+				},
+				K8sParent: parent,
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Equal(t, "secret", in.Config["string"])
+				assert.Equal(t, 123, in.Config["number"])
+				assert.Equal(t, true, in.Config["boolean"])
+				assert.Equal(t, map[string]any{"nested": "secret"}, in.Config["object"])
+				assert.Equal(t, []any{"first", "second"}, in.Config["array"])
+				assert.Nil(t, in.Config["null"])
+				assert.Same(t, in.K8sParent, got.K8sParent)
+			},
+		},
+		{
+			name: "keeps nil config nil",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name: kong.String("key-auth"),
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name: kong.String("key-auth"),
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Nil(t, in.Config)
+				assert.Nil(t, got.Config)
+			},
+		},
+		{
+			name: "returns an isolated config map copy",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name: kong.String("request-transformer"),
+					Config: kong.Configuration{
+						"add": "sensitive",
+					},
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name: kong.String("request-transformer"),
+					Config: kong.Configuration{
+						"add": "{REDACTED}",
+					},
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				got.Config["add"] = "changed"
+				got.Config["new"] = "new-value"
+				assert.Equal(t, "sensitive", in.Config["add"])
+				_, exists := in.Config["new"]
+				assert.False(t, exists)
+			},
+		},
+		{
+			name: "keeps empty config empty",
+			in: Plugin{
+				Plugin: kong.Plugin{
+					Name:   kong.String("cors"),
+					Config: kong.Configuration{},
+				},
+			},
+			want: Plugin{
+				Plugin: kong.Plugin{
+					Name:   kong.String("cors"),
+					Config: kong.Configuration{},
+				},
+			},
+			postCheck: func(t *testing.T, in Plugin, got Plugin) {
+				assert.Empty(t, in.Config)
+				assert.Empty(t, got.Config)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.SanitizedCopy()
+
+			assert.Equal(t, tt.want, got)
+
+			if tt.postCheck != nil {
+				tt.postCheck(t, tt.in, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* fix: fix unsanitized KongPlugin being included in sanitzed config dump

* tests: fix TestKongState_SanitizedCopy

* chore: add changelog

(cherry picked from commit 38415bdb02014ac69417cf1027c6278ef88bf233)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
