### PR TITLE
chore(ci): adjust for Kong Gateway >= 3.15 (EE only)

### DIFF
--- a/.github/workflows/_conformance_tests.yaml
+++ b/.github/workflows/_conformance_tests.yaml
@@ -3,6 +3,32 @@ name: conformance tests
 on:
   workflow_call:
     inputs:
+      kong-container-repo:
+        type: string
+        default: "kong/kong"
+        required: false
+      kong-container-tag:
+        type: string
+        default: "<from_test_dependencies.yaml>"
+        required: false
+      kong-oss-effective-version:
+        # specifies effective semver of Kong gateway OSS when tag is not a valid semver (like 'nightly').
+        type: string
+        default: ""
+        required: false
+      kong-enterprise-container-repo:
+        type: string
+        default: "kong/kong-gateway"
+        required: false
+      kong-enterprise-container-tag:
+        type: string
+        default: "<from_test_dependencies.yaml>"
+        required: false
+      kong-enterprise-effective-version:
+        # specifies effective semver of Kong gateway enterprise when tag is not a valid semver (like 'nightly').
+        type: string
+        default: ""
+        required: false
       log-output-file:
         # specifies the file for KIC manager's logs to output to.
         type: string
@@ -17,6 +43,9 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
     outputs:
+      kind: ${{ steps.set-versions.outputs.kind }}
+      kong-ee: ${{ steps.set-versions.outputs.kong-ee }}
+      kong-oss: ${{ steps.set-versions.outputs.kong-oss }}
       helm-kong: ${{ steps.set-versions.outputs.helm-kong }}
     steps:
       - name: Harden Runner
@@ -29,28 +58,72 @@ jobs:
       - id: set-versions
         name: Set versions
         run: |
-          echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )" >> $GITHUB_OUTPUT
+          (
+            echo "kind=$(yq -ojson -r '.integration.kind' < .github/test_dependencies.yaml )"
+            echo "kong-ee=$(yq -ojson -r '.integration.kong-ee' < .github/test_dependencies.yaml )"
+            echo "kong-oss=$(yq -ojson -r '.integration.kong-oss' < .github/test_dependencies.yaml )"
+            echo "helm-kong=$(yq -ojson -r '.integration.helm.kong' < .github/test_dependencies.yaml )"
+          ) >> $GITHUB_OUTPUT
 
   conformance-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: dependencies-versions
     env:
+      KONG_CLUSTER_VERSION: ${{ needs.dependencies-versions.outputs.kind }}
       TEST_KONG_HELM_CHART_VERSION: ${{ needs.dependencies-versions.outputs.helm-kong }}
     strategy:
       fail-fast: false
       matrix:
         include:
-        - name: traditional-compatible-router
-          router-flavor: traditional_compatible
-        - name: expressions-router
-          router-flavor: expressions
+          - name: traditional-compatible-router
+            router-flavor: traditional_compatible
+          - name: expressions-router
+            router-flavor: expressions
+          - name: enterprise-traditional-compatible-router
+            router-flavor: traditional_compatible
+            enterprise: true
+          - name: enterprise-expressions-router
+            router-flavor: expressions
+            enterprise: true
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+        id: license
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Set image of Kong
+        id: set_kong_image
+        run: |
+          kong_ee_tag="${{ inputs.kong-enterprise-container-tag }}"
+          if [ "${{ inputs.kong-enterprise-container-tag }}" == "<from_test_dependencies.yaml>" ]; then
+            kong_ee_tag=${{ needs.dependencies-versions.outputs.kong-ee }}
+          fi
+          kong_oss_tag="${{ inputs.kong-container-tag }}"
+          if [ "${{ inputs.kong-container-tag }}" == "<from_test_dependencies.yaml>" ]; then
+            kong_oss_tag=${{ needs.dependencies-versions.outputs.kong-oss }}
+          fi
+
+          if [ "${{ matrix.enterprise }}" == "true" ]; then
+            (
+              echo "TEST_KONG_IMAGE=${{ inputs.kong-enterprise-container-repo }}"
+              echo "TEST_KONG_TAG=${kong_ee_tag}"
+              echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-enterprise-effective-version }}"
+              echo "TEST_KONG_ENTERPRISE=true"
+            ) >> $GITHUB_ENV
+          else
+            (
+              echo "TEST_KONG_IMAGE=${{ inputs.kong-container-repo }}"
+              echo "TEST_KONG_TAG=${kong_oss_tag}"
+              echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-oss-effective-version }}"
+            ) >> $GITHUB_ENV
+          fi
+
       - name: checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -70,6 +143,7 @@ jobs:
         env:
           MISE_VERBOSE: 1
           MISE_DEBUG: 1
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           JUNIT_REPORT: ${{ env.JUNIT_REPORT }}
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
           TEST_KONG_KIC_MANAGER_LOG_OUTPUT: ${{ inputs.log-output-file }}
