### PR TITLE
test: fix Kong version detection for nightly images

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -43,7 +43,7 @@ jobs:
       # it reports the next release to be released as semver in the version field.
       # ref: https://github.com/Kong/kubernetes-ingress-controller/issues/4014
       kong-image: kong/kong-gateway-dev:nightly
-      kong-effective-version: "3.4.1"
+      kong-effective-version: "3.15.0"
       all-supported-k8s-versions: false
       run-gke: false
       run-istio: false
@@ -54,10 +54,10 @@ jobs:
     with:
       kong-container-repo: kong/kong-dev
       kong-container-tag: nightly
-      kong-oss-effective-version: "3.4.1"
+      kong-oss-effective-version: "3.15.0"
       kong-enterprise-container-repo: kong/kong-gateway-dev
       kong-enterprise-container-tag: nightly
-      kong-enterprise-effective-version: "3.4.1"
+      kong-enterprise-effective-version: "3.15.0"
       log-output-file:  /tmp/integration-tests-kic-logs
 
   test-reports:

--- a/.github/workflows/e2e_targeted.yaml
+++ b/.github/workflows/e2e_targeted.yaml
@@ -118,6 +118,7 @@ jobs:
       kic-image: ${{ needs.choose-image.outputs.image }}
       load-local-image: ${{ inputs.controller-image == '' }}
       kong-image: kong/kong-gateway-dev:nightly
