### PR TITLE
fix(ci): use correct OSS nightly Kong version

### DIFF
--- a/.github/workflows/e2e_nightly.yaml
+++ b/.github/workflows/e2e_nightly.yaml
@@ -54,7 +54,9 @@ jobs:
     with:
       kong-container-repo: kong/kong-dev
       kong-container-tag: nightly
-      kong-oss-effective-version: "3.15.0"
+      # OSS and Enterprise nightly images report different versions. Keep this
+      # aligned with the version reported by kong/kong-dev:nightly.
+      kong-oss-effective-version: "3.10.0"
       kong-enterprise-container-repo: kong/kong-gateway-dev
       kong-enterprise-container-tag: nightly
       kong-enterprise-effective-version: "3.15.0"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

The current version returned by OSS nightly is 3.10, but my last PR https://github.com/Kong/kubernetes-ingress-controller/pull/8046 mistakenly set it to the same as the EE version.

https://github.com/Kong/kubernetes-ingress-controller/actions/runs/30788034378/job/91605552835#step:9:147

```
INFO: using Kong instance (version: "3.10.0") reachable at http://172.18.128.2:8001/
```

**Which issue this PR fixes**:

<!--
Here you can add any links to issues that this PR is relevant for.
You can use Github keywords (like: closes, fixes or resolves) to auto-resolve
the linked issue(s) when this PR gets merged.

For example: fixes #<issue number>
-->

**Special notes for your reviewer**:

<!-- Here you can add any open questions or notes that you might have for reviewers -->

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
