### PR TITLE
force licenses if Kong version >= 3.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/tonglil/buflogr v1.1.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
+	go.yaml.in/yaml/v3 v3.0.3
 	google.golang.org/api v0.243.0
 	k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver v0.33.3
@@ -87,7 +88,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.3 // indirect
 	k8s.io/apiserver v0.33.3 // indirect
 	k8s.io/component-helpers v0.33.3 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/kong/semver/v4 v4.0.1 // indirect
+	github.com/kong/semver/v4 v4.0.1
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/tonglil/buflogr v1.1.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
-	go.yaml.in/yaml/v3 v3.0.3
 	google.golang.org/api v0.243.0
 	k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver v0.33.3
@@ -88,6 +87,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.3 // indirect
 	k8s.io/apiserver v0.33.3 // indirect
 	k8s.io/component-helpers v0.33.3 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect

--- a/test/consts/versions.go
+++ b/test/consts/versions.go
@@ -2,6 +2,4 @@ package consts
 
 import "github.com/blang/semver/v4"
 
-var (
-	ForceLicenseVersionCutoff = semver.MustParse("3.15.0")
-)
+var ForceLicenseVersionCutoff = semver.MustParse("3.15.0")

--- a/test/consts/versions.go
+++ b/test/consts/versions.go
@@ -1,0 +1,7 @@
+package consts
+
+import "github.com/blang/semver/v4"
+
+var (
+	ForceLicenseVersionCutoff = semver.MustParse("3.15.0")
+)

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -106,7 +106,6 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 
 	t.Log("deploying kong components")
 	manifestDeploy := ManifestDeploy{Path: postgresPath}
-	t.Log("deploying kong components")
 	kongImageVersion, err := helpers.GetKongImageVersion()
 	require.NoError(t, err)
 	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -87,7 +87,7 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	require.NoError(t, err)
 	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
-		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
 	}
 	manifestDeploy.Run(ctx, t, env)
 
@@ -111,7 +111,7 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	require.NoError(t, err)
 	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
-		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
 	}
 	deployments := manifestDeploy.Run(ctx, t, env)
 	deployment := deployments.ControllerNN
@@ -287,7 +287,7 @@ func TestDeployAllInOnePostgresGatewayDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
-		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
 	}
 	deployments := manifestDeploy.Run(ctx, t, env)
 
@@ -311,7 +311,7 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	require.NoError(t, err)
 	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
-		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
 	}
 	deployments := manifestDeploy.Run(ctx, t, env)
 

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
@@ -80,8 +81,15 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	t.Parallel()
 	ctx, env := setupE2ETest(t)
 
+	manifestDeploy := ManifestDeploy{Path: postgresPath}
 	t.Log("deploying kong components")
-	ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+	}
+	manifestDeploy.Run(ctx, t, env)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)
@@ -97,7 +105,15 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: postgresPath}
+	t.Log("deploying kong components")
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 	deployment := deployments.ControllerNN
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
@@ -265,7 +281,15 @@ func TestDeployAllInOnePostgresGatewayDiscovery(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: manifestFilePath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: manifestFilePath}
+	t.Log("deploying kong components")
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
@@ -282,7 +306,14 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: manifestFilePath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: manifestFilePath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch())
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	ingress := deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
 // TestKongRouterCompatibility verifies that KIC behaves consistently with all
@@ -34,6 +37,12 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 				Patches: []ManifestPatch{
 					patchKongRouterFlavorFn(rf),
 				},
+			}
+			kongImageVersion, err := helpers.GetKongImageVersion()
+			require.NoError(t, err)
+			if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+				t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+				deploy.Patches = append(deploy.Patches, WithLicensePatch(getProxyDeploymentName(deploy.Path)))
 			}
 			deployments := deploy.Run(ctx, t, env)
 			t.Cleanup(func() { deploy.Delete(ctx, t, env) })

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -120,7 +120,14 @@ func TestWebhookUpdate(t *testing.T) {
 	}()
 
 	t.Log("deploying kong components")
