### PR TITLE
[Backport release/3.5.x] chore: bump go-kong v0.72.2

### DIFF
--- a/.github/workflows/_integration_tests.yaml
+++ b/.github/workflows/_integration_tests.yaml
@@ -148,7 +148,7 @@ jobs:
             enterprise: true
 
     steps:
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,16 @@ Adding a new version? You'll need three changes:
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
 
+## Unreleased
+
+### Fixed
+
+- Bump go-kong to `v0.72.2`, which fixes `FillPluginsDefaults` overwriting
+  user-provided values of plugin config fields of type `json` with `nil`.
+  JSON object values (such as the `ai-mcp-proxy` plugin's `tool.request_body`)
+  are now preserved as-is.
+  [#8038](https://github.com/Kong/kubernetes-ingress-controller/pull/8038)
+
 ## [3.5.11]
 
 > Release date: 2026-07-16

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.31.6
-	github.com/kong/go-kong v0.72.1
+	github.com/kong/go-kong v0.72.2
 	github.com/kong/kubernetes-configuration v1.5.2
 	github.com/kong/kubernetes-telemetry v0.1.10
 	github.com/kong/kubernetes-testing-framework v0.47.2-patch.3

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-database-reconciler v1.31.6 h1:Tfjh7NCp6mujfP53qCDOUrEyxw2ZN7h8LzFtKqd35xQ=
 github.com/kong/go-database-reconciler v1.31.6/go.mod h1:A6BBhnK1AQ7mQAsnLHoAitS62nJRGqUI8NbjC1aRGOc=
-github.com/kong/go-kong v0.72.1 h1:rQ69f3Wd0Fvc3JANkavo34vePqR4uZG/YQ2y5U7d2Po=
-github.com/kong/go-kong v0.72.1/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
+github.com/kong/go-kong v0.72.2 h1:7sspaSgBwmU6qFeC2xEyt3wMUcIyJT/0np0tcA5FPSU=
+github.com/kong/go-kong v0.72.2/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
 github.com/kong/kubernetes-configuration v1.5.2 h1:E7aL+M7/wnqOkG3WXcO0Kx4Ru/7IM2WwtFv6h8Rx05w=
 github.com/kong/kubernetes-configuration v1.5.2/go.mod h1:DuPOhI2Ljm0EFE/rlL21DiURiqrcnc2Fs/rxVmeWNd0=
 github.com/kong/kubernetes-telemetry v0.1.10 h1:V+/Lco8VFY/CzoELwOPcGTyg0zbj/HAvoFkH50UsKYs=

--- a/internal/dataplane/deckgen/generate_test.go
+++ b/internal/dataplane/deckgen/generate_test.go
@@ -66,6 +66,90 @@ func TestFillPlugin(t *testing.T) {
 		expectedError error
 	}{
 		{
+			// NOTE: This fails with go-kong v0.72.1, where FillPluginsDefaults
+			// nulls a json-typed config field that holds a JSON object (e.g. the
+			// ai-mcp-proxy plugin's tool.request_body), while a json-typed field
+			// holding a JSON array (tool.parameters) is preserved. See
+			// https://github.com/Kong/go-kong/pull/625.
+			name: "json-typed config field holding an object is preserved",
+			plugin: &file.FPlugin{
+				Plugin: kong.Plugin{
+					Name: lo.ToPtr("ai-mcp-proxy"),
+					Config: kong.Configuration{
+						"tools": []interface{}{
+							map[string]interface{}{
+								"name": "create-issue",
+								"parameters": []interface{}{
+									map[string]interface{}{"name": "updateHistory", "in": "query"},
+								},
+								"request_body": map[string]interface{}{
+									"content": map[string]interface{}{
+										"application/json": map[string]interface{}{
+											"schema": map[string]interface{}{"type": "object"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			schemas: &mockPluginSchemaStore{
+				map[string]interface{}{
+					"fields": []interface{}{
+						map[string]interface{}{
+							"config": map[string]interface{}{
+								"type": "record",
+								"fields": []interface{}{
+									map[string]interface{}{
+										"tools": map[string]interface{}{
+											"type":     "array",
+											"required": false,
+											"elements": map[string]interface{}{
+												"type": "record",
+												"fields": []interface{}{
+													map[string]interface{}{"name": map[string]interface{}{"type": "string", "required": false}},
+													map[string]interface{}{"parameters": map[string]interface{}{"type": "json"}},
+													map[string]interface{}{"request_body": map[string]interface{}{"type": "json"}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &file.FPlugin{
+				Plugin: kong.Plugin{
+					Name: lo.ToPtr("ai-mcp-proxy"),
+					Protocols: []*string{
+						lo.ToPtr("http"),
+						lo.ToPtr("https"),
+					},
+					Enabled: lo.ToPtr(true),
+					Config: kong.Configuration{
+						"tools": []interface{}{
+							kong.Configuration{
+								"name": "create-issue",
+								"parameters": []interface{}{
+									map[string]interface{}{"name": "updateHistory", "in": "query"},
+								},
+								"request_body": map[string]interface{}{
+									"content": map[string]interface{}{
+										"application/json": map[string]interface{}{
+											"schema": map[string]interface{}{"type": "object"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Required field provided for plugin",
 			plugin: &file.FPlugin{
 				Plugin: kong.Plugin{

--- a/test/integration/isolated/license_test.go
+++ b/test/integration/isolated/license_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testlabels"
 )
 
@@ -42,8 +42,8 @@ func TestKongLicense(t *testing.T) {
 		).Assess(
 		"Expect Licenses available when KongLicense created",
 		func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-			licenseString, err := ktfkong.GetLicenseJSONFromEnv()
-			require.NoError(t, err)
+			licenseString := testenv.KongLicenseData()
+			require.NoError(t, helpers.ValidateKongLicense(licenseString))
 
 			kongLicenseResource := &configurationv1alpha1.KongLicense{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -2,12 +2,16 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
+	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
@@ -102,4 +106,29 @@ func GetKongLicenses(ctx context.Context, proxyAdminURL *url.URL, kongTestPasswo
 		return nil, err
 	}
 	return kc.Licenses.ListAll(ctx)
+}
+
+// ValidateKongLicense validates the license data and returns an error if the license is invalid or expired.
+func ValidateKongLicense(licenseData string) error {
+	licenseObj := &ktfkong.License{}
+	if err := json.Unmarshal([]byte(licenseData), licenseObj); err != nil {
+		return fmt.Errorf("invalid license JSON: %w", err)
+	}
+
+	// partialRFC3339Regex matches timestamps that only contain the date portion
+	// of an RFC3339 timestamp, as commonly used in Kong license timestamps.
+	partialRFC3339Regex := regexp.MustCompile("^[0-9]+-[0-9]+-[0-9]+$")
+
+	expirationDateStr := licenseObj.Data.Payload.ExpirationDate
+	if partialRFC3339Regex.MatchString(expirationDateStr) {
+		expirationDateStr = fmt.Sprintf("%sT00:00:01Z", expirationDateStr)
+	}
+	expirationDate, err := time.Parse(time.RFC3339, expirationDateStr)
+	if err != nil {
+		return fmt.Errorf("invalid license date (%s): %w", expirationDateStr, err)
+	}
+	if time.Now().UTC().After(expirationDate) {
+		return fmt.Errorf("the provided license is expired")
+	}
+	return nil
 }

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -17,8 +17,8 @@ func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
 	kongbuilder := kong.NewBuilder().WithNamespace(consts.ControllerNamespace)
 	extraControllerArgs := []string{}
 	if testenv.KongEnterpriseEnabled() {
-		licenseJSON, err := kong.GetLicenseJSONFromEnv()
-		if err != nil {
+		licenseJSON := testenv.KongLicenseData()
+		if err := ValidateKongLicense(licenseJSON); err != nil {
 			return nil, nil, err
 		}
 		kongbuilder = kongbuilder.WithProxyEnterpriseEnabled(licenseJSON)
@@ -71,8 +71,8 @@ func GenerateKongBuilderWithController() (*kong.Builder, error) {
 	kongbuilder := kong.NewBuilder().WithNamespace(consts.ControllerNamespace)
 
 	if testenv.KongEnterpriseEnabled() {
-		licenseJSON, err := kong.GetLicenseJSONFromEnv()
-		if err != nil {
+		licenseJSON := testenv.KongLicenseData()
+		if err := ValidateKongLicense(licenseJSON); err != nil {
 			return nil, err
 		}
 		kongbuilder = kongbuilder.WithProxyEnterpriseEnabled(licenseJSON)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bumps go-kong from v0.72.1 to v0.72.2 on release/3.5.x.
- Adds regression coverage proving JSON-typed plugin config objects are preserved.
- Adds an unreleased changelog entry.

go-kong v0.72.2 includes Kong/go-kong#625, which fixes FillPluginsDefaults overwriting user-provided JSON plugin config values with nil. This is the release/3.5.x counterpart to #8034.

**Which issue this PR fixes**:

Related to Kong/go-kong#625.

**Special notes for your reviewer**:


**PR Readiness Checklist**:

- [x] the CHANGELOG.md release notes have been updated to reflect this user-facing fix