### PR TITLE
fix(adminapi): preserve TLSServerName on admin client recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ Adding a new version? You'll need three changes:
 
 ### Fixed
 
+- Preserve the Admin API client's TLS server name (SNI) when a client turns pending and is
+  recreated (e.g. after a gateway Pod restart). Previously the SNI was dropped on recreation,
+  which, when gateway service discovery is combined with a mTLS-secured Admin API, caused
+  permanent TLS verification failures against the recreated client.
+  [#7950](https://github.com/Kong/kubernetes-ingress-controller/pull/7950)
 - Revert plugin config sanitization `--dump-sensitive-config` isn't set.
   Due to plugin configuration being dependent on plugin type controller is not
   able to make an informed decision whether a field is sensitive or not and more

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -36,6 +36,9 @@ type Client struct {
 	lastConfigSHA     []byte
 	// podRef (optional) describes the Pod that the Client communicates with.
 	podRef *k8stypes.NamespacedName
+	// tlsServerName (optional) is the SNI used for TLS verification against the Admin API.
+	// It's retained so the client can be recreated with the same SNI when it turns pending.
+	tlsServerName string
 }
 
 // NewClient creates an Admin API client that is to be used with a regular Admin API exposed by Kong Gateways.
@@ -206,6 +209,18 @@ func (c *Client) PodReference() (k8stypes.NamespacedName, bool) {
 	return k8stypes.NamespacedName{}, false
 }
 
+// AttachTLSServerName allows attaching the SNI used for TLS verification against the Admin API.
+// Should be used in case gateway service discovery is used so the SNI can be preserved when the
+// client is recreated (e.g. after the gateway Pod restarts).
+func (c *Client) AttachTLSServerName(name string) {
+	c.tlsServerName = name
+}
+
+// TLSServerName returns the SNI used for TLS verification against the Admin API, if any.
+func (c *Client) TLSServerName() string {
+	return c.tlsServerName
+}
+
 type ClientFactory struct {
 	logger     logr.Logger
 	workspace  string
@@ -241,5 +256,6 @@ func (cf ClientFactory) CreateAdminAPIClient(ctx context.Context, discoveredAdmi
 	}
 
 	cl.AttachPodReference(discoveredAdminAPI.PodRef)
+	cl.AttachTLSServerName(discoveredAdminAPI.TLSServerName)
 	return cl, nil
 }

--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -37,3 +37,22 @@ func TestClientFactory_CreateAdminAPIClientAttachesPodReference(t *testing.T) {
 		Name:      "name",
 	}, ref)
 }