@@ -78,7 +152,7 @@ jobs:
       - name: upload KIC logs
         if: ${{ failure() && inputs.log-output-file != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with: 
+        with:
           name: ${{ matrix.name }}-kic-logs
           path: ${{ inputs.log-output-file }}
           if-no-files-found: ignore
@@ -93,7 +167,7 @@ jobs:
   merge-junit-test-reports:
     runs-on: ubuntu-latest
     needs:
-    - conformance-tests
+      - conformance-tests
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -13,5 +13,8 @@ var KongRedirectPluginCutoff = semver.Version{Major: 3, Minor: 9, Patch: 0}
 // KongStickySessionsCutoff is the lowest version of Kong Gateway that supports `sticky_sessions` loadbalancing algorithm.
 var KongStickySessionsCutoff = semver.Version{Major: 3, Minor: 11, Patch: 0}
 
+// KongEnterpriseCutoff is the lowest version of Kong Gateway that is enterprise only.
+var KongEnterpriseCutoff = semver.Version{Major: 3, Minor: 15, Patch: 0}
+
 // DeckFileFormatVersion is the version of the decK file format used by KIC everywhere.
 const DeckFileFormatVersion = "3.0"

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -51,6 +51,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	if testenv.IsKongGatewayVersionEnterpriseOnly() && !testenv.KongEnterpriseEnabled() {
+		fmt.Println("INFO: skipping suite, because Kong Gateway >= 3.15 is enterprise only")
+		os.Exit(0)
+	}
 	var code int
 	defer func() {
 		os.Exit(code)

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -44,6 +44,10 @@ var tenv env.Environment
 // -----------------------------------------------------------------------------
 
 func TestMain(m *testing.M) {
+	if testenv.IsKongGatewayVersionEnterpriseOnly() && !testenv.KongEnterpriseEnabled() {
+		fmt.Println("INFO: skipping suite, because Kong Gateway >= 3.15 is enterprise only")
+		os.Exit(0)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -38,6 +38,10 @@ import (
 var kongGatewayVersion kongversion.Version
 
 func TestMain(m *testing.M) {
+	if testenv.IsKongGatewayVersionEnterpriseOnly() && !testenv.KongEnterpriseEnabled() {
+		fmt.Println("INFO: skipping suite, because Kong Gateway >= 3.15 is enterprise only")
+		os.Exit(0)
+	}
 	var code int
 	defer func() {
 		os.Exit(code)

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -5,10 +5,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/blang/semver/v4"
+	kongsemver "github.com/kong/semver/v4"
+	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"sigs.k8s.io/yaml"
 
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 )
 
 // -----------------------------------------------------------------------------
@@ -78,6 +82,15 @@ func KongImage() string {
 // KongTag is the Kong image tag to use in tests.
 func KongTag() string {
 	return os.Getenv("TEST_KONG_TAG")
+}
+
+// IsKongGatewayVersionEnterpriseOnly indicates if the Kong Gateway
+// version is enterprise only (basically unusable without license).
+func IsKongGatewayVersionEnterpriseOnly() bool {
+	parsed := lo.Must(kongsemver.Parse(KongTag()))
+	v := semver.Version{Major: parsed.Major, Minor: parsed.Minor, Patch: parsed.Patch}
+
+	return v.GTE(versions.KongEnterpriseCutoff)
 }
 
 // KongImageTag is the combined Kong image and tag if both are set, or empty string if not.

--- a/test/internal/testenv/testenv_test.go
+++ b/test/internal/testenv/testenv_test.go
@@ -1,0 +1,55 @@
+package testenv_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
+)
+
+func TestIsKongGatewayEnterpriseOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		kongTag  string
+		expected bool
+	}{
+		{
+			name:     "below cutoff - three-part",
+			kongTag:  "3.14.0",
+			expected: false,
+		},
+		{
+			name:     "below cutoff - four-part",
+			kongTag:  "3.14.0.0",
+			expected: false,
+		},
+		{
+			name:     "at cutoff - four-part",
+			kongTag:  "3.15.0.0",
+			expected: true,
+		},
+		{
+			name:     "at cutoff - four-part with rc pre-release",
+			kongTag:  "3.15.0.0-rc.6",
+			expected: true,
+		},
+		{
+			name:     "above cutoff - four-part",
+			kongTag:  "3.16.0.0",
+			expected: true,
+		},
+		{
+			name:     "above cutoff - higher major",
+			kongTag:  "4.0.0.0",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TEST_KONG_TAG", tc.kongTag)
+			require.Equal(t, tc.expected, testenv.IsKongGatewayVersionEnterpriseOnly())
+		})
+	}
+}

--- a/test/kongintegration/main_test.go
+++ b/test/kongintegration/main_test.go
@@ -1,0 +1,17 @@
+package kongintegration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	if testenv.IsKongGatewayVersionEnterpriseOnly() && !testenv.KongEnterpriseEnabled() {
+		fmt.Println("INFO: skipping suite, because Kong Gateway >= 3.15 is enterprise only")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Kong Gateway >= 3.15 is EE only, hence test suites that run without a license have to be skipped for those versions and still run both for older ones. 

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
