### PR TITLE
fix: fix credential recreation on every Konnect sync (#7978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Adding a new version? You'll need three changes:
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
+ - [3.4.17](#3417)
  - [3.4.16](#3416)
  - [3.4.15](#3415)
  - [3.4.14](#3414)
@@ -115,6 +116,14 @@ Adding a new version? You'll need three changes:
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [3.4.17]
+
+> Release date: TBD
+
+- Prevent recreating consumer credentials on every Konnect sync when running in
+  KIC in Konnect mode.
+  [#7978](https://github.com/Kong/kubernetes-ingress-controller/pull/7978)
 
 ## [3.4.16]
 
@@ -4239,6 +4248,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[3.4.17]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.16...v3.4.17
 [3.4.16]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.15...v3.4.16
 [3.4.15]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.14...v3.4.15
 [3.4.14]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.13...v3.4.14

--- a/internal/dataplane/kongstate/consumer_test.go
+++ b/internal/dataplane/kongstate/consumer_test.go
@@ -86,7 +86,7 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 				Plugins: []kong.Plugin{{ID: kong.String("1")}},
 				KeyAuths: []*KeyAuth{
 					{
-						KeyAuth: kong.KeyAuth{ID: kong.String("1"), Key: kong.String("{vault://52fdfc07-2182-454f-963f-5f0f9a621d72}")},
+						KeyAuth: kong.KeyAuth{ID: kong.String("1"), Key: deterministicRedactedString("secret")},
 					},
 				},
 				HMACAuths: []*HMACAuth{

--- a/internal/dataplane/kongstate/credentials.go
+++ b/internal/dataplane/kongstate/credentials.go
@@ -1,6 +1,7 @@
 package kongstate
 
 import (
+	"crypto/sha256"
 	"fmt"
 
 	"github.com/kong/go-kong/kong"
@@ -18,6 +19,15 @@ var redactedString = kong.String("{vault://redacted-value}")
 // collisions.
 func randRedactedString(uuidGenerator util.UUIDGenerator) *string {
 	s := fmt.Sprintf("{vault://%s}", uuidGenerator.NewString())
+	return &s
+}
+
+// deterministicRedactedString returns a stable vault-URI redaction derived from seed.
+// It produces the same output for the same seed (no churn on unchanged credentials) while
+// remaining distinct for different seeds. The real secret value is not recoverable from the output.
+func deterministicRedactedString(seed string) *string {
+	sum := sha256.Sum256([]byte(seed))
+	s := fmt.Sprintf("{vault://%x}", sum[:16])
 	return &s
 }
 
@@ -161,13 +171,23 @@ func NewMTLSAuth(config interface{}) (*MTLSAuth, error) {
 }
 
 // SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+// The Key field is replaced with a deterministic vault-URI derived from the real key so that
+// repeated syncs without a key change produce the same redacted value (preventing spurious
+// delete+create churn in go-database-reconciler). When the real key is unavailable the
+// redaction falls back to a random vault-URI.
 func (c *KeyAuth) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KeyAuth {
+	var redactedKey *string
+	if c.Key != nil {
+		redactedKey = deterministicRedactedString(*c.Key)
+	} else {
+		redactedKey = randRedactedString(uuidGenerator)
+	}
 	return &KeyAuth{
 		KeyAuth: kong.KeyAuth{
 			// Consumer field omitted
 			CreatedAt: c.CreatedAt,
 			ID:        c.ID,
-			Key:       randRedactedString(uuidGenerator),
+			Key:       redactedKey,
 			Tags:      c.Tags,
 		},
 	}

--- a/internal/dataplane/kongstate/credentials_test.go
+++ b/internal/dataplane/kongstate/credentials_test.go
@@ -14,7 +14,7 @@ func TestKeyAuth_SanitizedCopy(t *testing.T) {
 		want KeyAuth
 	}{
 		{
-			name: "fills all fields but Consumer and sanitizes key",
+			name: "fills all fields but Consumer and sanitizes key deterministically",
 			in: KeyAuth{
 				KeyAuth: kong.KeyAuth{
 					Consumer:  &kong.Consumer{Username: kong.String("foo")},
@@ -28,8 +28,23 @@ func TestKeyAuth_SanitizedCopy(t *testing.T) {
 				KeyAuth: kong.KeyAuth{
 					CreatedAt: kong.Int(1),
 					ID:        kong.String("2"),
-					Key:       kong.String("{vault://52fdfc07-2182-454f-963f-5f0f9a621d72}"),
+					Key:       deterministicRedactedString("3"),
 					Tags:      []*string{kong.String("4.1"), kong.String("4.2")},
+				},
+			},
+		},
+		{
+			name: "sanitizes key to random vault-URI when key is nil",
+			in: KeyAuth{
+				KeyAuth: kong.KeyAuth{
+					ID:  kong.String("2"),
+					Key: nil,
+				},
+			},
+			want: KeyAuth{
+				KeyAuth: kong.KeyAuth{
+					ID:  kong.String("2"),
+					Key: kong.String("{vault://52fdfc07-2182-454f-963f-5f0f9a621d72}"),
 				},
 			},
 		},
@@ -39,6 +54,21 @@ func TestKeyAuth_SanitizedCopy(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+
+	t.Run("deterministic: same key produces same redacted value across calls", func(t *testing.T) {
+		ka := KeyAuth{KeyAuth: kong.KeyAuth{Key: kong.String("mykey")}}
+		got1 := ka.SanitizedCopy(StaticUUIDGenerator{UUID: "x"})
+		got2 := ka.SanitizedCopy(StaticUUIDGenerator{UUID: "y"})
+		assert.Equal(t, got1.Key, got2.Key, "same real key must produce same redacted key regardless of uuidGenerator")
+	})
+
+	t.Run("different keys produce different redacted values", func(t *testing.T) {
+		ka1 := KeyAuth{KeyAuth: kong.KeyAuth{Key: kong.String("keyA")}}
+		ka2 := KeyAuth{KeyAuth: kong.KeyAuth{Key: kong.String("keyB")}}
+		got1 := ka1.SanitizedCopy(StaticUUIDGenerator{UUID: "x"})
+		got2 := ka2.SanitizedCopy(StaticUUIDGenerator{UUID: "x"})
+		assert.NotEqual(t, got1.Key, got2.Key, "different real keys must produce different redacted keys")
+	})
 }
 
 func TestHMACAuth_SanitizedCopy(t *testing.T) {

--- a/internal/dataplane/kongstate/kongstate_test.go
+++ b/internal/dataplane/kongstate/kongstate_test.go
@@ -112,7 +112,7 @@ func TestKongState_SanitizedCopy(t *testing.T) {
 					{
 						KeyAuths: []*KeyAuth{
 							{
-								KeyAuth: kong.KeyAuth{ID: kong.String("1"), Key: kong.String("{vault://52fdfc07-2182-454f-963f-5f0f9a621d72}")},
+								KeyAuth: kong.KeyAuth{ID: kong.String("1"), Key: deterministicRedactedString("secret")},
 							},
 						},
 					},

--- a/internal/dataplane/sendconfig/dbmode.go
+++ b/internal/dataplane/sendconfig/dbmode.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -94,6 +96,12 @@ func (s *UpdateStrategyDBMode) Update(ctx context.Context, targetContent Content
 
 	if err := s.refillPluginIDs(cs, ts); err != nil {
 		return mo.None[int](), err
+	}
+
+	if s.isKonnect {
+		if err := refillCredentialIDs(cs, ts, s.logger); err != nil {
+			return mo.None[int](), err
+		}
 	}
 
 	syncer, err := diff.NewSyncer(diff.SyncerOpts{
@@ -270,6 +278,256 @@ func (s *UpdateStrategyDBMode) targetState(
 	}
 
 	return state.Get(rawState)
+}
+
+// credentialMatchKey returns a string that uniquely identifies a credential within the KongState
+// across syncs. It combines the consumer's ID and a sorted, canonical form of the credential's tags.
+// KIC always tags credentials with GenerateTagsForObject(secret), which encodes the k8s Secret's
+// namespace/name/uid — this is deterministic and survives SanitizedCopy. The consumer ID is stable
+// because FillIDs covers consumers. Using these two fields (rather than the credential value such as
+// Key or Username) avoids the sanitization-induced churn where SanitizedCopy randomizes key-auth Key.
+func credentialMatchKey(consumerID string, tags []*string) string {
+	tagStrs := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t != nil {
+			tagStrs = append(tagStrs, *t)
+		}
+	}
+	sort.Strings(tagStrs)
+	return consumerID + "|" + strings.Join(tagStrs, ",")
+}
+
+// refillCredentialIDs reconciles credential IDs from the current state into the target state.
+// When KIC builds target content, credentials carry no IDs (go-kong has no FillID for credential
+// types). On the Konnect sync path, SanitizedCopy further randomizes key-auth Key values, so
+// go-database-reconciler's value-based ID recovery always misses, causing delete+create churn.
+// This function matches current-state credentials to target-state credentials by consumer ID + tags
+// and copies the existing ID, turning churn into a stable in-place update (or no event with Fix A).
+func refillCredentialIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	if err := refillKeyAuthIDs(currentState, targetState, logger); err != nil {
+		return err
+	}
+	if err := refillBasicAuthIDs(currentState, targetState, logger); err != nil {
+		return err
+	}
+	if err := refillHMACAuthIDs(currentState, targetState, logger); err != nil {
+		return err
+	}
+	if err := refillJWTAuthIDs(currentState, targetState, logger); err != nil {
+		return err
+	}
+	if err := refillACLGroupIDs(currentState, targetState, logger); err != nil {
+		return err
+	}
+	if err := refillOauth2CredIDs(currentState, targetState, logger); err != nil {
+		return err
+	}
+	return refillMTLSAuthIDs(currentState, targetState, logger)
+}
+
+// credential is a union of all credential types.
+// This is primarily used as a type constraint for credentialOps and refillCredTypeIDs.
+type credential interface {
+	state.KeyAuth |
+		state.BasicAuth |
+		state.HMACAuth |
+		state.JWTAuth |
+		state.ACLGroup |
+		state.Oauth2Credential |
+		state.MTLSAuth
+}
+
+// credentialOps holds type-specific operations for one credential collection, used by refillCredTypeIDs.
+type credentialOps[T credential] struct {
+	kind            string
+	getCurrentItems func() ([]*T, error)
+	getTargetItems  func() ([]*T, error)
+	consumerID      func(*T) string
+	id              func(*T) *string
+	tags            func(*T) []*string
+	setID           func(*T, *string)
+	delete          func(string) error
+	add             func(T) error
+}
+
+// refillCredTypeIDs is the shared implementation for all per-type refill functions.
+// It builds an index of current-state IDs keyed by credentialMatchKey(consumerID, tags) and
+// copies each matching ID into the target state (delete old entry + re-add with existing ID).
+func refillCredTypeIDs[T credential](ops credentialOps[T], logger logr.Logger) error {
+	current, err := ops.getCurrentItems()
+	if err != nil {
+		return fmt.Errorf("failed getting current %s: %w", ops.kind, err)
+	}
+
+	currentIndex := make(map[string]*string, len(current))
+	for _, c := range current {
+		id := ops.id(c)
+		if id == nil {
+			continue
+		}
+		k := credentialMatchKey(ops.consumerID(c), ops.tags(c))
+		currentIndex[k] = id
+	}
+
+	targets, err := ops.getTargetItems()
+	if err != nil {
+		return fmt.Errorf("failed getting target %s: %w", ops.kind, err)
+	}
+	for _, t := range targets {
+		k := credentialMatchKey(ops.consumerID(t), ops.tags(t))
+		existingID, ok := currentIndex[k]
+		if !ok || existingID == nil {
+			continue
+		}
+		currentID := ops.id(t)
+		if currentID != nil && *currentID == *existingID {
+			continue
+		}
+		logger.V(logging.DebugLevel).Info("keeping ID of existing "+ops.kind, "new_id", currentID, "old_id", existingID)
+		if currentID != nil {
+			if err := ops.delete(*currentID); err != nil && !errors.Is(err, state.ErrNotFound) {
+				return fmt.Errorf("failed deleting target %s: %w", ops.kind, err)
+			}
+		}
+		ops.setID(t, existingID)
+		if err := ops.add(*t); err != nil {
+			return fmt.Errorf("failed adding target %s with refilled ID: %w", ops.kind, err)
+		}
+	}
+	return nil
+}
+
+func refillKeyAuthIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.KeyAuth]{
+		kind:            "key-auth",
+		getCurrentItems: currentState.KeyAuths.GetAll,
+		getTargetItems:  targetState.KeyAuths.GetAll,
+		consumerID: func(ka *state.KeyAuth) string {
+			if ka.Consumer != nil && ka.Consumer.ID != nil {
+				return *ka.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(ka *state.KeyAuth) *string { return ka.ID },
+		tags:   func(ka *state.KeyAuth) []*string { return ka.Tags },
+		setID:  func(ka *state.KeyAuth, id *string) { ka.ID = id },
+		delete: targetState.KeyAuths.Delete,
+		add:    targetState.KeyAuths.Add,
+	}, logger)
+}
+
+func refillBasicAuthIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.BasicAuth]{
+		kind:            "basic-auth",
+		getCurrentItems: currentState.BasicAuths.GetAll,
+		getTargetItems:  targetState.BasicAuths.GetAll,
+		consumerID: func(ba *state.BasicAuth) string {
+			if ba.Consumer != nil && ba.Consumer.ID != nil {
+				return *ba.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(ba *state.BasicAuth) *string { return ba.ID },
+		tags:   func(ba *state.BasicAuth) []*string { return ba.Tags },
+		setID:  func(ba *state.BasicAuth, id *string) { ba.ID = id },
+		delete: targetState.BasicAuths.Delete,
+		add:    targetState.BasicAuths.Add,
+	}, logger)
+}
+
+func refillHMACAuthIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.HMACAuth]{
+		kind:            "hmac-auth",
+		getCurrentItems: currentState.HMACAuths.GetAll,
+		getTargetItems:  targetState.HMACAuths.GetAll,
+		consumerID: func(ha *state.HMACAuth) string {
+			if ha.Consumer != nil && ha.Consumer.ID != nil {
+				return *ha.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(ha *state.HMACAuth) *string { return ha.ID },
+		tags:   func(ha *state.HMACAuth) []*string { return ha.Tags },
+		setID:  func(ha *state.HMACAuth, id *string) { ha.ID = id },
+		delete: targetState.HMACAuths.Delete,
+		add:    targetState.HMACAuths.Add,
+	}, logger)
+}
+
+func refillJWTAuthIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.JWTAuth]{
+		kind:            "jwt-auth",
+		getCurrentItems: currentState.JWTAuths.GetAll,
+		getTargetItems:  targetState.JWTAuths.GetAll,
+		consumerID: func(ja *state.JWTAuth) string {
+			if ja.Consumer != nil && ja.Consumer.ID != nil {
+				return *ja.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(ja *state.JWTAuth) *string { return ja.ID },
+		tags:   func(ja *state.JWTAuth) []*string { return ja.Tags },
+		setID:  func(ja *state.JWTAuth, id *string) { ja.ID = id },
+		delete: targetState.JWTAuths.Delete,
+		add:    targetState.JWTAuths.Add,
+	}, logger)
+}
+
+func refillACLGroupIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.ACLGroup]{
+		kind:            "acl-group",
+		getCurrentItems: currentState.ACLGroups.GetAll,
+		getTargetItems:  targetState.ACLGroups.GetAll,
+		consumerID: func(ag *state.ACLGroup) string {
+			if ag.Consumer != nil && ag.Consumer.ID != nil {
+				return *ag.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(ag *state.ACLGroup) *string { return ag.ID },
+		tags:   func(ag *state.ACLGroup) []*string { return ag.Tags },
+		setID:  func(ag *state.ACLGroup, id *string) { ag.ID = id },
+		delete: targetState.ACLGroups.Delete,
+		add:    targetState.ACLGroups.Add,
+	}, logger)
+}
+
+func refillOauth2CredIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.Oauth2Credential]{
+		kind:            "oauth2-cred",
+		getCurrentItems: currentState.Oauth2Creds.GetAll,
+		getTargetItems:  targetState.Oauth2Creds.GetAll,
+		consumerID: func(oc *state.Oauth2Credential) string {
+			if oc.Consumer != nil && oc.Consumer.ID != nil {
+				return *oc.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(oc *state.Oauth2Credential) *string { return oc.ID },
+		tags:   func(oc *state.Oauth2Credential) []*string { return oc.Tags },
+		setID:  func(oc *state.Oauth2Credential, id *string) { oc.ID = id },
+		delete: targetState.Oauth2Creds.Delete,
+		add:    targetState.Oauth2Creds.Add,
+	}, logger)
+}
+
+func refillMTLSAuthIDs(currentState *state.KongState, targetState *state.KongState, logger logr.Logger) error {
+	return refillCredTypeIDs(credentialOps[state.MTLSAuth]{
+		kind:            "mtls-auth",
+		getCurrentItems: currentState.MTLSAuths.GetAll,
+		getTargetItems:  targetState.MTLSAuths.GetAll,
+		consumerID: func(ma *state.MTLSAuth) string {
+			if ma.Consumer != nil && ma.Consumer.ID != nil {
+				return *ma.Consumer.ID
+			}
+			return ""
+		},
+		id:     func(ma *state.MTLSAuth) *string { return ma.ID },
+		tags:   func(ma *state.MTLSAuth) []*string { return ma.Tags },
+		setID:  func(ma *state.MTLSAuth, id *string) { ma.ID = id },
+		delete: targetState.MTLSAuths.Delete,
+		add:    targetState.MTLSAuths.Add,
+	}, logger)
 }
 
 // refillPluginIDs keeps the plugin ID in the target state if there are already the same plugin

--- a/internal/dataplane/sendconfig/dbmode_test.go
+++ b/internal/dataplane/sendconfig/dbmode_test.go
@@ -276,6 +276,110 @@ func TestRefillPluginIDs(t *testing.T) {
 	}
 }
 
+func TestRefillCredentialIDs(t *testing.T) {
+	consumerID := "consumer-1"
+	consumer := &kong.Consumer{
+		Username: kong.String("consumer-1"),
+		ID:       kong.String(consumerID),
+	}
+	credTag := kong.String("k8s-name/default/my-secret/abc-uid")
+
+	testCases := []struct {
+		name              string
+		currentState      *state.KongState
+		targetState       *state.KongState
+		expectedKeyAuthID string
+	}{
+		{
+			name: "key-auth ID from current state is copied to target when tags and consumer match",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Consumers: []*kong.Consumer{consumer},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:       kong.String("existing-ka-id"),
+						Key:      kong.String("{vault://aaa}"),
+						Consumer: &kong.Consumer{ID: kong.String(consumerID)},
+						Tags:     []*string{credTag},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Consumers: []*kong.Consumer{consumer},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:       kong.String("new-ka-id"),
+						Key:      kong.String("{vault://bbb}"),
+						Consumer: &kong.Consumer{ID: kong.String(consumerID)},
+						Tags:     []*string{credTag},
+					},
+				},
+			}),
+			expectedKeyAuthID: "existing-ka-id",
+		},
+		{
+			name: "key-auth ID is NOT copied when tags differ (different credential)",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Consumers: []*kong.Consumer{consumer},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:       kong.String("existing-ka-id"),
+						Key:      kong.String("{vault://aaa}"),
+						Consumer: &kong.Consumer{ID: kong.String(consumerID)},
+						Tags:     []*string{kong.String("k8s-name/default/secret-A/uid-A")},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Consumers: []*kong.Consumer{consumer},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:       kong.String("new-ka-id"),
+						Key:      kong.String("{vault://bbb}"),
+						Consumer: &kong.Consumer{ID: kong.String(consumerID)},
+						Tags:     []*string{kong.String("k8s-name/default/secret-B/uid-B")},
+					},
+				},
+			}),
+			expectedKeyAuthID: "new-ka-id",
+		},
+		{
+			name: "key-auth ID is unchanged when IDs already match",
+			currentState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Consumers: []*kong.Consumer{consumer},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:       kong.String("same-id"),
+						Key:      kong.String("{vault://aaa}"),
+						Consumer: &kong.Consumer{ID: kong.String(consumerID)},
+						Tags:     []*string{credTag},
+					},
+				},
+			}),
+			targetState: mustNewKongStateFromRawState(t, &deckutils.KongRawState{
+				Consumers: []*kong.Consumer{consumer},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:       kong.String("same-id"),
+						Key:      kong.String("{vault://bbb}"),
+						Consumer: &kong.Consumer{ID: kong.String(consumerID)},
+						Tags:     []*string{credTag},
+					},
+				},
+			}),
+			expectedKeyAuthID: "same-id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := refillCredentialIDs(tc.currentState, tc.targetState, logr.Discard())
+			require.NoError(t, err)
+			_, err = tc.targetState.KeyAuths.Get(tc.expectedKeyAuthID)
+			require.NoError(t, err, "key-auth with expected ID %q not found in target state", tc.expectedKeyAuthID)
+		})
+	}
+}
+
 func mustNewKongStateFromRawState(t *testing.T, rawState *deckutils.KongRawState) *state.KongState {
 	t.Helper()
 


### PR DESCRIPTION
* fix: fix credential recreation on every Konnect sync

* Update CHANGELOG.md



* chore: rename credentialOps fields

* chore: comment for credential interface

---------


(cherry picked from commit 2af62b1bee9fcb1d9cf28619f940472490927491)

<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