+      kong-effective-version: "3.15.0"
       # these do not honor the inputs, as this job is intended to be a minimal
       # test against unreleased kong images, with the main run covering the
       # other test conditions

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -51,7 +51,12 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if testenv.IsKongGatewayVersionEnterpriseOnly() && testenv.KongLicenseData() == "" {
+	enterpriseOnly, err := testenv.IsKongGatewayVersionEnterpriseOnly()
+	if err != nil {
+		fmt.Printf("ERROR: failed to determine Kong Gateway version: %v\n", err)
+		os.Exit(1)
+	}
+	if enterpriseOnly && testenv.KongLicenseData() == "" {
 		fmt.Println("ERROR: Kong 3.15+ used and no license provided")
 		os.Exit(1)
 	}

--- a/test/integration/isolated/suite_test.go
+++ b/test/integration/isolated/suite_test.go
@@ -44,7 +44,12 @@ var tenv env.Environment
 // -----------------------------------------------------------------------------
 
 func TestMain(m *testing.M) {
-	if testenv.IsKongGatewayVersionEnterpriseOnly() && testenv.KongLicenseData() == "" {
+	enterpriseOnly, err := testenv.IsKongGatewayVersionEnterpriseOnly()
+	if err != nil {
+		fmt.Printf("ERROR: failed to determine Kong Gateway version: %v\n", err)
+		os.Exit(1)
+	}
+	if enterpriseOnly && testenv.KongLicenseData() == "" {
 		fmt.Println("ERROR: Kong 3.15+ used and no license provided")
 		os.Exit(1)
 	}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -38,7 +38,12 @@ import (
 var kongGatewayVersion kongversion.Version
 
 func TestMain(m *testing.M) {
-	if testenv.IsKongGatewayVersionEnterpriseOnly() && testenv.KongLicenseData() == "" {
+	enterpriseOnly, err := testenv.IsKongGatewayVersionEnterpriseOnly()
+	if err != nil {
+		fmt.Printf("ERROR: failed to determine Kong Gateway version: %v\n", err)
+		os.Exit(1)
+	}
+	if enterpriseOnly && testenv.KongLicenseData() == "" {
 		fmt.Println("ERROR: Kong 3.15+ used and no license provided")
 		os.Exit(1)
 	}

--- a/test/internal/helpers/ktf.go
+++ b/test/internal/helpers/ktf.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
-	kongsemver "github.com/kong/semver/v4"
 
 	dpconf "github.com/kong/kubernetes-ingress-controller/v3/internal/dataplane/config"
 	"github.com/kong/kubernetes-ingress-controller/v3/test/consts"
@@ -15,20 +14,7 @@ import (
 
 // GetKongImageVersion returns the Kong version to be used for the KTF addon based on environment variables.
 func GetKongImageVersion() (semver.Version, error) {
-	kongVersion, err := semver.Parse(testenv.KongEffectiveVersion())
-	if err == nil {
-		return kongVersion, nil
-	}
-	// Use kong/semver to parse the version string in the TEST_KONG_TAG in case it is a four-digit version like "3.15.0.0".
-	kongsemverVersion, err := kongsemver.Parse(testenv.KongTag())
-	if err != nil {
-		return semver.Version{}, fmt.Errorf("could not parse Kong version from TEST_KONG_EFFECTIVE_VERSION or TEST_KONG_TAG: %w", err)
-	}
-	return semver.Version{
-		Major: kongsemverVersion.Major,
-		Minor: kongsemverVersion.Minor,
-		Patch: kongsemverVersion.Patch,
-	}, nil
+	return testenv.KongImageVersion()
 }
 
 // GenerateKongBuilder returns a Kong KTF addon builder, a string slice

--- a/test/internal/testenv/testenv.go
+++ b/test/internal/testenv/testenv.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	kongsemver "github.com/kong/semver/v4"
-	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"sigs.k8s.io/yaml"
 
@@ -84,13 +83,38 @@ func KongTag() string {
 	return os.Getenv("TEST_KONG_TAG")
 }
 
+// KongImageVersion returns the effective Kong Gateway version configured for tests.
+// The effective version takes precedence because image tags such as "nightly" are not
+// valid semantic versions. If no image override is configured, it returns the zero
+// version: those tests use the version from their checked-in manifest or default chart.
+func KongImageVersion() (semver.Version, error) {
+	version, source := KongEffectiveVersion(), "TEST_KONG_EFFECTIVE_VERSION"
+	if version == "" {
+		version, source = KongTag(), "TEST_KONG_TAG"
+	}
+	if version == "" {
+		return semver.Version{}, nil
+	}
+
+	parsed, err := kongsemver.Parse(version)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("could not parse Kong version %q from %s: %w", version, source, err)
+	}
+	return semver.Version{
+		Major: parsed.Major,
+		Minor: parsed.Minor,
+		Patch: parsed.Patch,
+	}, nil
+}
+
 // IsKongGatewayVersionEnterpriseOnly indicates if the Kong Gateway
 // version is enterprise only (basically unusable without license).
-func IsKongGatewayVersionEnterpriseOnly() bool {
-	parsed := lo.Must(kongsemver.Parse(KongTag()))
-	v := semver.Version{Major: parsed.Major, Minor: parsed.Minor, Patch: parsed.Patch}
-
-	return v.GTE(versions.KongEnterpriseCutoff)
+func IsKongGatewayVersionEnterpriseOnly() (bool, error) {
+	v, err := KongImageVersion()
+	if err != nil {
+		return false, err
+	}
+	return v.GTE(versions.KongEnterpriseCutoff), nil
 }
 
 // KongImageTag is the combined Kong image and tag if both are set, or empty string if not.

--- a/test/internal/testenv/testenv_test.go
+++ b/test/internal/testenv/testenv_test.go
@@ -3,17 +3,80 @@ package testenv_test
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-ingress-controller/v3/test/internal/testenv"
 )
 
+func TestKongImageVersion(t *testing.T) {
+	tests := []struct {
+		name             string
+		effectiveVersion string
+		kongTag          string
+		expected         semver.Version
+		expectError      bool
+	}{
+		{
+			name:     "no image override",
+			expected: semver.Version{},
+		},
+		{
+			name:             "effective version takes precedence over nightly tag",
+			effectiveVersion: "3.15.0",
+			kongTag:          "nightly",
+			expected:         semver.MustParse("3.15.0"),
+		},
+		{
+			name:     "three-part tag",
+			kongTag:  "3.14.0",
+			expected: semver.MustParse("3.14.0"),
+		},
+		{
+			name:     "four-part tag",
+			kongTag:  "3.15.0.0-rc.6",
+			expected: semver.MustParse("3.15.0"),
+		},
+		{
+			name:             "invalid effective version",
+			effectiveVersion: "invalid",
+			kongTag:          "3.15.0.0",
+			expectError:      true,
+		},
+		{
+			name:        "invalid tag",
+			kongTag:     "nightly",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TEST_KONG_EFFECTIVE_VERSION", tc.effectiveVersion)
+			t.Setenv("TEST_KONG_TAG", tc.kongTag)
+
+			actual, err := testenv.KongImageVersion()
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestIsKongGatewayEnterpriseOnly(t *testing.T) {
 	tests := []struct {
-		name     string
-		kongTag  string
-		expected bool
+		name             string
+		effectiveVersion string
+		kongTag          string
+		expected         bool
 	}{
+		{
+			name:     "no image override",
+			expected: false,
+		},
 		{
 			name:     "below cutoff - three-part",
 			kongTag:  "3.14.0",
@@ -25,9 +88,10 @@ func TestIsKongGatewayEnterpriseOnly(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "at cutoff - four-part",
-			kongTag:  "3.15.0.0",
-			expected: true,
+			name:             "at cutoff - effective version for nightly",
+			effectiveVersion: "3.15.0",
+			kongTag:          "nightly",
+			expected:         true,
 		},
 		{
 			name:     "at cutoff - four-part with rc pre-release",
@@ -48,8 +112,12 @@ func TestIsKongGatewayEnterpriseOnly(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TEST_KONG_EFFECTIVE_VERSION", tc.effectiveVersion)
 			t.Setenv("TEST_KONG_TAG", tc.kongTag)
-			require.Equal(t, tc.expected, testenv.IsKongGatewayVersionEnterpriseOnly())
+
+			actual, err := testenv.IsKongGatewayVersionEnterpriseOnly()
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/test/kongintegration/main_test.go
+++ b/test/kongintegration/main_test.go
@@ -9,7 +9,12 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if testenv.IsKongGatewayVersionEnterpriseOnly() && testenv.KongLicenseData() == "" {
+	enterpriseOnly, err := testenv.IsKongGatewayVersionEnterpriseOnly()
+	if err != nil {
+		fmt.Printf("ERROR: failed to determine Kong Gateway version: %v\n", err)
+		os.Exit(1)
+	}
+	if enterpriseOnly && testenv.KongLicenseData() == "" {
 		fmt.Println("ERROR: Kong 3.15+ used and no license provided")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

The e2e nightly tests for KIC have been failing for a long time. I resolved the issue when releasing the new version of KIC this time.
https://github.com/Kong/kubernetes-ingress-controller/actions/workflows/e2e_nightly.yaml


**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
