### PR TITLE
chore(deps): bump github.com/kong/go-kong to v0.78.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Adding a new version? You'll need three changes:
 * Add the diff link, like "[2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
   This is all the way at the bottom. It's the thing we always forget.
 --->
+ - [3.4.20](#3420)
  - [3.4.19](#3419)
  - [3.4.18](#3418)
  - [3.4.17](#3417)
@@ -118,6 +119,19 @@ Adding a new version? You'll need three changes:
  - [0.1.0](#010)
  - [0.0.5](#005)
  - [0.0.4 and prior](#004-and-prior)
+
+## [3.4.20]
+
+> Release date: 2026-08-07
+
+### Fixed
+
+- Bump go-kong to `v0.78.0`, which fixes problem with syncing to Konnect that
+  manifested with log entries like the below
+
+  ```log
+  error konnect-config-synchronizer Failed to send request to Konnect {<REDACTED> failed: HTTP status 405 (message: "<failed to parse response body: unexpected end of JSON input>")"}
+  ```
 
 ## [3.4.19]
 
@@ -4281,6 +4295,7 @@ Please read the changelog and test in your environment.
  - The initial versions  were rapildy iterated to deliver
    a working ingress controller.
 
+[3.4.20]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.19...v3.4.20
 [3.4.19]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.18...v3.4.19
 [3.4.18]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.17...v3.4.18
 [3.4.17]: https://github.com/kong/kubernetes-ingress-controller/compare/v3.4.16...v3.4.17

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/kong/go-database-reconciler v1.31.6
-	github.com/kong/go-kong v0.72.2
+	github.com/kong/go-kong v0.78.0
 	github.com/kong/kubernetes-configuration v1.5.2
 	github.com/kong/kubernetes-telemetry v0.1.9
 	github.com/kong/kubernetes-testing-framework v0.47.2-patch.3

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kong/go-database-reconciler v1.31.6 h1:Tfjh7NCp6mujfP53qCDOUrEyxw2ZN7h8LzFtKqd35xQ=
 github.com/kong/go-database-reconciler v1.31.6/go.mod h1:A6BBhnK1AQ7mQAsnLHoAitS62nJRGqUI8NbjC1aRGOc=
-github.com/kong/go-kong v0.72.2 h1:7sspaSgBwmU6qFeC2xEyt3wMUcIyJT/0np0tcA5FPSU=
-github.com/kong/go-kong v0.72.2/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
+github.com/kong/go-kong v0.78.0 h1:VK5g26BCeF+l9o3j3pgU3BOuOdmTd9Vj33x29mKGtkg=
+github.com/kong/go-kong v0.78.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/kubernetes-configuration v1.5.2 h1:E7aL+M7/wnqOkG3WXcO0Kx4Ru/7IM2WwtFv6h8Rx05w=
 github.com/kong/kubernetes-configuration v1.5.2/go.mod h1:DuPOhI2Ljm0EFE/rlL21DiURiqrcnc2Fs/rxVmeWNd0=
 github.com/kong/kubernetes-telemetry v0.1.9 h1:XbDMZjZZclHO4oyJGW1mmZ6bzbTnANjcRAYsBg+jpno=


### PR DESCRIPTION
The same as #8056