### PR TITLE
[Backport release/3.4.x] test(helper): use license directly read from env

### DIFF
--- a/.github/workflows/_e2e_tests.yaml
+++ b/.github/workflows/_e2e_tests.yaml
@@ -128,7 +128,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -231,7 +231,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - name: fetch Kong license
+        uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         continue-on-error: true
         id: license
         with:
@@ -360,7 +361,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_envtest_tests.yaml
+++ b/.github/workflows/_envtest_tests.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           install: false
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_kongintegration_tests.yaml
+++ b/.github/workflows/_kongintegration_tests.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_performance_tests.yaml
+++ b/.github/workflows/_performance_tests.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
         id: license
         with:
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -110,6 +110,7 @@ jobs:
       kic-image: ${{ needs.choose-image.outputs.image }}
       load-local-image: ${{ inputs.controller-image == '' }}
       kong-image: kong/kong-gateway-dev:nightly
+      kong-effective-version: "3.15.0"
       # these do not honor the inputs, as this job is intended to be a minimal
       # test against unreleased kong images, with the main run covering the
       # other test conditions

--- a/.github/workflows/test_nightly.yaml
+++ b/.github/workflows/test_nightly.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
       id: license
       with:
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: Kong/kong-license@c4decf08584f84ff8fe8e7cd3c463e0192f6111b # master @ 20250107
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
       id: license
       with:
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/kong/semver/v4 v4.0.1 // indirect
+	github.com/kong/semver/v4 v4.0.1
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/test/consts/versions.go
+++ b/test/consts/versions.go
@@ -1,0 +1,5 @@
+package consts
+
+import "github.com/blang/semver/v4"
+
+var ForceLicenseVersionCutoff = semver.MustParse("3.15.0")

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/metrics"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
@@ -80,8 +81,15 @@ func TestDeployAllInOnePostgres(t *testing.T) {
 	t.Parallel()
 	ctx, env := setupE2ETest(t)
 
+	manifestDeploy := ManifestDeploy{Path: postgresPath}
 	t.Log("deploying kong components")
-	ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	manifestDeploy.Run(ctx, t, env)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)
@@ -97,7 +105,14 @@ func TestDeployAllInOnePostgresWithMultipleReplicas(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: postgresPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 	deployment := deployments.ControllerNN
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
@@ -265,7 +280,15 @@ func TestDeployAllInOnePostgresGatewayDiscovery(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: manifestFilePath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: manifestFilePath}
+	t.Log("deploying kong components")
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
@@ -282,7 +305,14 @@ func TestDeployAllInOneDBLESS(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: manifestFilePath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: manifestFilePath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	ingress := deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -53,7 +53,7 @@ func TestDeployAllInOneEnterpriseDBLESS(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("generating a license secret")
-	licenseSecret, err := kong.GetLicenseSecretFromEnv()
+	licenseSecret, err := helpers.GetLicenseSecretFromEnv()
 	require.NoError(t, err)
 
 	t.Log("deploying kong components")
@@ -232,7 +232,7 @@ func TestDeployAllInOneEnterprisePostgres(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("generating a license secret")
-	licenseSecret, err := kong.GetLicenseSecretFromEnv()
+	licenseSecret, err := helpers.GetLicenseSecretFromEnv()
 	require.NoError(t, err)
 
 	t.Log("deploying kong components")

--- a/test/e2e/compatibilities_test.go
+++ b/test/e2e/compatibilities_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
 // TestKongRouterCompatibility verifies that KIC behaves consistently with all
@@ -34,6 +37,12 @@ func TestKongRouterFlavorCompatibility(t *testing.T) {
 				Patches: []ManifestPatch{
 					patchKongRouterFlavorFn(rf),
 				},
+			}
+			kongImageVersion, err := helpers.GetKongImageVersion()
+			require.NoError(t, err)
+			if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+				t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+				deploy.Patches = append(deploy.Patches, WithLicensePatch(getProxyDeploymentName(deploy.Path)))
 			}
 			deployments := deploy.Run(ctx, t, env)
 			t.Cleanup(func() { deploy.Delete(ctx, t, env) })

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -458,6 +458,7 @@ func TestDefaultIngressClass(t *testing.T) {
 	t.Logf("creating a classless ingress for service %s", service.Name)
 	ingress := generators.NewIngressForService("/abbosiysaltanati", map[string]string{
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
+		annotations.AnnotationPrefix + annotations.ProtocolsKey: "http",
 	}, service)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), kongDeployment.Namespace, ingress))
 

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -119,7 +119,14 @@ func TestWebhookUpdate(t *testing.T) {
 	}()
 
 	t.Log("deploying kong components")
-	ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	manifestDeploy.Run(ctx, t, env)
 
 	certPool := x509.NewCertPool()
 	const firstCertificateHostName = "first.example"
@@ -239,7 +246,14 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 	controllerDeploymentNN := deployments.ControllerNN
 	controllerDeploymentListOptions := metav1.ListOptions{
 		LabelSelector: "app=" + controllerDeploymentNN.Name,
@@ -259,7 +273,7 @@ func TestDeployAllInOneDBLESSGateway(t *testing.T) {
 		}
 	}
 
-	_, err := env.Cluster().Client().AppsV1().Deployments(namespace).Update(ctx, controllerDeployment, metav1.UpdateOptions{})
+	_, err = env.Cluster().Client().AppsV1().Deployments(namespace).Update(ctx, controllerDeployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	t.Log("verifying that KIC waits for Gateway API CRDs and prints proper log")
@@ -395,7 +409,14 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	manifestDeploy.Run(ctx, t, env)
 
 	t.Log("running ingress tests to verify all-in-one deployed ingress controller and proxy are functional")
 	deployIngressWithEchoBackends(ctx, t, env, numberOfEchoBackends)
@@ -413,7 +434,7 @@ func TestDeployAllInOneDBLESSNoLoadBalancer(t *testing.T) {
 				corev1.EnvVar{Name: "CONTROLLER_FEATURE_GATES", Value: consts.DefaultFeatureGates})
 		}
 	}
