### PR TITLE
test(unit test): fix data race by using Eventually in `TestAdminAPIClientsManager_PeriodicReadinessReconciliation`

### DIFF
--- a/internal/clients/manager_test.go
+++ b/internal/clients/manager_test.go
@@ -519,11 +519,13 @@ func TestAdminAPIClientsManager_PeriodicReadinessReconciliation(t *testing.T) {
 	// Trigger a next readiness check which will make testURL2 ready.
 	readinessChecker.LetChecksReturn(clients.ReadinessCheckResult{ClientsTurnedReady: intoTurnedReady(testURL2)})
 	readinessTicker.Add(managercfg.DefaultDataPlanesReadinessReconciliationInterval)
-	readinessCheckCallEventuallyMatches(readinessCheckCall{
-		AlreadyCreatedURLs: []string{testURL1},
-		PendingURLs:        []string{testURL2},
-	})
-	require.Equal(t, 3, readinessChecker.CallsCount())
+	// Wait for CallsCount to reach 3 instead of relying on readinessCheckCallEventuallyMatches:
+	// the readiness check arguments here are identical to the previous step's (CheckReadiness is
+	// called with the pre-transition lists, so testURL2 is still pending), so LastCall already
+	// matches and would not synchronize with the tick-triggered check made by the manager goroutine.
+	require.Eventually(t, func() bool {
+		return readinessChecker.CallsCount() == 3
+	}, time.Second, time.Millisecond, "expected a third readiness check after the periodic tick")
 	require.True(t, lo.ContainsBy(m.GatewayClients(), func(c *adminapi.Client) bool {
 		return c.BaseRootURL() == testURL2
 	}), "expected to find the new client in the manager's clients list after it became ready")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

Fixes the data race in the unit test `TestAdminAPIClientsManager_PeriodicReadinessReconciliation`.
In the current code, it waits for the status "URL1 ready, URL2 pending" which is identical to the status after the 2nd call. Then it immediately checks for the 3rd call and the data race may happen here. The previous `eventually` did not actuall wait for the 3rd call but there is possibility that the check is called before the 3rd call of `AdminAPIClient`'s readiness checker.

Now we use `Eventually` to check for the 3rd call and verify if the URL2 becomes ready after the 3rd call.

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
