### PR TITLE
fix(gateway): skip parentRefs of unsupported kinds instead of erroring

### DIFF
--- a/internal/controllers/gateway/route_utils.go
+++ b/internal/controllers/gateway/route_utils.go
@@ -64,6 +64,14 @@ func (g supportedGatewayWithCondition) GetSectionName() mo.Option[string] {
 
 // parentRefsForRoute provides a list of the parentRefs given a Gateway APIs route object
 // (e.g. HTTPRoute, TCPRoute, e.t.c.) which refer to the Gateway resource(s) which manage it.
+//
+// parentRefs pointing at a kind this controller cannot resolve (e.g. a ListenerSet, or any
+// Gateway API kind introduced after the version this controller is built against) are filtered
+// out rather than rejected: such a reference means the route is managed by some other
+// controller. Routes left with no supported parentRef are handled by getSupportedGatewayForRoute
+// returning ErrNoSupportedGateway, which callers already treat as "not ours". Returning an error
+// here instead makes reconciliation of a route this controller does not own fail permanently,
+// retrying forever without ever converging.
 func parentRefsForRoute[T gatewayapi.RouteT](route T) ([]gatewayapi.ParentReference, error) {
 	// Note: Ideally we wouldn't have to do this but it's hard to juggle around types
 	// and support ParentReference and gatewayapi.ParentReference
@@ -90,36 +98,36 @@ func parentRefsForRoute[T gatewayapi.RouteT](route T) ([]gatewayapi.ParentRefere
 	case *gatewayapi.HTTPRoute:
 		refs = r.Spec.ParentRefs
 	case *gatewayapi.UDPRoute:
-		refs = r.Spec.ParentRefs
+		refs = convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs)
 	case *gatewayapi.TCPRoute:
-		refs = r.Spec.ParentRefs
+		refs = convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs)
 	case *gatewayapi.TLSRoute:
-		refs = r.Spec.ParentRefs
+		refs = convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs)
 	case *gatewayapi.GRPCRoute:
-		refs = r.Spec.ParentRefs
+		refs = convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs)
 	default:
 		return nil, fmt.Errorf("can't determine parent Gateway for unsupported route type %s", reflect.TypeOf(route))
-	}
-	for _, ref := range refs {
-		if string(*ref.Group) != gatewayv1.GroupName || string(*ref.Kind) != "Gateway" {
-			return nil, fmt.Errorf("unsupported parent kind %s/%s", string(*ref.Group), string(*ref.Kind))
-		}
 	}
 
-	switch r := (any)(route).(type) {
-	case *gatewayapi.HTTPRoute:
-		return r.Spec.ParentRefs, nil
-	case *gatewayapi.UDPRoute:
-		return convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs), nil
-	case *gatewayapi.TCPRoute:
-		return convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs), nil
-	case *gatewayapi.TLSRoute:
-		return convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs), nil
-	case *gatewayapi.GRPCRoute:
-		return convertV1Alpha2ToV1Beta1ParentReference(r.Spec.ParentRefs), nil
-	default:
-		return nil, fmt.Errorf("can't determine parent Gateway for unsupported route type %s", reflect.TypeOf(route))
+	return lo.Filter(refs, func(ref gatewayapi.ParentReference, _ int) bool {
+		return isSupportedParentRefKind(ref)
+	}), nil
+}
+
+// isSupportedParentRefKind reports whether a parentRef points at a core Gateway API Gateway,
+// the only parent kind this controller is able to resolve. Group and Kind are optional in the
+// Gateway API and default to gateway.networking.k8s.io and Gateway respectively, so a nil value
+// is treated as the default rather than dereferenced.
+func isSupportedParentRefKind(ref gatewayapi.ParentReference) bool {
+	group := gatewayv1.GroupName
+	if ref.Group != nil {
+		group = string(*ref.Group)
 	}
+	kind := "Gateway"
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	return group == gatewayv1.GroupName && kind == "Gateway"
 }
 
 // getSupportedGatewayForRoute will retrieve the Gateway and GatewayClass object for any

--- a/internal/controllers/gateway/route_utils_test.go
+++ b/internal/controllers/gateway/route_utils_test.go
@@ -1330,14 +1330,17 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 			Group: &badGroup,
 		},
 	}
