### PR TITLE
chore: bump GKE e2e version to 1.35.6

### DIFF
--- a/.github/test_dependencies.yaml
+++ b/.github/test_dependencies.yaml
@@ -12,7 +12,7 @@ e2e:
     - 'v1.31.14'
   gke:
     # renovate: datasource=custom.gke-rapid depName=gke versioning=semver
-    - '1.35.5'
+    - '1.35.6'
 
   # For Istio, we define combinations of Kind and Istio versions that will be
   # used directly in the test matrix `include` section.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:


```
=== RUN   TestDeployAllInOneEnterpriseDBLESS
    all_in_one_test.go:43: configuring manifests/all-in-one-dbless-k4k8s-enterprise.yaml manifest test
=== PAUSE TestDeployAllInOneEnterpriseDBLESS
=== CONT  TestDeployAllInOneEnterpriseDBLESS
    all_in_one_test.go:48: building test cluster and environment
    all_in_one_test.go:48: no existing cluster provided, creating a new one for "gke" type
    all_in_one_test.go:48: creating a GKE cluster builder
    all_in_one_test.go:48: creating GKE cluster, name: e2e-3c802dd4-eb5d-4108-8573-1a7d51f8c839
    all_in_one_test.go:48: creating GKE cluster, with requested version: 1.35.5
    all_in_one_test.go:48: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/helpers_test.go:109
        	            				/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/all_in_one_test.go:48
        	Error:      	Received unexpected error:
        	            	rpc error: code = InvalidArgument desc = No valid versions with the prefix "1.35.5" found.
        	            	error details: name = RequestInfo id = 0x779ba97490c9eca8 data =
        	Test:       	TestDeployAllInOneEnterpriseDBLESS
--- FAIL: TestDeployAllInOneEnterpriseDBLESS (0.53s)
FAIL
FAIL	github.com/kong/kubernetes-ingress-controller/v3/test/e2e	0.917s

=== Failed
=== FAIL: test/e2e TestDeployAllInOneEnterpriseDBLESS (0.53s)
    all_in_one_test.go:43: configuring manifests/all-in-one-dbless-k4k8s-enterprise.yaml manifest test
    all_in_one_test.go:48: building test cluster and environment
    all_in_one_test.go:48: no existing cluster provided, creating a new one for "gke" type
    all_in_one_test.go:48: creating a GKE cluster builder
    all_in_one_test.go:48: creating GKE cluster, name: e2e-3c802dd4-eb5d-4108-8573-1a7d51f8c839
    all_in_one_test.go:48: creating GKE cluster, with requested version: 1.35.5
    all_in_one_test.go:48: 
        	Error Trace:	/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/helpers_test.go:109
        	            				/home/runner/work/kubernetes-ingress-controller/kubernetes-ingress-controller/test/e2e/all_in_one_test.go:48
        	Error:      	Received unexpected error:
        	            	rpc error: code = InvalidArgument desc = No valid versions with the prefix "1.35.5" found.
        	            	error details: name = RequestInfo id = 0x779ba97490c9eca8 data =
        	Test:       	TestDeployAllInOneEnterpriseDBLESS

DONE 1 tests, 1 failure in 0.917s
```

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/28573841318/job/84724924600#logs

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

> Version [1.36.0-gke.3302004](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1360) is now the default version for cluster creation in the Rapid channel.
> The following versions are now available in the Rapid channel:
> [1.33.12-gke.1270000](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13312)
> [1.34.9-gke.1065000](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1349)
> [1.35.6-gke.1049000](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1356)
> [1.36.0-gke.3302004](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1360)
> [1.36.0-gke.3712000](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1360)
> The following versions are no longer available in the Rapid channel:
> 1.33.12-gke.1165000
> 1.34.8-gke.1278000
> 1.35.5-gke.1241004
> 1.36.0-gke.3070003
> 1.36.0-gke.3302001 is [deprecated](https://docs.cloud.google.com/kubernetes-engine/versioning#patch-version-support) in the Rapid channel. This version will be removed in 90 days, or at the end of support, if sooner.
> 

https://docs.cloud.google.com/kubernetes-engine/docs/release-notes-rapid

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