-	ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	manifestDeploy.Run(ctx, t, env)
 
 	certPool := x509.NewCertPool()
 	const firstCertificateHostName = "first.example"
@@ -240,7 +247,14 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 	controllerDeploymentNN := deployments.ControllerNN
 	controllerDeploymentListOptions := metav1.ListOptions{
 		LabelSelector: "app=" + controllerDeploymentNN.Name,
@@ -260,7 +274,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 		}
 	}
 
-	_, err := env.Cluster().Client().AppsV1().Deployments(namespace).Update(ctx, controllerDeployment, metav1.UpdateOptions{})
+	_, err = env.Cluster().Client().AppsV1().Deployments(namespace).Update(ctx, controllerDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	t.Log("verifying that KIC waits for Gateway API CRDs and prints proper log")
@@ -396,7 +410,14 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	manifestDeploy.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
@@ -414,7 +435,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: consts.DefaultFeatureGates})
 		}
 	}
-	_, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx,
+	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx,
 		deployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -442,13 +463,20 @@ func TestDefaultIngressClass(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 	kongDeployment := deployments.ControllerNN
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err := env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("exposing deployment %s via service", deployment.Name)

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -82,7 +81,7 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 	require.NoError(t, err)
 	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
-		licenseJSON, err := ktfkong.GetLicenseJSONFromEnv()
+		licenseJSON, err := kongaddon.GetLicenseJSONFromEnv()
 		require.NoError(t, err, "failed to get Kong license from environment variable")
 		kongBuilder = kongBuilder.WithProxyEnterpriseEnabled(licenseJSON)
 	}

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +78,14 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 		WithControllerDisabled().
 		WithProxyAdminServiceTypeLoadBalancer().
 		WithNamespace(consts.ControllerNamespace)
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		licenseJSON, err := ktfkong.GetLicenseJSONFromEnv()
+		require.NoError(t, err, "failed to get Kong license from environment variable")
+		kongBuilder = kongBuilder.WithProxyEnterpriseEnabled(licenseJSON)
+	}
 	kongAddon := kongBuilder.Build()
 
 	t.Log("configuring istio cluster addon for the testing environment")

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/nodes"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	testkonnect "github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers/konnect"
 )
 
@@ -70,6 +72,18 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+
+	if kongImageVersion.LT(consts.ForceLicenseVersionCutoff) {
+		testKonnectLicenseActivationWithoutForceLicense(ctx, t, env, rgID)
+	} else {
+		t.Logf("Kong version %s requires a license at the beginning", kongImageVersion)
+		testKonnectLicenseActivationWithForceLicense(ctx, t, env, rgID)
+	}
+}
+
+func testKonnectLicenseActivationWithoutForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {
 	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
 	ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
 
@@ -135,6 +149,37 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	t.Log("done")
 }
 
+func testKonnectLicenseActivationWithForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {
+	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
+	ManifestDeploy{
+		Path: manifestFile,
+		Patches: []ManifestPatch{
+			WithKonnectLicensingPatch(),
+		},
+	}.Run(ctx, t, env)
+	exposeAdminAPI(ctx, t, env, k8stypes.NamespacedName{Namespace: "kong", Name: "proxy-kong"})
+
+	t.Log("confirming that the license is set")
+	assert.Eventually(t, func() bool {
+		license, err := getLicenseFromAdminAPI(ctx, env, "")
+		if err != nil {
+			t.Logf("failed to get license: %v", err)
+			return false
+		}
+		return license.License.Expiration != ""
+	}, adminAPIWait, time.Second)
+
+	skipTestIfControllerVersionBelow(t, semver.MustParse("3.5.1"))
+	t.Log("checking if the license is stored in the local secret")
+	secret, err := env.Cluster().Client().CoreV1().Secrets(namespace).Get(
+		ctx, "konnect-license-"+rgID, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, secret.Data, "secret to store Konnect license should not be empty")
+	require.NotEmpty(t, secret.Data["id"], "stored license should have a non-empty ID")
+
+	t.Log("done")
+}
+
 func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
 	t.Parallel()
 	testkonnect.SkipIfMissingRequiredKonnectEnvVariables(t)