+
+func TestClientFactory_CreateAdminAPIClientAttachesTLSServerName(t *testing.T) {
+	factory := adminapi.NewClientFactoryForWorkspace(logr.Discard(), "workspace", managercfg.AdminAPIClientConfig{}, "")
+
+	adminAPIHandler := mocks.NewAdminAPIHandler(t)
+	adminAPIServer := httptest.NewServer(adminAPIHandler)
+	t.Cleanup(func() { adminAPIServer.Close() })
+
+	const tlsServerName = "pod.dataplane-admin-kong.default.svc"
+	client, err := factory.CreateAdminAPIClient(t.Context(), adminapi.DiscoveredAdminAPI{
+		Address:       adminAPIServer.URL,
+		TLSServerName: tlsServerName,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	require.Equal(t, tlsServerName, client.TLSServerName(),
+		"expected TLSServerName to be attached to the client")
+}

--- a/internal/clients/readiness.go
+++ b/internal/clients/readiness.go
@@ -47,6 +47,7 @@ type AlreadyCreatedClient interface {
 	IsReady(context.Context) error
 	PodReference() (k8stypes.NamespacedName, bool)
 	BaseRootURL() string
+	TLSServerName() string
 }
 
 type DefaultReadinessChecker struct {
@@ -178,8 +179,9 @@ func (c DefaultReadinessChecker) checkAlreadyExistingClients(ctx context.Context
 				select {
 				case <-ctx.Done():
 				case pendingChan <- adminapi.DiscoveredAdminAPI{
-					Address: client.BaseRootURL(),
-					PodRef:  podRef,
+					Address:       client.BaseRootURL(),
+					TLSServerName: client.TLSServerName(),
+					PodRef:        podRef,
 				}:
 				}
 			}

--- a/internal/clients/readiness_test.go
+++ b/internal/clients/readiness_test.go
@@ -57,9 +57,10 @@ func (cf *mockClientFactory) CallsForAddress(address string) int {
 }
 
 type mockAlreadyCreatedClient struct {
-	url     string
-	isReady bool
-	podRef  k8stypes.NamespacedName
+	url           string
+	isReady       bool
+	podRef        k8stypes.NamespacedName
+	tlsServerName string
 }
 
 func (m mockAlreadyCreatedClient) IsReady(context.Context) error {
@@ -75,6 +76,10 @@ func (m mockAlreadyCreatedClient) PodReference() (k8stypes.NamespacedName, bool)
 
 func (m mockAlreadyCreatedClient) BaseRootURL() string {
 	return m.url
+}
+
+func (m mockAlreadyCreatedClient) TLSServerName() string {
+	return m.tlsServerName
 }
 
 func TestDefaultReadinessChecker(t *testing.T) {
@@ -275,4 +280,34 @@ func TestDefaultReadinessChecker(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDefaultReadinessChecker_PreservesTLSServerName ensures that when an already created client
+// turns pending (e.g. after a gateway Pod restart), the TLSServerName (SNI) is carried over to the
+// resulting DiscoveredAdminAPI so the client can be recreated with a valid SNI for TLS verification.
+func TestDefaultReadinessChecker_PreservesTLSServerName(t *testing.T) {
+	const (
+		testURL           = "http://localhost:8001"
+		testTLSServerName = "pod.dataplane-admin-kong.default.svc"
+	)
+	testPodRef := k8stypes.NamespacedName{Namespace: "default", Name: "mock"}
+
+	factory := newMockClientFactory(t, nil)
+	checker := clients.NewDefaultReadinessChecker(factory, managercfg.DefaultDataPlanesReadinessCheckTimeout, logr.Discard())
+
+	result := checker.CheckReadiness(t.Context(),
+		[]clients.AlreadyCreatedClient{
+			mockAlreadyCreatedClient{
+				podRef:        testPodRef,
+				url:           testURL,
+				isReady:       false, // Turns pending.
+				tlsServerName: testTLSServerName,
+			},
+		},
+		nil,
+	)
+
+	require.Len(t, result.ClientsTurnedPending, 1)
+	require.Equal(t, testTLSServerName, result.ClientsTurnedPending[0].TLSServerName,
+		"TLSServerName must be preserved when a client turns pending")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When an already-created Kong Admin API client fails its readiness check, the readiness checker
re-queues it as *pending* but only carried `Address` and `PodRef` — it dropped `TLSServerName`.
The pending client was then recreated via `ClientFactory.CreateAdminAPIClient` with an empty
SNI.

With gateway service discovery combined with a mTLS-secured Admin API, the recreated client
then fails TLS verification permanently: with an empty SNI Go's TLS stack verifies the server
certificate against the dial IP rather than the pod DNS SAN (`pod.<service>.<namespace>.svc`),
which the gateway certificate does not contain. This results in an endless reconnection loop
until the controller is restarted.

This PR persists `TLSServerName` on the `adminapi.Client` (mirroring the existing `podRef`
handling) and carries it through the readiness recovery path, so the SNI is preserved when the
client is recreated.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

The bug is independent of the restart cause — any transient Admin API unreadiness (network
blip, rolling restart, OOM) that trips the readiness checker triggers the same SNI loss. Added
unit coverage in `internal/clients/readiness_test.go` and `internal/adminapi/client_test.go`.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
