### PR TITLE
fix(tests): correct typo in skip message ('skiping' -> 'skipping')

### DIFF
--- a/test/integration/isolated/skip.go
+++ b/test/integration/isolated/skip.go
@@ -15,7 +15,7 @@ import (
 func SkipIfRouterNotExpressions(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 	flavor := testenv.KongRouterFlavor()
 	if flavor != dpconf.RouterFlavorExpressions {
-		t.Skipf("skiping, %q router flavor specified via TEST_KONG_ROUTER_FLAVOR env but %q is required", flavor, "expressions")
+		t.Skipf("skipping, %q router flavor specified via TEST_KONG_ROUTER_FLAVOR env but %q is required", flavor, "expressions")
 	}
 	return ctx
 }


### PR DESCRIPTION
## Description

Fixed a typo in `test/integration/isolated/skip.go` — "skiping" → "skipping" in the `SkipIfRouterNotExpressions` function's skip message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
