### PR TITLE
chore: set protocol to `http` for Ingress in e2e tests

### DIFF
--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -459,6 +459,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	t.Logf("creating a classless ingress for service %s", service.Name)
 	ingress := generators.NewIngressForService("/abbosiysaltanati", map[string]string{
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
+		annotations.AnnotationPrefix + annotations.ProtocolsKey: "http",
 	}, service)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), kongDeployment.Namespace, ingress))
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -439,6 +439,7 @@ func deployIngressWithEchoBackends(ctx context.Context, t *testing.T, env enviro
 	ingress := generators.NewIngressForService(echoPath, map[string]string{
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 		annotations.AnnotationPrefix + annotations.MethodsKey:   http.MethodGet,
+		annotations.AnnotationPrefix + annotations.ProtocolsKey: "http",
 	}, service)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- [E2E suite run on this branch](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/26045319078) triggered with `ci/run-e2e` label
- [manually triggered validation workflow](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/26045273850) on this branch 
  <img width="372" height="670" alt="image" src="https://github.com/user-attachments/assets/fa6da19b-17e1-4124-ad75-bcc140d0b3c7" />
  passes since it uses the adjusted testing code from this branch

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

Part of efforts to be compatible with 3.14 - https://github.com/Kong/kong-operator/issues/4338

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->