-	_, err := env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx,
+	_, err = env.Cluster().Client().AppsV1().Deployments(deployment.Namespace).Update(ctx,
 		deployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
@@ -441,13 +462,20 @@ func TestDefaultIngressClass(t *testing.T) {
 	ctx, env := setupE2ETest(t)
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 	kongDeployment := deployments.ControllerNN
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
 	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err := env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(kongDeployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	t.Logf("exposing deployment %s via service", deployment.Name)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -432,6 +432,7 @@ func deployIngressWithEchoBackends(ctx context.Context, t *testing.T, env enviro
 	ingress := generators.NewIngressForService(echoPath, map[string]string{
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 		annotations.AnnotationPrefix + annotations.MethodsKey:   http.MethodGet,
+		annotations.AnnotationPrefix + annotations.ProtocolsKey: "http",
 	}, service)
 	ingress.Spec.IngressClassName = kong.String(ingressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -594,7 +594,8 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 
 	t.Log("pulling the admin api information")
 	adminOutput := struct {
-		Version string `json:"version"`
+		License map[string]any `json:"license"`
+		Version string         `json:"version"`
 	}{}
 
 	require.Eventually(t, func() bool {
@@ -621,6 +622,7 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		}
 		return adminOutput.Version != ""
 	}, adminAPIWait, time.Second)
+	t.Log("Kong Version:", adminOutput.Version)
 	if string(adminOutput.Version[0]) == "3" {
 		// 3.x removed the "-enterprise-edition" string but provided no other indication that something is enterprise
 		require.Len(t, strings.Split(adminOutput.Version, "."), 4,
@@ -629,6 +631,11 @@ func verifyEnterprise(ctx context.Context, t *testing.T, env environments.Enviro
 		require.Contains(t, adminOutput.Version, "enterprise-edition",
 			fmt.Sprintf("actual kong version: %s", adminOutput.Version))
 	}
+
+	// Logging the license information is useful for debugging and for ensuring that the license is valid.
+	licenseInfo := adminOutput.License
+	t.Log("License Support Plan: ", licenseInfo["support_plan"])
+	t.Log("License expiration date:", licenseInfo["license_expiration_date"])
 }
 
 func verifyEnterpriseWithPostgres(ctx context.Context, t *testing.T, env environments.Environment, adminPassword string) {

--- a/test/e2e/istio_test.go
+++ b/test/e2e/istio_test.go
@@ -77,6 +77,14 @@ func TestIstioWithKongIngressGateway(t *testing.T) {
 		WithControllerDisabled().
 		WithProxyAdminServiceTypeLoadBalancer().
 		WithNamespace(consts.ControllerNamespace)
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		licenseJSON, err := kongaddon.GetLicenseJSONFromEnv()
+		require.NoError(t, err, "failed to get Kong license from environment variable")
+		kongBuilder = kongBuilder.WithProxyEnterpriseEnabled(licenseJSON)
+	}
 	kongAddon := kongBuilder.Build()
 
 	t.Log("configuring istio cluster addon for the testing environment")

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,8 @@ import (
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/konnect/nodes"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	testkonnect "github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers/konnect"
 )
 
@@ -69,6 +72,18 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+
+	if kongImageVersion.LT(consts.ForceLicenseVersionCutoff) {
+		testKonnectLicenseActivationWithoutForceLicense(ctx, t, env, rgID)
+	} else {
+		t.Logf("Kong version %s requires a license at the beginning", kongImageVersion)
+		testKonnectLicenseActivationWithForceLicense(ctx, t, env, rgID)
+	}
+}
+
+func testKonnectLicenseActivationWithoutForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {
 	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
 	ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
 
@@ -125,6 +140,37 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	t.Log("done")
 }
 
+func testKonnectLicenseActivationWithForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {
+	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
+	ManifestDeploy{
+		Path: manifestFile,
+		Patches: []ManifestPatch{
+			WithKonnectLicensingPatch(),
+		},
+	}.Run(ctx, t, env)
+	exposeAdminAPI(ctx, t, env, k8stypes.NamespacedName{Namespace: "kong", Name: "proxy-kong"})
+
+	t.Log("confirming that the license is set")
+	assert.Eventually(t, func() bool {
+		license, err := getLicenseFromAdminAPI(ctx, env, "")
+		if err != nil {
+			t.Logf("failed to get license: %v", err)
+			return false
+		}
+		return license.License.Expiration != ""
+	}, adminAPIWait, time.Second)
+
+	skipTestIfControllerVersionBelow(t, semver.MustParse("3.5.1"))
+	t.Log("checking if the license is stored in the local secret")
+	secret, err := env.Cluster().Client().CoreV1().Secrets(namespace).Get(
+		ctx, "konnect-license-"+rgID, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, secret.Data, "secret to store Konnect license should not be empty")
+	require.NotEmpty(t, secret.Data["id"], "stored license should have a non-empty ID")
+
+	t.Log("done")
+}
+
 func TestKonnectWhenMisconfiguredBasicIngressNotAffected(t *testing.T) {
 	t.Parallel()
 	testkonnect.SkipIfMissingRequiredKonnectEnvVariables(t)
@@ -150,7 +196,14 @@ func deployAllInOneKonnectManifest(ctx context.Context, t *testing.T, env enviro
 	const manifestFile = "manifests/all-in-one-dbless-konnect.yaml"
 	t.Logf("deploying %s manifest file", manifestFile)
 
-	return ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: manifestFile}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	return manifestDeploy.Run(ctx, t, env)
 }
 
 // createKonnectClientSecretAndConfigMap creates a Secret with client TLS certificate that is used by KIC to communicate

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -78,10 +77,10 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
-	testKonnectLicenseActivationWithoutForceLicense(ctx, t, env, rgID)
+	testKonnectLicenseActivationWithoutForceLicense(ctx, t, env)
 }
 
-func testKonnectLicenseActivationWithoutForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {
+func testKonnectLicenseActivationWithoutForceLicense(ctx context.Context, t *testing.T, env environment.Environment) {
 	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
 	ManifestDeploy{Path: manifestFile}.Run(ctx, t, env)
 
@@ -135,37 +134,6 @@ func testKonnectLicenseActivationWithoutForceLicense(ctx context.Context, t *tes
 		}
 		return license.License.Expiration != ""
 	}, adminAPIWait, time.Second)
-	t.Log("done")
-}
-
-func testKonnectLicenseActivationWithForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {
-	const manifestFile = "manifests/all-in-one-dbless-konnect-enterprise.yaml"
-	ManifestDeploy{
-		Path: manifestFile,
-		Patches: []ManifestPatch{
-			WithKonnectLicensingPatch(),
-		},
-	}.Run(ctx, t, env)
-	exposeAdminAPI(ctx, t, env, k8stypes.NamespacedName{Namespace: "kong", Name: "proxy-kong"})
-
-	t.Log("confirming that the license is set")
-	assert.Eventually(t, func() bool {
-		license, err := getLicenseFromAdminAPI(ctx, env, "")
-		if err != nil {
-			t.Logf("failed to get license: %v", err)
-			return false
-		}
-		return license.License.Expiration != ""
-	}, adminAPIWait, time.Second)
-
-	skipTestIfControllerVersionBelow(t, semver.MustParse("3.5.1"))
-	t.Log("checking if the license is stored in the local secret")
-	secret, err := env.Cluster().Client().CoreV1().Secrets(namespace).Get(
-		ctx, "konnect-license-"+rgID, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.NotNil(t, secret.Data, "secret to store Konnect license should not be empty")
-	require.NotEmpty(t, secret.Data["id"], "stored license should have a non-empty ID")
-
 	t.Log("done")
 }
 

--- a/test/e2e/konnect_test.go
+++ b/test/e2e/konnect_test.go
@@ -66,21 +66,19 @@ func TestKonnectLicenseActivation(t *testing.T) {
 	t.Parallel()
 	testkonnect.SkipIfMissingRequiredKonnectEnvVariables(t)
 
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Skip("KIC 3.4 does not support activating a Konnect license before Kong Gateway starts")
+	}
+
 	ctx, env := setupE2ETest(t)
 
 	rgID := testkonnect.CreateTestControlPlane(ctx, t)
 	cert, key := testkonnect.CreateClientCertificate(ctx, t, rgID)
 	createKonnectClientSecretAndConfigMap(ctx, t, env, cert, key, rgID)
 
-	kongImageVersion, err := helpers.GetKongImageVersion()
-	require.NoError(t, err)
-
-	if kongImageVersion.LT(consts.ForceLicenseVersionCutoff) {
-		testKonnectLicenseActivationWithoutForceLicense(ctx, t, env, rgID)
-	} else {
-		t.Logf("Kong version %s requires a license at the beginning", kongImageVersion)
-		testKonnectLicenseActivationWithForceLicense(ctx, t, env, rgID)
-	}
+	testKonnectLicenseActivationWithoutForceLicense(ctx, t, env, rgID)
 }
 
 func testKonnectLicenseActivationWithoutForceLicense(ctx context.Context, t *testing.T, env environment.Environment, rgID string) {

--- a/test/e2e/kuma_test.go
+++ b/test/e2e/kuma_test.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
@@ -24,7 +26,15 @@ func TestDeployAllInOneDBLESSKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, buildKumaAddon(t))
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: dblessPath}.Run(ctx, t, env)
+
+	manifestDeploy := ManifestDeploy{Path: dblessPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("adding Kuma mesh")
 	require.NoError(t, kuma.EnableMeshForNamespace(ctx, env.Cluster(), "kong"))
@@ -46,7 +56,14 @@ func TestDeployAllInOnePostgresKuma(t *testing.T) {
 	ctx, env := setupE2ETest(t, buildKumaAddon(t))
 
 	t.Log("deploying kong components")
-	deployments := ManifestDeploy{Path: postgresPath}.Run(ctx, t, env)
+	manifestDeploy := ManifestDeploy{Path: postgresPath}
+	kongImageVersion, err := helpers.GetKongImageVersion()
+	require.NoError(t, err)
+	if kongImageVersion.GTE(consts.ForceLicenseVersionCutoff) {
+		t.Logf("Kong version %s requires a license, patching the manifest", kongImageVersion)
+		manifestDeploy.Patches = append(manifestDeploy.Patches, WithLicensePatch(getProxyDeploymentName(manifestDeploy.Path)))
+	}
+	deployments := manifestDeploy.Run(ctx, t, env)
 
 	t.Log("this deployment used a postgres backend, verifying that postgres migrations ran properly")
 	verifyPostgres(ctx, t, env)

--- a/test/e2e/kustomizations_test.go
+++ b/test/e2e/kustomizations_test.go
@@ -3,14 +3,19 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/kubectl"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/helpers"
 )
 
 const (
@@ -177,4 +182,108 @@ func patchLivenessProbes(baseManifestReader io.Reader, deployment k8stypes.Names
 		},
 	}
 	return kubectl.GetKustomizedManifest(kustomization, baseManifestReader)
+}
+
+const kongLicenseEnvPatch = `- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: KONG_LICENSE_DATA
+    valueFrom:
+      secretKeyRef:
+        key: license
+        name: kong-enterprise-license`
+
+// WithLicensePatch injects the enterprise license from the environment into the deployed
+// manifest. It adds the KONG_LICENSE_DATA env var (referencing the kong-enterprise-license
+// secret) to the proxy container of the given proxy deployment and appends the secret itself.
+// proxyDeploymentName must be the name of the deployment that runs the proxy container, which
+// differs between manifest variants (proxy-kong for multi-pod, ingress-kong for single-pod);
+// use getProxyDeploymentName to derive it from the manifest path.
+func WithLicensePatch(proxyDeploymentName string) ManifestPatch {
+	return func(r io.Reader) (io.Reader, error) {
+		licenseSecret, err := helpers.GetLicenseSecretFromEnv()
+		if err != nil {
+			return nil, err
+		}
+		// GetLicenseSecretFromEnv returns a secret without TypeMeta/namespace; both are
+		// required for it to apply cleanly into the kong namespace via `kubectl apply -f -`.
+		licenseSecret.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}
+		licenseSecret.Namespace = namespace
+
+		// Add the KONG_LICENSE_DATA env var (referencing the secret) to the proxy
+		// container (index 0) of the proxy deployment.
+		kustomization := types.Kustomization{
+			Patches: []types.Patch{
+				{
+					Patch: kongLicenseEnvPatch,
+					Target: &types.Selector{
+						ResId: resid.ResId{
+							Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"},
+							Name:      proxyDeploymentName,
+							Namespace: namespace,
+						},
+					},
+				},
+			},
+		}
+		patched, err := kubectl.GetKustomizedManifest(kustomization, r)
+		if err != nil {
+			return nil, err
+		}
+
+		// Append the license secret as an additional document so it is created
+		// alongside the deployment.
+		secretYAML, err := yaml.Marshal(licenseSecret)
+		if err != nil {
+			return nil, err
+		}
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, patched); err != nil {
+			return nil, err
+		}
+		buf.WriteString("\n---\n")
+		buf.Write(secretYAML)
+		return &buf, nil
+	}
+}
+
+// konnectLicensingEnvPatch is the patch to add the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
+const konnectLicensingEnvPatch = `- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: CONTROLLER_KONNECT_LICENSING_ENABLED
+    value: "true"`
+
+// WithKonnectLicensingPatch adds the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
+// This is required for tests that involve Konnect licensing with Kong versions that require a license at startup,
+// since the presence of this env var changes the licensing activation flow to be compatible with such versions.
+func WithKonnectLicensingPatch() ManifestPatch {
+	return func(r io.Reader) (io.Reader, error) {
+		ingressDeploymentName := "ingress-kong"
+		// Add the CONTROLLER_KONNECT_LICENSING_ENABLED env var to the controller container to enable Konnect licensing behavior.
+		kustomization := types.Kustomization{
+			Patches: []types.Patch{
+				{
+					Patch: konnectLicensingEnvPatch,
+					Target: &types.Selector{
+						ResId: resid.ResId{
+							Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"},
+							Name:      ingressDeploymentName,
+							Namespace: namespace,
+						},
+					},
+				},
+			},
+		}
+		patched, err := kubectl.GetKustomizedManifest(kustomization, r)
+		if err != nil {
+			return nil, err
+		}
+
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, patched); err != nil {
+			return nil, err
+		}
+		return &buf, nil
+	}
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,7 +17,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/kong/go-kong/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/sethvargo/go-password/password"
@@ -239,22 +237,6 @@ func patchControllerImageFromEnv(t *testing.T, manifestReader io.Reader) (io.Rea
 
 	t.Log("controller image override undefined, using defaults")
 	return manifestReader, nil
-}
-
-// getKongVersionFromOverrideTag parses Kong version from env effective version or override tag. The effective version
-// takes precedence.
-//
-//lint:ignore U1000 retained for future use
-func getKongVersionFromOverrideTag() (kong.Version, error) {
-	if kongEffectiveVersion := testenv.KongEffectiveVersion(); kongEffectiveVersion != "" {
-		return kong.ParseSemanticVersion(kongEffectiveVersion)
-	}
-
-	if testenv.KongImageTag() == "" {
-		return kong.Version{}, errors.New("No Kong tag provided")
-	}
-
-	return kong.ParseSemanticVersion(testenv.KongTag())
 }
 
 // getKongProxyIP takes a Service with Kong proxy ports and returns and its IP, or fails the test if it cannot.

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -801,9 +801,11 @@ func TestPluginNullInConfig(t *testing.T) {
 	t.Logf("Checking the configuration of the plugin %s in Kong", kongplugin.Name)
 	kc, err := adminapi.NewKongAPIClient(proxyAdminURL.String(), managercfg.AdminAPIClientConfig{}, consts.KongTestPassword)
 	require.NoError(t, err, "failed to create Kong client")
+
 	// For integration tests in enterprise edition and postgres DB backed Kong gateway,
 	// the tests are run in "notdefault" workspace of Kong.
-	if testenv.DBMode() != testenv.DBModeOff && testenv.KongEnterpriseEnabled() {
+	// Kong gateway 3.15 and later forces presence of a license, so the tests are run in "notdefault" workspace of Kong.
+	if testenv.DBMode() != testenv.DBModeOff && (testenv.KongEnterpriseEnabled() || kongGatewayVersionRequiresLicense()) {
 		kc.SetWorkspace(consts.KongTestWorkspace)
 	}
 	require.Eventually(t, func() bool {

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -123,3 +123,10 @@ func eventuallyGetKongRouterFlavor(ctx context.Context, t *testing.T, adminURL *
 	}, time.Minute, time.Second)
 	return routerFlavor
 }
+
+// kongGatewayVersionRequiresLicense returns true if the Kong Gateway version requires a license to run.
+func kongGatewayVersionRequiresLicense() bool {
+	return kongGatewayVersion.IsKongGatewayEnterprise() &&
+		kongGatewayVersion.Major() >= consts.ForceLicenseVersionCutoff.Major &&
+		kongGatewayVersion.Minor() >= consts.ForceLicenseVersionCutoff.Minor
+}

--- a/test/internal/helpers/kong.go
+++ b/test/internal/helpers/kong.go
@@ -12,12 +12,15 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/kong/go-kong/kong"
 	ktfkong "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/adminapi"
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/manager/utils/kongconfig"
 	"github.com/kong/kubernetes-ingress-controller/v3/internal/versions"
 	managercfg "github.com/kong/kubernetes-ingress-controller/v3/pkg/manager/config"
+	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
 // GetKongRootConfig gets version and root configurations of Kong from / endpoint of the provided Admin API URL.
@@ -106,6 +109,24 @@ func GetKongLicenses(ctx context.Context, proxyAdminURL *url.URL, kongTestPasswo
 		return nil, err
 	}
 	return kc.Licenses.ListAll(ctx)
+}
+
+// GetLicenseSecretFromEnv returns a secret object containing the license data from the environment variable KONG_LICENSE_DATA.
+// It validates the license data and returns an error if the license is invalid or missing.
+func GetLicenseSecretFromEnv() (*corev1.Secret, error) {
+	licenseData := testenv.KongLicenseData()
+	if err := ValidateKongLicense(licenseData); err != nil {
+		return nil, err
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kong-enterprise-license",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"license": []byte(licenseData),
+		},
+	}, nil
 }
 
 // ValidateKongLicense validates the license data and returns an error if the license is invalid or expired.

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -4,19 +4,44 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	kongsemver "github.com/kong/semver/v4"
 
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
+// GetKongImageVersion returns the Kong version to be used for the KTF addon based on environment variables.
+func GetKongImageVersion() (semver.Version, error) {
+	kongVersion, err := semver.Parse(testenv.KongEffectiveVersion())
+	if err == nil {
+		return kongVersion, nil
+	}
+	// Use kong/semver to parse the version string in the TEST_KONG_TAG in case it is a four-digit version like "3.15.0.0".
+	kongsemverVersion, err := kongsemver.Parse(testenv.KongTag())
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("could not parse Kong version from TEST_KONG_EFFECTIVE_VERSION or TEST_KONG_TAG: %w", err)
+	}
+	return semver.Version{
+		Major: kongsemverVersion.Major,
+		Minor: kongsemverVersion.Minor,
+		Patch: kongsemverVersion.Patch,
+	}, nil
+}
+
 // GenerateKongBuilder returns a Kong KTF addon builder, a string slice
 // of controller arguments needed to interact with the addon and an error.
 func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