@@ -160,7 +205,14 @@ func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env enviro
 	const manifestFile = "manifests/all-in-one-dbless-konnect.yaml"
 	t.Logf("deploying %s manifest file", manifestFile)
 
-	return ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: manifestFile}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	return manifestDeploy.Run(ctx, t, env)
 }
 
 // createKonnectClientSecretAndConfigMap creates a Secret with client TLS certificate that is used by KIC to communicate

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
@@ -24,7 +26,15 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, buildKumaAddon(t))
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("adding Kuma mesh")
 	require.NoError(t, kuma.EnableMeshForNamespace(ctx, env.Cluster(), "kong"))
@@ -46,7 +56,14 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, buildKumaAddon(t))
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: postgresPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -251,7 +251,7 @@ const konnectLicensingEnvPatch = `- op: add
   path: /spec/template/spec/containers/0/env/-
   value:
     name: CONTROLLER_KONNECT_LICENSING_ENABLED
-	value: "true"`
+    value: "true"`
 
 // WithKonnectLicensingPatch adds the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
 // This is required for tests that involve Konnect licensing with Kong versions that require a license at startup,

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -245,3 +245,44 @@ func WithLicensePatch(proxyDeploymentName string) ManifestPatch {
 		return &buf, nil
 	}
 }
+
+// konnectLicensingEnvPatch is the patch to add the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
+const konnectLicensingEnvPatch = `- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: CONTROLLER_KONNECT_LICENSING_ENABLED
+	value: "true"`
+
+// WithKonnectLicensingPatch adds the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
+// This is required for tests that involve Konnect licensing with Kong versions that require a license at startup,
+// since the presence of this env var changes the licensing activation flow to be compatible with such versions.
+func WithKonnectLicensingPatch() ManifestPatch {
+	return func(r io.Reader) (io.Reader, error) {
+		ingressDeploymentName := "ingress-kong"
+		// Add the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
+		kustomization := types.Kustomization{
+			Patches: []types.Patch{
+				{
+					Patch: konnectLicensingEnvPatch,
+					Target: &types.Selector{
+						ResId: resid.ResId{
+							Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"},
+							Name:      ingressDeploymentName,
+							Namespace: namespace,
+						},
+					},
+				},
+			},
+		}
+		patched, err := kubectl.GetKustomizedManifest(kustomization, r)
+		if err != nil {
+			return nil, err
+		}
+
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, patched); err != nil {
+			return nil, err
+		}
+		return &buf, nil
+	}
+}

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -10,11 +10,11 @@ import (
 
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/kubectl"
-	"go.yaml.in/yaml/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -192,7 +192,13 @@ const kongLicenseEnvPatch = `- op: add
         key: license
         name: kong-enterprise-license`
 
-func WithLicensePatch() ManifestPatch {
+// WithLicensePatch injects the enterprise license from the environment into the deployed
+// manifest. It adds the KONG_LICENSE_DATA env var (referencing the kong-enterprise-license
+// secret) to the proxy container of the given proxy deployment and appends the secret itself.
+// proxyDeploymentName must be the name of the deployment that runs the proxy container, which
+// differs between manifest variants (proxy-kong for multi-pod, ingress-kong for single-pod);
+// use getProxyDeploymentName to derive it from the manifest path.
+func WithLicensePatch(proxyDeploymentName string) ManifestPatch {
 	return func(r io.Reader) (io.Reader, error) {
 		licenseSecret, err := ktfkong.GetLicenseSecretFromEnv()
 		if err != nil {
@@ -204,7 +210,7 @@ func WithLicensePatch() ManifestPatch {
 		licenseSecret.Namespace = namespace
 
 		// Add the KONG_LICENSE_DATA env var (referencing the secret) to the proxy
-		// container (index 0) of the proxy-kong deployment.
+		// container (index 0) of the proxy deployment.
 		kustomization := types.Kustomization{
 			Patches: []types.Patch{
 				{
@@ -212,7 +218,7 @@ func WithLicensePatch() ManifestPatch {
 					Target: &types.Selector{
 						ResId: resid.ResId{
 							Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"},
-							Name:      "proxy-kong",
+							Name:      proxyDeploymentName,
 							Namespace: namespace,
 						},
 					},

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -3,11 +3,15 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"time"
 
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/kubectl"
+	"go.yaml.in/yaml/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
@@ -177,4 +181,61 @@ func patchLivenessProbes(baseManifestReader io.Reader, deployment k8stypes.Names
 		},
 	}
 	return kubectl.GetKustomizedManifest(kustomization, baseManifestReader)
+}
+
+const kongLicenseEnvPatch = `- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: KONG_LICENSE_DATA
+    valueFrom:
+      secretKeyRef:
+        key: license
+        name: kong-enterprise-license`
+
+func WithLicensePatch() ManifestPatch {
+	return func(r io.Reader) (io.Reader, error) {
+		licenseSecret, err := ktfkong.GetLicenseSecretFromEnv()
+		if err != nil {
+			return nil, err
+		}
+		// GetLicenseSecretFromEnv returns a secret without TypeMeta/namespace; both are
+		// required for it to apply cleanly into the kong namespace via `kubectl apply -f -`.
+		licenseSecret.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}
+		licenseSecret.Namespace = namespace
+
+		// Add the KONG_LICENSE_DATA env var (referencing the secret) to the proxy
+		// container (index 0) of the proxy-kong deployment.
+		kustomization := types.Kustomization{
+			Patches: []types.Patch{
+				{
+					Patch: kongLicenseEnvPatch,
+					Target: &types.Selector{
+						ResId: resid.ResId{
+							Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"},
+							Name:      "proxy-kong",
+							Namespace: namespace,
+						},
+					},
+				},
+			},
+		}
+		patched, err := kubectl.GetKustomizedManifest(kustomization, r)
+		if err != nil {
+			return nil, err
+		}
+
+		// Append the license secret as an additional document so it is created
+		// alongside the deployment.
+		secretYAML, err := yaml.Marshal(licenseSecret)
+		if err != nil {
+			return nil, err
+		}
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, patched); err != nil {
+			return nil, err
+		}
+		buf.WriteString("\n---\n")
+		buf.Write(secretYAML)
+		return &buf, nil
+	}
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,7 +17,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/sethvargo/go-password/password"
@@ -237,22 +235,6 @@ func patchControllerImageFromEnv(t *testing.T, manifestReader io.Reader) (io.Rea
 
 	t.Log("controller image override undefined, using defaults")
 	return manifestReader, nil
-}
-
-// getKongVersionFromOverrideTag parses Kong version from env effective version or override tag. The effective version
-// takes precedence.
-//
-//lint:ignore U1000 retained for future use
-func getKongVersionFromOverrideTag() (kong.Version, error) {
-	if kongEffectiveVersion := testenv.KongEffectiveVersion(); kongEffectiveVersion != "" {
-		return kong.ParseSemanticVersion(kongEffectiveVersion)
-	}
-
-	if testenv.KongImageTag() == "" {
-		return kong.Version{}, errors.New("No Kong tag provided")
-	}
-
-	return kong.ParseSemanticVersion(testenv.KongTag())
 }
 
 // getKongProxyIP takes a Service with Kong proxy ports and returns and its IP, or fails the test if it cannot.

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -801,9 +801,11 @@ func TestPluginNullInConfig(t *testing.T) {
 	t.Logf("Checking the configuration of the plugin %s in Kong", kongplugin.Name)
 	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), managercfg.AdminAPIClientConfig{}, consts.KongTestPassword)
 	require.NoError(t, err, "failed to create Kong client")
+
 	// For integration tests in enterprise edition and postgres DB backed Kong gateway,
 	// the tests are run in "notdefault" workspace of Kong.
-	if testenv.DBMode() != testenv.DBModeOff && testenv.KongEnterpriseEnabled() {
+	// Kong gateway 3.15 and later forces presence of a license, so the tests are run in "notdefault" workspace of Kong.
+	if testenv.DBMode() != testenv.DBModeOff && (testenv.KongEnterpriseEnabled() || kongGatewayVersionRequiresLicense()) {
 		kc.SetWorkspace(consts.KongTestWorkspace)
 	}
 	require.Eventually(t, func() bool {

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -123,3 +123,10 @@ func eventuallyGetKongRouterFlavor(ctx context.Context, t *testing.T, adminURL *
 	}, time.Minute, time.Second)
 	return routerFlavor
 }
+
+// kongGatewayVersionRequiresLicense returns true if the Kong Gateway version requires a license to run.
+func kongGatewayVersionRequiresLicense() bool {
+	return kongGatewayVersion.IsKongGatewayEnterprise() &&
+		kongGatewayVersion.Major() >= consts.ForceLicenseVersionCutoff.Major &&
+		kongGatewayVersion.Minor() >= consts.ForceLicenseVersionCutoff.Minor
+}

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -13,7 +13,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
-func getKongVersion() (semver.Version, error) {
+// GetKongImageVersion returns the Kong version to be used for the KTF addon based on environment variables.
+func GetKongImageVersion() (semver.Version, error) {
 	kongVersion, err := semver.Parse(testenv.KongEffectiveVersion())
 	if err == nil {
 		return kongVersion, nil
@@ -33,7 +34,7 @@ func getKongVersion() (semver.Version, error) {
 // GenerateKongBuilder returns a Kong KTF addon builder, a string slice
 // of controller arguments needed to interact with the addon and an error.
 func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
-	kongVersion, err := getKongVersion()
+	kongVersion, err := GetKongImageVersion()
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not determine Kong version: %w", err)
 	}

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
@@ -11,12 +12,25 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
+func getKongVersion() (semver.Version, error) {
+	kongVersion, err := semver.Parse(testenv.KongEffectiveVersion())
+	if err == nil {
+		return kongVersion, nil
+	}
+	return semver.Parse(testenv.KongImageTag())
+}
+
 // GenerateKongBuilder returns a Kong KTF addon builder, a string slice
 // of controller arguments needed to interact with the addon and an error.
 func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
+	kongVersion, err := getKongVersion()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not determine Kong version: %w", err)
+	}
+
 	kongbuilder := kong.NewBuilder().WithNamespace(consts.ControllerNamespace)
 	extraControllerArgs := []string{}
-	if testenv.KongEnterpriseEnabled() {
+	if testenv.KongEnterpriseEnabled() || kongVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		licenseJSON, err := kong.GetLicenseJSONFromEnv()
 		if err != nil {
 			return nil, nil, err

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	kongsemver "github.com/kong/semver/v4"
 
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
@@ -17,7 +18,16 @@ func getKongVersion() (semver.Version, error) {
 	if err == nil {
 		return kongVersion, nil
 	}
-	return semver.Parse(testenv.KongImageTag())
+	// Use kong/semver to parse the version string in the TEST_KONG_TAG in case it is a four-digit version like "3.15.0.0".
+	kongsemverVersion, err := kongsemver.Parse(testenv.KongTag())
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("could not parse Kong version from TEST_KONG_EFFECTIVE_VERSION or TEST_KONG_TAG: %w", err)
+	}
+	return semver.Version{
+		Major: kongsemverVersion.Major,
+		Minor: kongsemverVersion.Minor,
+		Patch: kongsemverVersion.Patch,
+	}, nil
 }
 
 // GenerateKongBuilder returns a Kong KTF addon builder, a string slice


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Apply licenses in all e2e tests and integration tests if the image of Kong gateway is later than `3.15.0` as it forces a license to accept configuration from KIC.

For the case of retrieving license from Konnect, it enables fetching license from Konnect at the beginning if Kong version >= 3.15.0.

See: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/27670312469 

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
