### PR TITLE
[Backport release/3.5.x] fix: fix missing certificate tags (#7991)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ Adding a new version? You'll need three changes:
 - Prevent recreating consumer credentials on every Konnect sync when running in
   KIC in Konnect mode.
   [#7981](https://github.com/Kong/kubernetes-ingress-controller/pull/7981)
+- Fix missing certificate tags in generated config.
+  [#7991](https://github.com/Kong/kubernetes-ingress-controller/pull/7991)
 
 ## [3.5.9]
 

--- a/internal/dataplane/deckgen/deckgen.go
+++ b/internal/dataplane/deckgen/deckgen.go
@@ -43,6 +43,7 @@ func GetFCertificateFromKongCert(kongCert kong.Certificate) file.FCertificate {
 	if kongCert.Cert != nil {
 		res.Cert = kong.String(*kongCert.Cert)
 	}
+	res.Tags = kongCert.Tags
 	res.SNIs = getCertsSNIs(kongCert)
 	return res
 }

--- a/internal/dataplane/deckgen/deckgen_test.go
+++ b/internal/dataplane/deckgen/deckgen_test.go
@@ -10,6 +10,64 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/deckgen"
 )
 
+func TestGetFCertificateFromKongCert(t *testing.T) {
+	const (
+		certID  = "c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af"
+		certPEM = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"
+		keyPEM  = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----"
+		sniName = "example.com"
+		tag1    = "k8s-name:sooper-secret"
+		tag2    = "k8s-namespace:bar-namespace"
+	)
+
+	testCases := []struct {
+		name     string
+		input    kong.Certificate
+		wantTags []*string
+	}{
+		{
+			name: "copies tags",
+			input: kong.Certificate{
+				ID:   kong.String(certID),
+				Cert: kong.String(certPEM),
+				Key:  kong.String(keyPEM),
+				SNIs: []*string{kong.String(sniName)},
+				Tags: []*string{kong.String(tag1), kong.String(tag2)},
+			},
+			wantTags: []*string{kong.String(tag1), kong.String(tag2)},
+		},
+		{
+			name: "nil tags",
+			input: kong.Certificate{
+				ID:   kong.String(certID),
+				Cert: kong.String(certPEM),
+				Key:  kong.String(keyPEM),
+				SNIs: []*string{kong.String(sniName)},
+				Tags: nil,
+			},
+			wantTags: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deckgen.GetFCertificateFromKongCert(tc.input)
+
+			require.Equal(t, tc.input.ID, got.ID)
+			require.Equal(t, tc.input.Cert, got.Cert)
+			require.Equal(t, tc.input.Key, got.Key)
+			require.Equal(t, tc.wantTags, got.Tags)
+
+			require.Len(t, got.SNIs, len(tc.input.SNIs))
+			for i, sni := range got.SNIs {
+				require.Equal(t, tc.input.SNIs[i], sni.Name)
+				require.NotNil(t, sni.Certificate)
+				require.Equal(t, tc.input.ID, sni.Certificate.ID)
+			}
+		})
+	}
+}
+
 func TestIsContentEmpty(t *testing.T) {
 	testCases := []struct {
 		name    string

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/default_golden.yaml
@@ -37,6 +37,12 @@ certificates:
   - certificate:
       id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
     name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 consumers:
 - basicauth_credentials:
   - password: consumer-1-password

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls-and-consumer/expression-routes-on_golden.yaml
@@ -37,6 +37,12 @@ certificates:
   - certificate:
       id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
     name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 consumers:
 - basicauth_credentials:
   - password: consumer-1-password

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/default_golden.yaml
@@ -37,6 +37,12 @@ certificates:
   - certificate:
       id: 8aade13c-1470-46bd-9849-9a74e349214f
     name: 4.example.com
+  tags:
+  - k8s-name:sooper-secret2
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:8aade13c-1470-46bd-9849-9a74e349214f
+  - k8s-version:v1
 - cert: |-
     -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
@@ -74,6 +80,12 @@ certificates:
   - certificate:
       id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
     name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc

--- a/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
+++ b/internal/dataplane/testdata/golden/ingress-v1-rule-with-tls/expression-routes-on_golden.yaml
@@ -37,6 +37,12 @@ certificates:
   - certificate:
       id: 8aade13c-1470-46bd-9849-9a74e349214f
     name: 4.example.com
+  tags:
+  - k8s-name:sooper-secret2
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:8aade13c-1470-46bd-9849-9a74e349214f
+  - k8s-version:v1
 - cert: |-
     -----BEGIN CERTIFICATE-----
     MIIBoTCCAQoCCQC/V5OfTXu7xDANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApr
@@ -74,6 +80,12 @@ certificates:
   - certificate:
       id: c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
     name: 2.example.com
+  tags:
+  - k8s-name:sooper-secret
+  - k8s-namespace:bar-namespace
+  - k8s-kind:Secret
+  - k8s-uid:c6ac927c-4f5a-4e88-8b5d-c7b01d0f43af
+  - k8s-version:v1
 services:
 - connect_timeout: 60000
   host: foo-svc.bar-namespace.80.svc


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport https://github.com/Kong/kubernetes-ingress-controller/pull/7991

(cherry picked from commit 287127f9f14196e2dffc6d9ebb75c8c4c8189b4d)

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