+	kongVersion, err := GetKongImageVersion()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not determine Kong version: %w", err)
+	}
+
 	kongbuilder := kong.NewBuilder().WithNamespace(consts.ControllerNamespace)
 	extraControllerArgs := []string{}
-	if testenv.KongEnterpriseEnabled() {
+	if testenv.KongEnterpriseEnabled() || kongVersion.GTE(consts.ForceLicenseVersionCutoff) {
 		licenseJSON := testenv.KongLicenseData()
 		if err := ValidateKongLicense(licenseJSON); err != nil {
 			return nil, nil, err

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -15,6 +15,13 @@ import (
 
 // GetKongImageVersion returns the Kong version to be used for the KTF addon based on environment variables.
 func GetKongImageVersion() (semver.Version, error) {
+	if testenv.KongEffectiveVersion() == "" && testenv.KongTag() == "" {
+		// No image override is configured. The test will use the version from the
+		// checked-in manifest or the default Helm chart, both of which predate the
+		// version that requires a license.
+		return semver.Version{}, nil
+	}
+
 	kongVersion, err := semver.Parse(testenv.KongEffectiveVersion())
 	if err == nil {
 		return kongVersion, nil

--- a/test/internal/helpers/ktf_test.go
+++ b/test/internal/helpers/ktf_test.go
@@ -1,0 +1,54 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetKongImageVersion(t *testing.T) {
+	testCases := []struct {
+		name             string
+		effectiveVersion string
+		tag              string
+		expected         semver.Version
+		expectError      bool
+	}{
+		{
+			name:     "no image override",
+			expected: semver.Version{},
+		},
+		{
+			name:             "effective version",
+			effectiveVersion: "3.15.0",
+			tag:              "nightly",
+			expected:         semver.MustParse("3.15.0"),
+		},
+		{
+			name:     "four component image tag",
+			tag:      "3.15.0.0",
+			expected: semver.MustParse("3.15.0"),
+		},
+		{
+			name:        "invalid image tag",
+			tag:         "nightly",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TEST_KONG_EFFECTIVE_VERSION", tt.effectiveVersion)
+			t.Setenv("TEST_KONG_TAG", tt.tag)
+
+			actual, err := GetKongImageVersion()
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports the remaining license-handling changes from #8032 to release/3.4.x.

- Updates workflows that still use the old Kong license action.
- Builds the Kubernetes license Secret directly from the original KONG_LICENSE_DATA value, avoiding schema fields being dropped by unmarshalling and re-marshalling through the older KTF License type.
- Adds non-sensitive Kong version and license metadata to e2e diagnostics.

The integration/isolated portion was already included in #8037. This completes the e2e and other workflow paths after the release workflow failed with 403 Enterprise license missing or expired:
https://github.com/Kong/kubernetes-ingress-controller/actions/runs/30538573196/job/90859723408

**Which issue this PR fixes**:

Backport of #8032 , #7931 and #7941

**Special notes for your reviewer**:

Conflicts were resolved by retaining release-specific workflow and helper structure where the relevant #8032 change was already present or the main-only code did not exist on this release line.

Verification:
- The e2e test package compiles with Go 1.25.11 and the e2e_tests build tag.
- make lint.actions passes.
- The license-backed e2e test requires the CI license secret and will be validated by CI.

**PR Readiness Checklist**:

- [x] CHANGELOG.md update is not required for this test-infrastructure-only backport