-	t.Run("invalid parentRef kind rejected", func(t *testing.T) {
+	t.Run("unsupported parentRef kind is skipped, not rejected", func(t *testing.T) {
 		fakeClient := fakeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			Build()
 
+		// A route whose only parent is of a kind this controller cannot resolve belongs to some
+		// other controller. It must resolve to "no supported gateway", which callers handle by
+		// dropping the route, rather than to a hard error that retries forever.
 		_, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, bustedParentHTTPRoute, controllers.OptionalNamespacedName{})
-		require.Equal(t, fmt.Errorf("unsupported parent kind %s/%s", string(badGroup), string(badKind)), err)
+		require.ErrorIs(t, err, ErrNoSupportedGateway)
 	})
 
 	t.Run("single Gateway", func(t *testing.T) {
@@ -2554,6 +2557,70 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 			ok, err := isRouteAcceptedByListener(ctx, fakeClient, tc.httpRoute, tc.gateway, 0, tc.httpRoute.Spec.ParentRefs[0])
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedValue, ok)
+		})
+	}
+}
+
+func TestParentRefsForRoute(t *testing.T) {
+	gatewayGroup := gatewayapi.Group(gatewayv1.GroupName)
+	gatewayKind := gatewayapi.Kind("Gateway")
+	listenerSetKind := gatewayapi.Kind("ListenerSet")
+	otherGroup := gatewayapi.Group("example.com")
+	otherKind := gatewayapi.Kind("Frobnicator")
+
+	routeWithParents := func(refs ...gatewayapi.ParentReference) *gatewayapi.HTTPRoute {
+		return &gatewayapi.HTTPRoute{
+			TypeMeta: gatewayapi.V1GatewayTypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "httproute",
+				Namespace: "test-namespace",
+			},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: refs},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		route    *gatewayapi.HTTPRoute
+		expected []gatewayapi.ParentReference
+	}{
+		{
+			name:     "a Gateway parentRef is kept",
+			route:    routeWithParents(gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"}),
+			expected: []gatewayapi.ParentReference{{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"}},
+		},
+		{
+			name:     "an omitted Group and Kind default to a Gateway and are kept",
+			route:    routeWithParents(gatewayapi.ParentReference{Name: "gw"}),
+			expected: []gatewayapi.ParentReference{{Name: "gw"}},
+		},
+		{
+			name:     "a ListenerSet parentRef is dropped",
+			route:    routeWithParents(gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &listenerSetKind, Name: "ls"}),
+			expected: []gatewayapi.ParentReference{},
+		},
+		{
+			name:     "a parentRef from an unrelated group is dropped",
+			route:    routeWithParents(gatewayapi.ParentReference{Group: &otherGroup, Kind: &otherKind, Name: "other"}),
+			expected: []gatewayapi.ParentReference{},
+		},
+		{
+			name: "an unsupported parentRef does not discard the supported ones alongside it",
+			route: routeWithParents(
+				gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &listenerSetKind, Name: "ls"},
+				gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"},
+			),
+			expected: []gatewayapi.ParentReference{{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs, err := parentRefsForRoute(tc.route)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, refs)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #8078.

### What this changes

`parentRefsForRoute` rejects a whole route as soon as one `parentRef` names a kind other than a core Gateway API `Gateway`:

```go
for _, ref := range refs {
    if string(*ref.Group) != gatewayv1.GroupName || string(*ref.Kind) != "Gateway" {
        return nil, fmt.Errorf("unsupported parent kind %s/%s", ...)
    }
}
```

That runs *before* `getSupportedGatewayForRoute` compares the parent's `GatewayClass.spec.controllerName` against `GetControllerName()`, so a route owned by a different Gateway API implementation never reaches the "not mine, skip it" path — even though that path exists and is used for every other not-mine case (missing Gateway, missing GatewayClass, foreign `controllerName`, all `continue`).

Because such a route is never going to change, the reconcile error repeats on controller-runtime's backoff forever. We hit this running KIC alongside Envoy Gateway in a shared watched namespace, where Envoy owns an HTTPRoute parented to a `ListenerSet` (GEP-1713, served by the Gateway API v1.5.1 experimental bundle):

```
error controllers.HTTPRoute Reconciler error {"error": "unsupported parent kind gateway.networking.k8s.io/ListenerSet"}
```

This PR filters unsupported parentRefs out instead of erroring. A route left with no supported parentRef resolves to `ErrNoSupportedGateway`, which every route controller already handles — it clears any stale status and drops the object from the dataplane cache, returning no error. That is precisely the right outcome for a route owned by another controller, and it needs no new error handling.

Two smaller things fall out of the same change:

- The old code `return`ed on the first bad ref, so a route combining an unsupported parent with a legitimate `Gateway` parent was discarded whole. Filtering keeps the `Gateway` one.
- `Group` and `Kind` are optional in the Gateway API and default to `gateway.networking.k8s.io` / `Gateway`. The old code dereferenced both unconditionally; the new helper treats nil as the default.

The two `switch` statements over the route type collapse into one, since the first existed only to feed the validation loop.

### Scope

This deliberately does **not** implement ListenerSet support (#7818). KIC does not need to understand `ListenerSet` at all here — it only needs to not error out on routes that reference one. The fix is generic: any Gateway API kind newer than the `sigs.k8s.io/gateway-api` version KIC is built against (currently v1.3.0, against a v1.5.1 CRD bundle in our cluster) would behave the same way.

### Testing

- `TestGetSupportedGatewayForRoute` — the existing `invalid parentRef kind rejected` case now asserts `ErrNoSupportedGateway` rather than the raw error, and is renamed to match the new semantics.
- New `TestParentRefsForRoute` covers: a `Gateway` ref kept; omitted Group/Kind defaulted and kept; a `ListenerSet` ref dropped; an unrelated group dropped; and an unsupported ref not discarding a supported one alongside it.

`go test ./internal/controllers/...` passes.

### Note

I left `CHANGELOG.md` alone — on `main` it looks maintainer-curated through release and backport commits rather than per-PR, and there is no `Unreleased` section to append to. Happy to add an entry wherever you'd like it.
